### PR TITLE
feat: implement IP allowlist guard for admin endpoints (#227)

### DIFF
--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -3,19 +3,22 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ApiKey } from '../auth/entities/api-key.entity';
 import { User } from '../auth/entities/user.entity';
 import { AuditLogEntity } from '../common/audit/audit-log.entity';
+import { ConfigModule } from '@nestjs/config';
 import { ApiKeyService } from '../auth/services/api-key.service';
 import { AuditService } from '../common/audit/audit.service';
 import { AdminController } from './controllers/admin.controller';
 import { AdminPatientsController } from './controllers/admin-patients.controller';
 import { PatientModule } from '../patients/patients.module';
+import { IpAllowlistGuard } from '../common/guards/ip-allowlist.guard';
 
 @Module({
   imports: [
+    ConfigModule,
     TypeOrmModule.forFeature([ApiKey, User, AuditLogEntity]),
     PatientModule,
   ],
   controllers: [AdminController, AdminPatientsController],
-  providers: [ApiKeyService, AuditService],
+  providers: [ApiKeyService, AuditService, IpAllowlistGuard],
   exports: [ApiKeyService],
 })
 export class AdminModule {}

--- a/src/admin/controllers/admin-patients.controller.ts
+++ b/src/admin/controllers/admin-patients.controller.ts
@@ -14,10 +14,11 @@ import { UserRole } from '../../auth/entities/user.entity';
 import { PatientsService } from '../../patients/patients.service';
 import { AdminMergePatientsDto } from '../../patients/dto/admin-merge-patients.dto';
 import { Patient } from '../../patients/entities/patient.entity';
+import { IpAllowlistGuard } from '../../common/guards/ip-allowlist.guard';
 
 @ApiTags('Admin - Patients')
 @Controller('admin/patients')
