### PR TITLE
feat: implement circuit breaker pattern for external service calls

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,6 +34,9 @@ module.exports = {
         '^@test/(.*)$': '<rootDir>/test/$1',
         '^uuid$': 'uuid',
         '^@nestjs/bullmq$': '<rootDir>/node_modules/@nestjs/bullmq',
+        '^ipfs-http-client$': '<rootDir>/test/__mocks__/ipfs-http-client.js',
+        '^bull$': '<rootDir>/test/__mocks__/bull.js',
+        '^@nestjs-modules/mailer$': '<rootDir>/test/__mocks__/@nestjs-modules/mailer.js',
       },
       setupFilesAfterEnv: ['<rootDir>/test/setup-unit.ts'],
       globals: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
+        "fast-check": "^3.22.0",
         "globals": "^16.0.0",
         "jest": "^30.0.0",
         "prettier": "^3.4.2",
@@ -8970,6 +8971,46 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-copy": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "@types/argon2": "^0.14.1",
     "@types/bcrypt": "^5.0.2",
     "@types/cron": "^2.0.1",
-    "@types/fast-check": "^3.5.0",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@types/multer": "^1.4.11",

--- a/src/Email Notification Service for Critical Access Events/mail.service.spec.ts
+++ b/src/Email Notification Service for Critical Access Events/mail.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MailService, Patient, Provider, MedicalRecord } from './mail.service';
 import { MailerService } from '@nestjs-modules/mailer';
 import { ConfigService } from '@nestjs/config';
+import { CircuitBreakerService } from '../common/circuit-breaker/circuit-breaker.service';
 
 const mockPatient: Patient = {
   id: 'patient-1',
@@ -47,6 +48,12 @@ describe('MailService', () => {
               };
               return env[key] ?? defaultVal;
             },
+          },
+        },
+        {
+          provide: CircuitBreakerService,
+          useValue: {
+            execute: jest.fn().mockImplementation((service, fn) => fn()),
           },
         },
       ],

--- a/src/common/circuit-breaker/circuit-breaker.service.spec.ts
+++ b/src/common/circuit-breaker/circuit-breaker.service.spec.ts
@@ -1,11 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CircuitBreakerService } from './circuit-breaker.service';
 import { BrokenCircuitError } from 'cockatiel';
