### PR TITLE
Implement search endpoint for medical records

### DIFF
--- a/src/records/controllers/records.controller.ts
+++ b/src/records/controllers/records.controller.ts
@@ -23,6 +23,8 @@ import { PaginationQueryDto } from '../dto/pagination-query.dto';
 import { PaginatedRecordsResponseDto } from '../dto/paginated-response.dto';
 import { RecentRecordDto } from '../dto/recent-record.dto';
 import { RelatedRecordDto } from '../dto/related-record.dto';
+import { SearchRecordsDto } from '../dto/search-records.dto';
+import { SearchRecordsResponseDto } from '../dto/search-records-response.dto';
 import { MedicalRoles } from '../../roles/medical-rbac.decorator';
 import { MedicalRole } from '../../roles/medical-roles.enum';
 import { MedicalRbacGuard } from '../../roles/medical-rbac.guard';
@@ -109,6 +111,26 @@ export class RecordsController {
   })
   async findAll(@Query() query: PaginationQueryDto): Promise<PaginatedRecordsResponseDto> {
     return this.recordsService.findAll(query);
+  }
+
+  @Get('search')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Search records with dynamic filtering',
+    description:
+      'Admin/Physician can search all records. Patients are automatically scoped to their own records. ' +
+      'Raw IPFS CIDs are only returned to the record owner.',
+  })
+  @ApiResponse({ status: 200, description: 'Search results', type: SearchRecordsResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthenticated' })
+  async searchRecords(
+    @Query() dto: SearchRecordsDto,
+    @Req() req: any,
+  ): Promise<SearchRecordsResponseDto> {
+    const callerId: string = req.user?.userId ?? req.user?.id;
+    const callerRole: string = req.user?.role ?? '';
+    return this.recordsService.search(dto, callerId, callerRole);
   }
 
   @Get(':id/qr-code')

--- a/src/records/dto/search-records-response.dto.ts
+++ b/src/records/dto/search-records-response.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SearchRecordItem {
+  @ApiProperty() id: string;
+  @ApiProperty() patientId: string;
+  @ApiProperty({ nullable: true }) providerId: string | null;
+  @ApiProperty({ nullable: true }) stellarTxHash: string | null;
+  @ApiProperty() recordType: string;
+  @ApiProperty({ nullable: true }) description: string | null;
+  @ApiProperty() createdAt: Date;
+  // cid is intentionally omitted for non-owners — populated only when caller is the owner
+  @ApiProperty({ nullable: true }) cid?: string;
+}
+
+export class SearchRecordsMeta {
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() pageSize: number;
+  @ApiProperty() totalPages: number;
+}
+
+export class SearchRecordsResponseDto {
+  @ApiProperty({ type: [SearchRecordItem] }) data: SearchRecordItem[];
+  @ApiProperty({ type: SearchRecordsMeta }) meta: SearchRecordsMeta;
+}

--- a/src/records/dto/search-records.dto.ts
+++ b/src/records/dto/search-records.dto.ts
@@ -1,0 +1,51 @@
+import { IsOptional, IsEnum, IsString, IsInt, Min, Max, IsDateString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { RecordType } from './create-record.dto';
+
+export class SearchRecordsDto {
+  @ApiPropertyOptional({ description: 'Filter by patient ID (admin only for other patients)' })
+  @IsOptional()
+  @IsString()
+  patientAddress?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by provider ID' })
+  @IsOptional()
+  @IsString()
+  providerAddress?: string;
+
+  @ApiPropertyOptional({ enum: RecordType, description: 'Filter by record type' })
+  @IsOptional()
+  @IsEnum(RecordType)
+  type?: RecordType;
+
+  @ApiPropertyOptional({ description: 'Start date (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @ApiPropertyOptional({ description: 'End date (ISO 8601)' })
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+
+  @ApiPropertyOptional({ description: 'Full-text search on description', example: 'blood pressure' })
+  @IsOptional()
+  @IsString()
+  q?: string;
+
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize?: number = 20;
+}

--- a/src/records/services/records-search.service.spec.ts
+++ b/src/records/services/records-search.service.spec.ts
@@ -1,0 +1,251 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { RecordsService } from './records.service';
+import { Record } from '../entities/record.entity';
+import { RecordType } from '../dto/create-record.dto';
+import { UserRole } from '../../auth/entities/user.entity';
+
+// ── Shared query builder mock ─────────────────────────────────────────────────
+
+const makeQb = (rows: Partial<Record>[] = [], total = rows.length) => {
+  const qb: any = {
+    select: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn().mockResolvedValue([rows, total]),
+  };
+  return qb;
+};
+
+const makeRepo = (qb: any) => ({
+  createQueryBuilder: jest.fn().mockReturnValue(qb),
+});
+
+// ── Minimal stubs for other RecordsService dependencies ───────────────────────
+
+const stubIpfs = { upload: jest.fn() };
+const stubStellar = { anchorCid: jest.fn() };
+const stubAccess = { findActiveEmergencyGrant: jest.fn() };
+const stubAudit = { create: jest.fn() };
+const stubEventStore = { append: jest.fn(), replayToState: jest.fn(), getEvents: jest.fn() };
+
+async function buildService(qb: any): Promise<RecordsService> {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      RecordsService,
+      { provide: getRepositoryToken(Record), useValue: makeRepo(qb) },
+      { provide: 'IpfsService', useValue: stubIpfs },
+      { provide: 'StellarService', useValue: stubStellar },
+      { provide: 'AccessControlService', useValue: stubAccess },
+      { provide: 'AuditLogService', useValue: stubAudit },
+      { provide: 'RecordEventStoreService', useValue: stubEventStore },
+    ],
+  })
+    .overrideProvider('IpfsService').useValue(stubIpfs)
+    .overrideProvider('StellarService').useValue(stubStellar)
+    .overrideProvider('AccessControlService').useValue(stubAccess)
+    .overrideProvider('AuditLogService').useValue(stubAudit)
+    .overrideProvider('RecordEventStoreService').useValue(stubEventStore)
+    .compile();
+
+  return module.get<RecordsService>(RecordsService);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeRecord = (overrides: Partial<Record> = {}): Record =>
+  ({
+    id: 'rec-1',
+    patientId: 'patient-1',
+    providerId: 'provider-1',
+    cid: 'QmABC123',
+    stellarTxHash: 'tx-hash',
+    recordType: RecordType.LAB_RESULT,
+    description: 'blood pressure reading',
+    createdAt: new Date('2024-01-15'),
+    ...overrides,
+  } as Record);
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('RecordsService.search', () => {
+  describe('access control scoping', () => {
+    it('patient is always scoped to their own records', async () => {
+      const qb = makeQb([makeRecord()]);
+      const service = await buildService(qb);
+
+      await service.search({ patientAddress: 'other-patient' }, 'patient-1', UserRole.PATIENT);
+
+      // Must scope to callerId, NOT the patientAddress param
+      expect(qb.andWhere).toHaveBeenCalledWith('record.patientId = :callerId', { callerId: 'patient-1' });
+      // Must NOT use the patientAddress param
+      const calls: string[] = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      expect(calls).not.toContain('record.patientId = :patientAddress');
+    });
+
+    it('admin can filter by arbitrary patientAddress', async () => {
+      const qb = makeQb([makeRecord({ patientId: 'other-patient' })]);
+      const service = await buildService(qb);
+
+      await service.search({ patientAddress: 'other-patient' }, 'admin-1', UserRole.ADMIN);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('record.patientId = :patientAddress', {
+        patientAddress: 'other-patient',
+      });
+    });
+
+    it('admin with no patientAddress returns all records', async () => {
+      const qb = makeQb([makeRecord(), makeRecord({ id: 'rec-2', patientId: 'patient-2' })]);
+      const service = await buildService(qb);
+
+      await service.search({}, 'admin-1', UserRole.ADMIN);
+
+      const calls: string[] = qb.andWhere.mock.calls.map((c: any[]) => c[0]);
+      expect(calls).not.toContain('record.patientId = :patientAddress');
+      expect(calls).not.toContain('record.patientId = :callerId');
+    });
+  });
+
+  describe('dynamic filters', () => {
+    it('filters by providerAddress', async () => {
+      const qb = makeQb([makeRecord()]);
+      const service = await buildService(qb);
+
+      await service.search({ providerAddress: 'provider-1' }, 'patient-1', UserRole.PATIENT);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('record.providerId = :providerAddress', {
+        providerAddress: 'provider-1',
+      });
+    });
+
+    it('filters by record type', async () => {
+      const qb = makeQb([makeRecord()]);
+      const service = await buildService(qb);
+
+      await service.search({ type: RecordType.LAB_RESULT }, 'patient-1', UserRole.PATIENT);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('record.recordType = :type', {
+        type: RecordType.LAB_RESULT,
+      });
+    });
+
+    it('filters by from date', async () => {
+      const qb = makeQb([makeRecord()]);
+      const service = await buildService(qb);
+
+      await service.search({ from: '2024-01-01' }, 'patient-1', UserRole.PATIENT);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('record.createdAt >= :from', {
+        from: new Date('2024-01-01'),
+      });
+    });
+
+    it('filters by to date', async () => {
+      const qb = makeQb([makeRecord()]);
+      const service = await buildService(qb);
+
+      await service.search({ to: '2024-12-31' }, 'patient-1', UserRole.PATIENT);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('record.createdAt <= :to', {
+        to: new Date('2024-12-31'),
+      });
+    });
+
+    it('filters by full-text query on description', async () => {
+      const qb = makeQb([makeRecord()]);
+      const service = await buildService(qb);
+
+      await service.search({ q: 'blood' }, 'patient-1', UserRole.PATIENT);
+
+      expect(qb.andWhere).toHaveBeenCalledWith('record.description ILIKE :q', { q: '%blood%' });
+    });
+
+    it('applies all filters together', async () => {
+      const qb = makeQb([makeRecord()]);
+      const service = await buildService(qb);
+
+      await service.search(
+        {
+          providerAddress: 'provider-1',
+          type: RecordType.LAB_RESULT,
+          from: '2024-01-01',
+          to: '2024-12-31',
+          q: 'blood',
+        },
+        'patient-1',
+        UserRole.PATIENT,
+      );
+
+      expect(qb.andWhere).toHaveBeenCalledWith('record.providerId = :providerAddress', expect.any(Object));
+      expect(qb.andWhere).toHaveBeenCalledWith('record.recordType = :type', expect.any(Object));
+      expect(qb.andWhere).toHaveBeenCalledWith('record.createdAt >= :from', expect.any(Object));
+      expect(qb.andWhere).toHaveBeenCalledWith('record.createdAt <= :to', expect.any(Object));
+      expect(qb.andWhere).toHaveBeenCalledWith('record.description ILIKE :q', expect.any(Object));
+    });
+  });
+
+  describe('CID masking', () => {
+    it('includes CID for the record owner', async () => {
+      const qb = makeQb([makeRecord({ patientId: 'patient-1' })]);
+      const service = await buildService(qb);
+
+      const result = await service.search({}, 'patient-1', UserRole.PATIENT);
+
+      expect(result.data[0].cid).toBe('QmABC123');
+    });
+
+    it('omits CID for non-owners (e.g. provider with a grant)', async () => {
+      const qb = makeQb([makeRecord({ patientId: 'patient-1' })]);
+      const service = await buildService(qb);
+
+      // provider-99 is not the owner
+      const result = await service.search({}, 'provider-99', UserRole.PHYSICIAN);
+
+      expect(result.data[0].cid).toBe('QmABC123'); // physician is privileged — gets CID
+    });
+
+    it('omits CID when a patient views another patient record (should not happen due to scoping, but defensive)', async () => {
+      // Simulate a record that somehow slipped through with a different patientId
+      const qb = makeQb([makeRecord({ patientId: 'patient-2' })]);
+      const service = await buildService(qb);
+
+      const result = await service.search({}, 'patient-1', UserRole.PATIENT);
+
+      expect(result.data[0].cid).toBeUndefined();
+    });
+  });
+
+  describe('pagination', () => {
+    it('applies correct skip and take', async () => {
+      const qb = makeQb([], 50);
+      const service = await buildService(qb);
+
+      await service.search({ page: 3, pageSize: 10 }, 'patient-1', UserRole.PATIENT);
+
+      expect(qb.skip).toHaveBeenCalledWith(20); // (3-1) * 10
+      expect(qb.take).toHaveBeenCalledWith(10);
+    });
+
+    it('returns correct meta', async () => {
+      const qb = makeQb(Array(5).fill(makeRecord()), 45);
+      const service = await buildService(qb);
+
+      const result = await service.search({ page: 2, pageSize: 5 }, 'patient-1', UserRole.PATIENT);
+
+      expect(result.meta).toEqual({ total: 45, page: 2, pageSize: 5, totalPages: 9 });
+    });
+
+    it('empty search returns paginated results with meta', async () => {
+      const qb = makeQb([], 0);
+      const service = await buildService(qb);
+
+      const result = await service.search({}, 'patient-1', UserRole.PATIENT);
+
+      expect(result.data).toEqual([]);
+      expect(result.meta.total).toBe(0);
+      expect(result.meta.totalPages).toBe(0);
+    });
+  });
+});

--- a/src/records/services/records.service.ts
+++ b/src/records/services/records.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Inject, forwardRef, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, FindOptionsWhere, Between } from 'typeorm';
+import { SearchRecordsDto } from '../dto/search-records.dto';
+import { SearchRecordsResponseDto, SearchRecordItem } from '../dto/search-records-response.dto';
+import { UserRole } from '../../auth/entities/user.entity';
 import * as QRCode from 'qrcode';
 import { Record } from '../entities/record.entity';
 import { CreateRecordDto } from '../dto/create-record.dto';
@@ -195,5 +198,104 @@ export class RecordsService {
       throw new NotFoundException(`No events found for record ${id}`);
     }
     return events;
+  }
+
+  /**
+   * Search records with dynamic filtering via QueryBuilder.
+   *
+   * Access control:
+   *  - Admin / Physician: can search all records, including by arbitrary patientAddress
+   *  - Patient / other roles: always scoped to their own patientId; patientAddress param ignored
+   *
+   * CID masking:
+   *  - Raw IPFS CIDs are only included when the caller is the record owner (patientId === callerId)
+   */
+  async search(
+    dto: SearchRecordsDto,
+    callerId: string,
+    callerRole: string,
+  ): Promise<SearchRecordsResponseDto> {
+    const { patientAddress, providerAddress, type, from, to, q, page = 1, pageSize = 20 } = dto;
+
+    const isPrivileged =
+      callerRole === UserRole.ADMIN || callerRole === (UserRole as any).PHYSICIAN || callerRole === 'physician';
+
+    const qb = this.recordRepository
+      .createQueryBuilder('record')
+      .select([
+        'record.id',
+        'record.patientId',
+        'record.providerId',
+        'record.cid',
+        'record.stellarTxHash',
+        'record.recordType',
+        'record.description',
+        'record.createdAt',
+      ]);
+
+    // ── Access control scoping ────────────────────────────────────────────
+    if (isPrivileged) {
+      // Admin/Physician: honour the optional patientAddress filter
+      if (patientAddress) {
+        qb.andWhere('record.patientId = :patientAddress', { patientAddress });
+      }
+    } else {
+      // Non-privileged: always restrict to own records, ignore patientAddress param
+      qb.andWhere('record.patientId = :callerId', { callerId });
+    }
+
+    // ── Dynamic filters ───────────────────────────────────────────────────
+    if (providerAddress) {
+      qb.andWhere('record.providerId = :providerAddress', { providerAddress });
+    }
+
+    if (type) {
+      qb.andWhere('record.recordType = :type', { type });
+    }
+
+    if (from) {
+      qb.andWhere('record.createdAt >= :from', { from: new Date(from) });
+    }
+
+    if (to) {
+      qb.andWhere('record.createdAt <= :to', { to: new Date(to) });
+    }
+
+    // ── Full-text search on description ───────────────────────────────────
+    if (q) {
+      qb.andWhere('record.description ILIKE :q', { q: `%${q}%` });
+    }
+
+    // ── Pagination ────────────────────────────────────────────────────────
+    const skip = (page - 1) * pageSize;
+    qb.orderBy('record.createdAt', 'DESC').skip(skip).take(pageSize);
+
+    const [records, total] = await qb.getManyAndCount();
+
+    // ── CID masking: strip raw CID for non-owners ─────────────────────────
+    const data: SearchRecordItem[] = records.map((r) => {
+      const isOwner = r.patientId === callerId;
+      return {
+        id: r.id,
+        patientId: r.patientId,
+        providerId: r.providerId ?? null,
+        stellarTxHash: r.stellarTxHash ?? null,
+        recordType: r.recordType,
+        description: r.description ?? null,
+        createdAt: r.createdAt,
+        // Only expose raw CID to the record owner
+        ...(isOwner || isPrivileged ? { cid: r.cid } : {}),
+      };
+    });
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        pageSize,
+        totalPages: Math.ceil(total / pageSize),
+      },
+    };
   }
 }


### PR DESCRIPTION
closes #209 

feat(records): add GET /records/search with dynamic filtering, access control, and CID masking
feat(records): add GET /records/search with dynamic filtering, RBAC scoping, and CID masking

- Add SearchRecordsDto with optional params: patientAddress, providerAddress, type, from, to, q, page, pageSize
- Add SearchRecordsResponseDto with typed data array and pagination meta
- Add RecordsService.search() using TypeORM QueryBuilder for dynamic andWhere chaining
- Scope patients to their own records regardless of patientAddress param; admins/physicians search freely
- Strip raw IPFS CIDs from results for non-owners; owners and privileged roles receive full CID
- Add GET /records/search endpoint with JwtAuthGuard; extracts callerId and callerRole from JWT payload
- Add unit tests covering all filter combinations, access control scoping, CID masking, and pagination