-@UseGuards(JwtAuthGuard, RolesGuard)
+@UseGuards(IpAllowlistGuard, JwtAuthGuard, RolesGuard)
 @Roles(UserRole.ADMIN)
 @ApiBearerAuth()
 export class AdminPatientsController {

--- a/src/admin/controllers/admin.controller.ts
+++ b/src/admin/controllers/admin.controller.ts
@@ -19,17 +19,11 @@ import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { UserRole } from '../../auth/entities/user.entity';
 import { ApiKeyThrottlerGuard } from '../../common/throttler/api-key-throttler.guard';
+import { IpAllowlistGuard } from '../../common/guards/ip-allowlist.guard';
 
 @ApiTags('Admin - API Keys')
 @Controller('admin/api-keys')
-@UseGuards(JwtAuthGuard, RolesGuard)
-@Roles(UserRole.ADMIN)
-@ApiBearerAuth()
-export class AdminController {
-
-@ApiTags('Admin - API Keys')
-@Controller('admin/api-keys')
-@UseGuards(JwtAuthGuard, RolesGuard)
+@UseGuards(IpAllowlistGuard, JwtAuthGuard, RolesGuard)
 @Roles(UserRole.ADMIN)
 @ApiBearerAuth()
 export class AdminController {

--- a/src/common/guards/ip-allowlist.guard.spec.ts
+++ b/src/common/guards/ip-allowlist.guard.spec.ts
@@ -1,0 +1,97 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import { IpAllowlistGuard } from './ip-allowlist.guard';
+
+function makeContext(ip: string, headers: Record<string, string> = {}): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({
+        ip,
+        socket: { remoteAddress: ip },
+        headers,
+      }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+async function buildGuard(allowlist: string): Promise<IpAllowlistGuard> {
+  const module = await Test.createTestingModule({
+    providers: [
+      IpAllowlistGuard,
+      {
+        provide: ConfigService,
+        useValue: {
+          get: jest.fn((key: string, def = '') =>
+            key === 'ADMIN_IP_ALLOWLIST' ? allowlist : def,
+          ),
+        },
+      },
+    ],
+  }).compile();
+  return module.get(IpAllowlistGuard);
+}
+
+describe('IpAllowlistGuard', () => {
+  describe('exact IP match', () => {
+    it('allows a listed IP', async () => {
+      const guard = await buildGuard('192.168.1.10,10.0.0.1');
+      expect(guard.canActivate(makeContext('192.168.1.10'))).toBe(true);
+    });
+
+    it('blocks an unlisted IP', async () => {
+      const guard = await buildGuard('192.168.1.10');
+      expect(() => guard.canActivate(makeContext('192.168.1.99'))).toThrow(ForbiddenException);
+    });
+  });
+
+  describe('CIDR range match', () => {
+    it('allows an IP inside the CIDR range', async () => {
+      const guard = await buildGuard('10.0.0.0/8');
+      expect(guard.canActivate(makeContext('10.42.1.5'))).toBe(true);
+    });
+
+    it('blocks an IP outside the CIDR range', async () => {
+      const guard = await buildGuard('10.0.0.0/8');
+      expect(() => guard.canActivate(makeContext('172.16.0.1'))).toThrow(ForbiddenException);
+    });
+
+    it('allows an IP matching a /24 subnet', async () => {
+      const guard = await buildGuard('192.168.1.0/24');
+      expect(guard.canActivate(makeContext('192.168.1.200'))).toBe(true);
+    });
+  });
+
+  describe('X-Forwarded-For header', () => {
+    it('uses the first IP from X-Forwarded-For', async () => {
+      const guard = await buildGuard('203.0.113.5');
+      const ctx = makeContext('10.0.0.1', {
+        'x-forwarded-for': '203.0.113.5, 10.0.0.1',
+      });
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it('blocks when X-Forwarded-For IP is not allowlisted', async () => {
+      const guard = await buildGuard('203.0.113.5');
+      const ctx = makeContext('10.0.0.1', {
+        'x-forwarded-for': '1.2.3.4, 10.0.0.1',
+      });
+      expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+    });
+  });
+
+  describe('X-Real-IP header', () => {
+    it('uses X-Real-IP when X-Forwarded-For is absent', async () => {
+      const guard = await buildGuard('203.0.113.7');
+      const ctx = makeContext('10.0.0.1', { 'x-real-ip': '203.0.113.7' });
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+  });
+
+  describe('empty allowlist', () => {
+    it('denies all requests when ADMIN_IP_ALLOWLIST is not set', async () => {
+      const guard = await buildGuard('');
+      expect(() => guard.canActivate(makeContext('127.0.0.1'))).toThrow(ForbiddenException);
+    });
+  });
+});

--- a/src/common/guards/ip-allowlist.guard.ts
+++ b/src/common/guards/ip-allowlist.guard.ts
@@ -1,0 +1,79 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+import * as ipaddr from 'ipaddr.js';
+
+@Injectable()
+export class IpAllowlistGuard implements CanActivate {
+  private readonly logger = new Logger(IpAllowlistGuard.name);
+  private readonly allowlist: string[];
+
+  constructor(private readonly config: ConfigService) {
+    const raw = this.config.get<string>('ADMIN_IP_ALLOWLIST', '');
+    this.allowlist = raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    // If no allowlist configured, deny all (fail-secure)
+    if (this.allowlist.length === 0) {
+      throw new ForbiddenException('Admin access not configured');
+    }
+
+    const req = context.switchToHttp().getRequest<Request>();
+    const clientIp = this.extractIp(req);
+
+    if (!clientIp || !this.isAllowed(clientIp)) {
+      this.logger.warn(`Admin access denied for IP: ${clientIp}`);
+      throw new ForbiddenException('Access denied');
+    }
+
+    return true;
+  }
+
+  private extractIp(req: Request): string | null {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (forwarded) {
+      return (Array.isArray(forwarded) ? forwarded[0] : forwarded)
+        .split(',')[0]
+        .trim();
+    }
+    const realIp = req.headers['x-real-ip'];
+    if (realIp) {
+      return Array.isArray(realIp) ? realIp[0] : realIp;
+    }
+    return req.ip ?? req.socket?.remoteAddress ?? null;
+  }
+
+  private isAllowed(clientIp: string): boolean {
+    let parsed: ipaddr.IPv4 | ipaddr.IPv6;
+    try {
+      parsed = ipaddr.process(clientIp); // normalises IPv4-mapped IPv6
+    } catch {
+      return false;
+    }
+
+    for (const entry of this.allowlist) {
+      try {
+        if (entry.includes('/')) {
+          const [range, bits] = ipaddr.parseCIDR(entry);
+          const candidate = ipaddr.process(clientIp);
+          // Both must be same kind for matchCIDR
+          if (candidate.kind() === range.kind() && candidate.match(range, bits)) {
+            return true;
+          }
+        } else {
+          if (parsed.toString() === ipaddr.process(entry).toString()) {
+            return true;
+          }
+        }
+      } catch {
+        this.logger.warn(`Invalid allowlist entry ignored: ${entry}`);
+      }
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
## What

Adds IpAllowlistGuard to restrict all /admin/* routes to trusted IP addresses and CIDR 
ranges configured via environment variable.

## Changes

common/guards/ip-allowlist.guard.ts (new)
- Reads ADMIN_IP_ALLOWLIST — comma-separated IPs and/or CIDR ranges
- Resolves client IP from X-Forwarded-For → X-Real-IP → req.ip (reverse proxy safe)
- Matches exact IPs and CIDR ranges using ipaddr.js (IPv4 + IPv6)
- Fail-secure: empty/unset allowlist returns 403 for all requests

admin/controllers/admin.controller.ts & admin-patients.controller.ts
- IpAllowlistGuard added as the first guard in @UseGuards(...), before JWT auth

admin/admin.module.ts
- ConfigModule imported, IpAllowlistGuard registered as a provider

## Configuration

env
# Comma-separated IPs and/or CIDR ranges
ADMIN_IP_ALLOWLIST=10.0.0.0/8,192.168.1.50,203.0.113.5


## Tests

9 unit tests covering: exact IP allow/block, CIDR allow/block, /24 subnet, X-Forwarded-For,
X-Real-IP, and empty allowlist — all passing.

## Checklist
- [x] ADMIN_IP_ALLOWLIST accepts IPs and CIDR ranges
- [x] Guard applied to all /admin/* routes
- [x] Returns 403 Forbidden for non-allowlisted IPs
- [x] X-Forwarded-For and X-Real-IP respected
- [x] Unit tests passing

close #227 