+import { register } from 'prom-client';
 
 describe('CircuitBreakerService', () => {
   let service: CircuitBreakerService;
 
   beforeEach(async () => {
+    register.clear();
     const module: TestingModule = await Test.createTestingModule({
       providers: [CircuitBreakerService],
     }).compile();

--- a/src/medical-records/services/ipfs.service.ts
+++ b/src/medical-records/services/ipfs.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { create } from 'ipfs-http-client';
+import { CircuitBreakerService } from '../../common/circuit-breaker/circuit-breaker.service';
 import * as fs from 'fs';
 
 @Injectable()
@@ -7,41 +8,47 @@ export class IpfsService {
   private readonly logger = new Logger(IpfsService.name);
   private ipfs;
 
-  constructor() {
+  constructor(private readonly circuitBreaker: CircuitBreakerService) {
     this.ipfs = create({ url: process.env.IPFS_URL || 'http://localhost:5001' });
   }
 
   async uploadFile(filePath: string): Promise<string> {
-    try {
-      const file = fs.readFileSync(filePath);
-      const result = await this.ipfs.add(file, { pin: true });
-      
-      await this.ipfs.pin.add(result.cid, { timeout: 10000 });
-      
-      setTimeout(() => this.unpinFile(result.cid.toString()), 7 * 24 * 60 * 60 * 1000);
-      
-      this.logger.log(`File uploaded to IPFS: ${result.cid}`);
-      return result.cid.toString();
-    } catch (error) {
-      this.logger.error(`IPFS upload failed: ${error.message}`);
-      throw error;
-    }
+    return this.circuitBreaker.execute('ipfs', async () => {
+      try {
+        const file = fs.readFileSync(filePath);
+        const result = await this.ipfs.add(file, { pin: true });
+
+        await this.ipfs.pin.add(result.cid, { timeout: 10000 });
+
+        setTimeout(() => this.unpinFile(result.cid.toString()), 7 * 24 * 60 * 60 * 1000);
+
+        this.logger.log(`File uploaded to IPFS: ${result.cid}`);
+        return result.cid.toString();
+      } catch (error) {
+        this.logger.error(`IPFS upload failed: ${error.message}`);
+        throw error;
+      }
+    });
   }
 
   async unpinFile(cid: string): Promise<void> {
-    try {
-      await this.ipfs.pin.rm(cid);
-      this.logger.log(`File unpinned from IPFS: ${cid}`);
-    } catch (error) {
-      this.logger.error(`IPFS unpin failed: ${error.message}`);
-    }
+    return this.circuitBreaker.execute('ipfs', async () => {
+      try {
+        await this.ipfs.pin.rm(cid);
+        this.logger.log(`File unpinned from IPFS: ${cid}`);
+      } catch (error) {
+        this.logger.error(`IPFS unpin failed: ${error.message}`);
+      }
+    });
   }
 
   async getFile(cid: string): Promise<Buffer> {
-    const chunks = [];
-    for await (const chunk of this.ipfs.cat(cid)) {
-      chunks.push(chunk);
-    }
-    return Buffer.concat(chunks);
+    return this.circuitBreaker.execute('ipfs', async () => {
+      const chunks = [];
+      for await (const chunk of this.ipfs.cat(cid)) {
+        chunks.push(chunk);
+      }
+      return Buffer.concat(chunks);
+    });
   }
 }

--- a/src/stellar/services/stellar.service.spec.ts
+++ b/src/stellar/services/stellar.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { StellarService } from './stellar.service';
+import { CircuitBreakerService } from '../../common/circuit-breaker/circuit-breaker.service';
 
 // ── Mock @stellar/stellar-sdk ─────────────────────────────────────────────
 
@@ -127,6 +128,12 @@ describe('StellarService', () => {
           provide: ConfigService,
           useValue: {
             get: jest.fn((key: string, fallback?: string) => configValues[key] ?? fallback),
+          },
+        },
+        {
+          provide: CircuitBreakerService,
+          useValue: {
+            execute: jest.fn().mockImplementation((service, fn) => fn()),
           },
         },
       ],

--- a/test/__mocks__/@nestjs-modules/mailer.js
+++ b/test/__mocks__/@nestjs-modules/mailer.js
@@ -1,0 +1,10 @@
+// Manual mock for @nestjs-modules/mailer
+module.exports = {
+    MailerService: jest.fn().mockImplementation(() => ({
+        sendMail: jest.fn().mockResolvedValue(undefined),
+    })),
+    MailerModule: {
+        forRoot: jest.fn().mockReturnValue({ module: class { } }),
+        forRootAsync: jest.fn().mockReturnValue({ module: class { } }),
+    },
+};

--- a/test/__mocks__/bull.js
+++ b/test/__mocks__/bull.js
@@ -1,0 +1,9 @@
+// Manual mock for bull (not directly installed)
+module.exports = {
+    Queue: jest.fn().mockImplementation(() => ({
+        add: jest.fn(),
+        process: jest.fn(),
+        on: jest.fn(),
+        close: jest.fn(),
+    })),
+};

--- a/test/__mocks__/ipfs-http-client.js
+++ b/test/__mocks__/ipfs-http-client.js
@@ -1,0 +1,18 @@
+// Manual mock for ipfs-http-client (ESM-only package)
+module.exports = {
+    create: jest.fn(() => ({
+        add: jest.fn(async () => ({
+            path: 'QmMockIPFSHash123456789',
+            cid: {
+                toString: () => 'QmMockIPFSHash123456789',
+            },
+        })),
+        cat: jest.fn(async function* () {
+            yield Buffer.from('mock file content');
+        }),
+        pin: {
+            add: jest.fn(),
+            rm: jest.fn(),
+        },
+    })),
+};


### PR DESCRIPTION
pr closes #187 
- Fix cockatiel API usage in circuit-breaker.config.ts (use circuitBreaker() builder)
- Integrate CircuitBreakerService into StellarService, IpfsService, KeyManagementService, MailService
- Add Prometheus metrics (medchain_circuit_breaker_state gauge + state_changes counter)
- Add CircuitBreakerExceptionFilter for 503 + Retry-After on open circuits
- Fix Jest test infrastructure: module mocks for ipfs-http-client, bull, @nestjs-modules/mailer
- Clear prom-client registry between tests to prevent duplicate metric registration
- Remove invalid @types/fast-check dependency
- All 53 circuit-breaker-related tests pass