### PR TITLE
security: add HMAC-SHA256 signature verification and body size limit …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -331,3 +331,8 @@ STELLAR_MAX_RETRIES=3
 # Leave empty to block all admin access (fail-secure default)
 # Example: ADMIN_IP_ALLOWLIST=192.168.1.0/24,10.0.0.1
 ADMIN_IP_ALLOWLIST=
+
+# Webhook Signature Secrets (HMAC-SHA256)
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+IPFS_WEBHOOK_SECRET=your_ipfs_webhook_secret_here
+STELLAR_WEBHOOK_SECRET=your_stellar_webhook_secret_here

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -59,6 +59,7 @@ import { RequestContextMiddleware } from './common/middleware/request-context.mi
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { EventStoreModule } from './event-store/event-store.module';
 import { BullBoardAuthMiddleware } from './queues/middleware/bull-board-auth.middleware';
+import { WebhooksModule } from './webhooks/webhooks.module';
 
 @Module({
   imports: [
@@ -125,6 +126,7 @@ import { BullBoardAuthMiddleware } from './queues/middleware/bull-board-auth.mid
     ProjectionsModule,
     CqrsModule,
     ProviderPatientModule,
+    WebhooksModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/middleware/raw-body.middleware.ts
+++ b/src/common/middleware/raw-body.middleware.ts
@@ -1,14 +1,30 @@
-import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Injectable, NestMiddleware, PayloadTooLargeException } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import * as bodyParser from 'body-parser';
 
+const MAX_WEBHOOK_BODY_SIZE = '1mb';
+
+/**
+ * Captures the raw request buffer before JSON parsing so HMAC can be
+ * computed over the original wire bytes.
+ */
 @Injectable()
 export class RawBodyMiddleware implements NestMiddleware {
-  use(req: Request, res: Response, next: NextFunction) {
+  use(req: Request, res: Response, next: NextFunction): void {
     bodyParser.json({
-      verify: (req: any, res, buf) => {
+      limit: MAX_WEBHOOK_BODY_SIZE,
+      verify: (req: any, _res, buf) => {
         req.rawBody = buf.toString('utf8');
       },
-    })(req, res, next);
+    })(req, res, (err?: any) => {
+      if (err) {
+        // body-parser emits a 413 error when the limit is exceeded
+        if (err.status === 413 || err.type === 'entity.too.large') {
+          throw new PayloadTooLargeException('Webhook payload exceeds maximum allowed size');
+        }
+        throw err;
+      }
+      next();
+    });
   }
 }

--- a/src/common/middleware/webhook-signature.middleware.spec.ts
+++ b/src/common/middleware/webhook-signature.middleware.spec.ts
@@ -1,104 +1,147 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { WebhookSignatureMiddleware } from './webhook-signature.middleware';
 import { UnauthorizedException } from '@nestjs/common';
 import * as crypto from 'crypto';
 
+const IPFS_SECRET = 'ipfs-test-secret';
+const STELLAR_SECRET = 'stellar-test-secret';
+const SECRET_ENV = 'IPFS_WEBHOOK_SECRET';
+
+/** Build a valid X-Signature header value */
+function sign(body: string, secret: string, timestamp = Date.now()): string {
+  const sig = crypto.createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex');
+  return `${timestamp}.${sig}`;
+}
+
+function makeReq(header: string | undefined, body = '{}'): any {
+  return {
+    headers: header !== undefined ? { 'x-signature': header } : {},
+    rawBody: body,
+  };
+}
+
 describe('WebhookSignatureMiddleware', () => {
   let middleware: WebhookSignatureMiddleware;
-  const mockSecret = 'test-webhook-secret-key';
 
   beforeEach(() => {
-    process.env.WEBHOOK_SECRET = mockSecret;
-    middleware = new WebhookSignatureMiddleware();
+    process.env[SECRET_ENV] = IPFS_SECRET;
+    middleware = new WebhookSignatureMiddleware(SECRET_ENV);
   });
 
   afterEach(() => {
-    delete process.env.WEBHOOK_SECRET;
+    delete process.env[SECRET_ENV];
+    delete process.env['STELLAR_WEBHOOK_SECRET'];
   });
 
-  const createSignature = (timestamp: number, body: string, secret: string): string => {
-    const payload = `${timestamp}.${body}`;
-    const signature = crypto.createHmac('sha256', secret).update(payload).digest('hex');
-    return `${timestamp}.${signature}`;
-  };
+  // ── Construction ──────────────────────────────────────────────────────────
 
-  it('should pass with valid signature', () => {
-    const timestamp = Date.now();
-    const body = JSON.stringify({ event: 'test' });
-    const signature = createSignature(timestamp, body, mockSecret);
-
-    const req: any = {
-      headers: { 'x-webhook-signature': signature },
-      rawBody: body,
-    };
-    const res: any = {};
-    const next = jest.fn();
-
-    middleware.use(req, res, next);
-
-    expect(next).toHaveBeenCalled();
-  });
-
-  it('should reject with invalid signature', () => {
-    const timestamp = Date.now();
-    const body = JSON.stringify({ event: 'test' });
-    const signature = createSignature(timestamp, body, 'wrong-secret');
-
-    const req: any = {
-      headers: { 'x-webhook-signature': signature },
-      rawBody: body,
-    };
-    const res: any = {};
-    const next = jest.fn();
-
-    expect(() => middleware.use(req, res, next)).toThrow(UnauthorizedException);
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it('should reject expired timestamp (older than 5 minutes)', () => {
-    const timestamp = Date.now() - 6 * 60 * 1000; // 6 minutes ago
-    const body = JSON.stringify({ event: 'test' });
-    const signature = createSignature(timestamp, body, mockSecret);
-
-    const req: any = {
-      headers: { 'x-webhook-signature': signature },
-      rawBody: body,
-    };
-    const res: any = {};
-    const next = jest.fn();
-
-    expect(() => middleware.use(req, res, next)).toThrow(UnauthorizedException);
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it('should reject missing header', () => {
-    const req: any = {
-      headers: {},
-      rawBody: JSON.stringify({ event: 'test' }),
-    };
-    const res: any = {};
-    const next = jest.fn();
-
-    expect(() => middleware.use(req, res, next)).toThrow(UnauthorizedException);
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it('should reject malformed signature header', () => {
-    const req: any = {
-      headers: { 'x-webhook-signature': 'invalid-format' },
-      rawBody: JSON.stringify({ event: 'test' }),
-    };
-    const res: any = {};
-    const next = jest.fn();
-
-    expect(() => middleware.use(req, res, next)).toThrow(UnauthorizedException);
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it('should throw error if WEBHOOK_SECRET is not set', () => {
-    delete process.env.WEBHOOK_SECRET;
-    expect(() => new WebhookSignatureMiddleware()).toThrow(
-      'WEBHOOK_SECRET environment variable is required',
+  it('throws on construction when env var is missing', () => {
+    delete process.env[SECRET_ENV];
+    expect(() => new WebhookSignatureMiddleware(SECRET_ENV)).toThrow(
+      `${SECRET_ENV} environment variable is required`,
     );
+  });
+
+  it('constructs successfully when env var is present', () => {
+    expect(() => new WebhookSignatureMiddleware(SECRET_ENV)).not.toThrow();
+  });
+
+  // ── Valid signature ───────────────────────────────────────────────────────
+
+  it('calls next() for a valid signature', () => {
+    const body = JSON.stringify({ event: 'pin.added' });
+    const next = jest.fn();
+    middleware.use(makeReq(sign(body, IPFS_SECRET), body), {} as any, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses rawBody bytes (not re-parsed JSON) for HMAC', () => {
+    // Whitespace-sensitive: the raw body has extra spaces
+    const rawBody = '{ "event" :  "pin.added" }';
+    const next = jest.fn();
+    middleware.use(makeReq(sign(rawBody, IPFS_SECRET), rawBody), {} as any, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Missing / malformed header ────────────────────────────────────────────
+
+  it('throws 401 when X-Signature header is absent', () => {
+    expect(() => middleware.use(makeReq(undefined), {} as any, jest.fn())).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('throws 401 when X-Signature has no dot separator', () => {
+    expect(() => middleware.use(makeReq('invalidsignature'), {} as any, jest.fn())).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('throws 401 when timestamp part is empty', () => {
+    expect(() => middleware.use(makeReq('.abc123'), {} as any, jest.fn())).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('throws 401 when signature part is empty', () => {
+    const ts = Date.now();
+    expect(() => middleware.use(makeReq(`${ts}.`), {} as any, jest.fn())).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  // ── Wrong secret ──────────────────────────────────────────────────────────
+
+  it('throws 401 when signed with the wrong secret', () => {
+    const body = JSON.stringify({ event: 'pin.added' });
+    expect(() =>
+      middleware.use(makeReq(sign(body, 'wrong-secret'), body), {} as any, jest.fn()),
+    ).toThrow(UnauthorizedException);
+  });
+
+  // ── Replay attack prevention ──────────────────────────────────────────────
+
+  it('throws 401 for a timestamp older than 5 minutes', () => {
+    const body = '{}';
+    const staleTs = Date.now() - 6 * 60 * 1000;
+    const header = sign(body, IPFS_SECRET, staleTs);
+    expect(() => middleware.use(makeReq(header, body), {} as any, jest.fn())).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('throws 401 for a non-numeric timestamp', () => {
+    const body = '{}';
+    const sig = crypto.createHmac('sha256', IPFS_SECRET).update(`NaN.${body}`).digest('hex');
+    expect(() => middleware.use(makeReq(`NaN.${sig}`, body), {} as any, jest.fn())).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  // ── Per-endpoint secret isolation ─────────────────────────────────────────
+
+  it('IPFS middleware rejects a payload signed with the Stellar secret', () => {
+    const body = JSON.stringify({ tx: 'abc' });
+    // Signed with Stellar secret but verified against IPFS secret
+    expect(() =>
+      middleware.use(makeReq(sign(body, STELLAR_SECRET), body), {} as any, jest.fn()),
+    ).toThrow(UnauthorizedException);
+  });
+
+  it('Stellar middleware accepts a payload signed with the Stellar secret', () => {
+    process.env['STELLAR_WEBHOOK_SECRET'] = STELLAR_SECRET;
+    const stellarMiddleware = new WebhookSignatureMiddleware('STELLAR_WEBHOOK_SECRET');
+    const body = JSON.stringify({ tx: 'abc' });
+    const next = jest.fn();
+    stellarMiddleware.use(makeReq(sign(body, STELLAR_SECRET), body), {} as any, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('Stellar middleware rejects a payload signed with the IPFS secret', () => {
+    process.env['STELLAR_WEBHOOK_SECRET'] = STELLAR_SECRET;
+    const stellarMiddleware = new WebhookSignatureMiddleware('STELLAR_WEBHOOK_SECRET');
+    const body = JSON.stringify({ tx: 'abc' });
+    expect(() =>
+      stellarMiddleware.use(makeReq(sign(body, IPFS_SECRET), body), {} as any, jest.fn()),
+    ).toThrow(UnauthorizedException);
   });
 });

--- a/src/common/middleware/webhook-signature.middleware.ts
+++ b/src/common/middleware/webhook-signature.middleware.ts
@@ -2,47 +2,66 @@ import { Injectable, NestMiddleware, UnauthorizedException } from '@nestjs/commo
 import { Request, Response, NextFunction } from 'express';
 import * as crypto from 'crypto';
 
+/**
+ * HMAC-SHA256 signature verification middleware for webhook endpoints.
+ *
+ * Expects header: X-Signature: {timestamp}.{hmac-sha256-hex}
+ * where the HMAC is computed over `{timestamp}.{rawBody}`.
+ *
+ * Instantiate with the appropriate secret env-var name per route:
+ *   new WebhookSignatureMiddleware('IPFS_WEBHOOK_SECRET')
+ *   new WebhookSignatureMiddleware('STELLAR_WEBHOOK_SECRET')
+ */
 @Injectable()
 export class WebhookSignatureMiddleware implements NestMiddleware {
   private readonly secret: string;
-  private readonly maxAge = 5 * 60 * 1000; // 5 minutes
+  private readonly maxAge = 5 * 60 * 1000; // 5-minute replay window
 
-  constructor() {
-    this.secret = process.env.WEBHOOK_SECRET;
-    if (!this.secret) {
-      throw new Error('WEBHOOK_SECRET environment variable is required');
+  constructor(secretEnvVar: string) {
+    const secret = process.env[secretEnvVar];
+    if (!secret) {
+      throw new Error(`${secretEnvVar} environment variable is required`);
     }
+    this.secret = secret;
   }
 
-  use(req: Request, res: Response, next: NextFunction) {
-    const signature = req.headers['x-webhook-signature'] as string;
+  use(req: Request, _res: Response, next: NextFunction): void {
+    const header = req.headers['x-signature'] as string | undefined;
 
-    if (!signature) {
+    if (!header) {
       throw new UnauthorizedException();
     }
 
-    const [timestamp, receivedSignature] = signature.split('.');
-
-    if (!timestamp || !receivedSignature) {
+    const dotIndex = header.indexOf('.');
+    if (dotIndex === -1) {
       throw new UnauthorizedException();
     }
 
-    // Replay attack prevention
+    const timestamp = header.slice(0, dotIndex);
+    const receivedSig = header.slice(dotIndex + 1);
+
+    if (!timestamp || !receivedSig) {
+      throw new UnauthorizedException();
+    }
+
     const requestTime = parseInt(timestamp, 10);
     if (isNaN(requestTime) || Date.now() - requestTime > this.maxAge) {
       throw new UnauthorizedException();
     }
 
-    // Compute expected signature
-    const rawBody = (req as any).rawBody || '';
-    const payload = `${timestamp}.${rawBody}`;
-    const expectedSignature = crypto
+    const rawBody = (req as any).rawBody ?? '';
+    const expected = crypto
       .createHmac('sha256', this.secret)
-      .update(payload)
+      .update(`${timestamp}.${rawBody}`)
       .digest('hex');
 
-    // Constant-time comparison
-    if (!crypto.timingSafeEqual(Buffer.from(receivedSignature), Buffer.from(expectedSignature))) {
+    // Constant-time comparison to prevent timing attacks
+    try {
+      if (!crypto.timingSafeEqual(Buffer.from(receivedSig, 'hex'), Buffer.from(expected, 'hex'))) {
+        throw new UnauthorizedException();
+      }
+    } catch {
+      // timingSafeEqual throws if buffers differ in length
       throw new UnauthorizedException();
     }
 

--- a/src/webhooks/webhooks.module.ts
+++ b/src/webhooks/webhooks.module.ts
@@ -1,4 +1,4 @@
-import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
+import { Module, NestModule, MiddlewareConsumer, RequestMethod } from '@nestjs/common';
 import { WebhooksController } from './webhooks.controller';
 import { WebhookSignatureMiddleware } from '../common/middleware/webhook-signature.middleware';
 import { RawBodyMiddleware } from '../common/middleware/raw-body.middleware';
@@ -8,6 +8,17 @@ import { RawBodyMiddleware } from '../common/middleware/raw-body.middleware';
 })
 export class WebhooksModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(RawBodyMiddleware, WebhookSignatureMiddleware).forRoutes(WebhooksController);
+    // Raw body must run first on all webhook routes so HMAC has the original bytes
+    consumer.apply(RawBodyMiddleware).forRoutes(WebhooksController);
+
+    // IPFS webhook — verified with IPFS_WEBHOOK_SECRET
+    consumer
+      .apply(new WebhookSignatureMiddleware('IPFS_WEBHOOK_SECRET') as any)
+      .forRoutes({ path: 'webhooks/ipfs', method: RequestMethod.POST });
+
+    // Stellar webhook — verified with STELLAR_WEBHOOK_SECRET
+    consumer
+      .apply(new WebhookSignatureMiddleware('STELLAR_WEBHOOK_SECRET') as any)
+      .forRoutes({ path: 'webhooks/stellar', method: RequestMethod.POST });
   }
 }


### PR DESCRIPTION
## Problem

Both `/webhooks/ipfs` and `/webhooks/stellar` were completely unauthenticated — any POST request was accepted and returned `{ received: true }`. This exposed the endpoints to:
- Forged / replayed webhook events
- Request-body DoS (no payload size limit)

this pr Closes #352 

## Changes

### `WebhookSignatureMiddleware`
- Rewritten to accept a `secretEnvVar` constructor argument, enabling per-endpoint secret isolation
- Reads `IPFS_WEBHOOK_SECRET` for `/webhooks/ipfs` and `STELLAR_WEBHOOK_SECRET` for `/webhooks/stellar`
- Verifies the `X-Signature: {timestamp}.{hmac-sha256-hex}` header
- Uses `crypto.timingSafeEqual` to prevent timing attacks
- Enforces a 5-minute replay window — stale timestamps are rejected with 401

### `RawBodyMiddleware`
- Captures raw buffer bytes before JSON parsing so HMAC is computed over original wire bytes
- Enforces a 1 MB body limit via `body-parser`'s `limit` option; throws `PayloadTooLargeException` (413) on oversize payloads

### `WebhooksModule`
- Applies `RawBodyMiddleware` across all webhook routes
- Applies `WebhookSignatureMiddleware` per-route with the correct secret env var
- Module registered in `AppModule` (was previously missing)

### `.env.example`
- Added `IPFS_WEBHOOK_SECRET` and `STELLAR_WEBHOOK_SECRET` with generation instructions

## Tests

14 unit tests covering:
- Valid signature → passes
- Raw body bytes used for HMAC (not re-parsed JSON)
- Missing `X-Signature` header → 401
- Malformed header (no dot, empty timestamp, empty sig) → 401
- Wrong secret → 401
- Expired timestamp (>5 min) → 401
- Non-numeric timestamp → 401
- Secret isolation: IPFS middleware rejects Stellar-signed payloads and vice versa
- Missing env var at construction time → throws

## Environment Variables Required

```env
IPFS_WEBHOOK_SECRET=<32-byte hex>
STELLAR_WEBHOOK_SECRET=<32-byte hex>


