### PR TITLE
fix(#355): dual-key master key rotation with rotation log and status …

### DIFF
--- a/src/key-management/controllers/key-management-admin.controller.ts
+++ b/src/key-management/controllers/key-management-admin.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { EnvelopeKeyManagementService } from '../services/envelope-key-management.service';
+
+@ApiTags('Admin - Key Management')
+@ApiBearerAuth()
+@Controller('admin/key-management')
+export class KeyManagementAdminController {
+  constructor(private readonly keyMgmt: EnvelopeKeyManagementService) {}
+
+  @Post('rotate')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Phase-2 master key rotation: re-encrypt all DEKs with MASTER_KEY_NEW' })
+  async rotate(@Body('operatorId') operatorId: string) {
+    return this.keyMgmt.rotateMasterKey(operatorId ?? 'system');
+  }
+
+  @Get('rotation-status')
+  @ApiOperation({ summary: 'Get the last 20 key rotation events' })
+  async rotationStatus() {
+    return this.keyMgmt.getRotationStatus();
+  }
+}

--- a/src/key-management/entities/key-rotation-log.entity.ts
+++ b/src/key-management/entities/key-rotation-log.entity.ts
@@ -1,0 +1,31 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('key_rotation_log')
+export class KeyRotationLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'old_key_version', type: 'varchar', length: 50 })
+  oldKeyVersion: string;
+
+  @Column({ name: 'new_key_version', type: 'varchar', length: 50 })
+  newKeyVersion: string;
+
+  @Column({ name: 'reencrypted_count', type: 'int', default: 0 })
+  reencryptedCount: number;
+
+  @Column({ name: 'operator_id', type: 'varchar', length: 255 })
+  operatorId: string;
+
+  @Column({ name: 'phase', type: 'varchar', length: 20 })
+  phase: string; // 'started' | 'completed' | 'failed'
+
+  @Column({ name: 'error_message', type: 'text', nullable: true })
+  errorMessage: string;
+
+  @CreateDateColumn({ name: 'started_at' })
+  startedAt: Date;
+
+  @Column({ name: 'completed_at', type: 'timestamp', nullable: true })
+  completedAt: Date;
+}

--- a/src/key-management/key-management.module.ts
+++ b/src/key-management/key-management.module.ts
@@ -2,15 +2,18 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PatientDekEntity } from './entities/patient-dek.entity';
+import { KeyRotationLog } from './entities/key-rotation-log.entity';
 import { EnvelopeKeyManagementService } from './services/envelope-key-management.service';
+import { KeyManagementAdminController } from './controllers/key-management-admin.controller';
 
 export const KEY_MANAGEMENT_SERVICE = 'KeyManagementService';
 
 @Module({
   imports: [
     ConfigModule,
-    TypeOrmModule.forFeature([PatientDekEntity]),
+    TypeOrmModule.forFeature([PatientDekEntity, KeyRotationLog]),
   ],
+  controllers: [KeyManagementAdminController],
   providers: [
     EnvelopeKeyManagementService,
     {

--- a/src/key-management/services/envelope-key-management.service.ts
+++ b/src/key-management/services/envelope-key-management.service.ts
@@ -2,68 +2,59 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { createCipheriv, createDecipheriv, randomBytes, createHash } from 'crypto';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 import { EncryptedKey, DataKeyResult, KeyManagementService } from '../interfaces/key-management.interface';
 import { PatientDekEntity } from '../entities/patient-dek.entity';
+import { KeyRotationLog } from '../entities/key-rotation-log.entity';
 import { KeyManagementException, KeyRotationException } from '../exceptions/key-management.exceptions';
 
 const ALGORITHM = 'aes-256-gcm';
 const IV_BYTES = 12;
-const TAG_BYTES = 16;
 const KEY_BYTES = 32;
 
 @Injectable()
 export class EnvelopeKeyManagementService implements KeyManagementService, OnModuleInit {
   private readonly logger = new Logger(EnvelopeKeyManagementService.name);
 
-  /** Active master key — loaded from env/HSM, never logged */
-  private masterKey: Buffer;
-  private masterKeyVersion: string;
+  /** All loaded master keys keyed by version — supports dual-key during rotation */
+  private readonly masterKeys = new Map<string, Buffer>();
+  private activeMasterKeyVersion: string;
 
   constructor(
     private readonly config: ConfigService,
     @InjectRepository(PatientDekEntity)
     private readonly dekRepo: Repository<PatientDekEntity>,
+    @InjectRepository(KeyRotationLog)
+    private readonly rotationLogRepo: Repository<KeyRotationLog>,
   ) {}
 
   onModuleInit(): void {
-    this.loadMasterKey();
+    this.loadMasterKeys();
   }
 
   // ─── Public API ────────────────────────────────────────────────────────────
 
-  /**
-   * Generates a fresh 256-bit DEK for a patient, encrypts it with the master
-   * key, persists the encrypted form, and returns both.
-   * The caller MUST zero the plainKey after use and MUST NOT persist it.
-   */
   async generateDEK(patientAddress: string): Promise<DataKeyResult> {
     const plainKey = randomBytes(KEY_BYTES);
-    const encryptedKey = this.encryptWithMasterKey(plainKey);
-
+    const encryptedKey = this.encryptWithActiveKey(plainKey);
     await this.persistDek(patientAddress, encryptedKey);
-
     return { encryptedKey, plainKey };
   }
 
-  /**
-   * Decrypts an encrypted DEK using the master key version recorded on the
-   * EncryptedKey. Throws if the master key version is unknown or auth fails.
-   */
   async decryptDEK(encryptedKey: EncryptedKey): Promise<Buffer> {
-    return this.decryptWithMasterKey(encryptedKey);
+    return this.decryptWithKey(encryptedKey);
   }
 
   /**
-   * Re-encrypts every stored DEK with the new master key.
-   * Atomically updates each row; rolls back on any failure.
+   * Three-phase key rotation:
+   *   Phase 1 — Operator sets MASTER_KEY_NEW + MASTER_KEY_NEW_VERSION in env.
+   *   Phase 2 — Call rotateMasterKey(): re-encrypts all DEKs with the new key.
+   *   Phase 3 — Operator removes MASTER_KEY_PREV / MASTER_KEY_PREV_VERSION from env.
    *
-   * Key rotation procedure:
-   *   1. Set MASTER_KEY_NEW + MASTER_KEY_NEW_VERSION in env/HSM.
-   *   2. Call rotateMasterKey() (or trigger via admin endpoint).
-   *   3. After success, promote NEW → current and remove OLD.
+   * During phase 2 the service holds both keys in memory so any in-flight
+   * decryption against the old version continues to work.
    */
-  async rotateMasterKey(): Promise<void> {
+  async rotateMasterKey(operatorId: string): Promise<{ reencryptedCount: number }> {
     const newKeyHex = this.config.get<string>('MASTER_KEY_NEW');
     const newVersion = this.config.get<string>('MASTER_KEY_NEW_VERSION');
 
@@ -76,11 +67,26 @@ export class EnvelopeKeyManagementService implements KeyManagementService, OnMod
       throw new KeyRotationException('all', 'MASTER_KEY_NEW must be 32 bytes (64 hex chars)');
     }
 
-    const deks = await this.dekRepo.find();
-    this.logger.log(`Starting master key rotation for ${deks.length} DEKs`);
+    const oldVersion = this.activeMasterKeyVersion;
 
-    for (const dek of deks) {
-      try {
+    // Register new key in memory immediately so concurrent decryptions keep working
+    this.masterKeys.set(newVersion, newMasterKey);
+
+    const logEntry = this.rotationLogRepo.create({
+      oldKeyVersion: oldVersion,
+      newKeyVersion: newVersion,
+      operatorId,
+      phase: 'started',
+      reencryptedCount: 0,
+    });
+    await this.rotationLogRepo.save(logEntry);
+
+    const deks = await this.dekRepo.find();
+    this.logger.log(`Starting master key rotation for ${deks.length} DEKs (${oldVersion} → ${newVersion})`);
+
+    let reencryptedCount = 0;
+    try {
+      for (const dek of deks) {
         const encryptedKey: EncryptedKey = {
           ciphertext: Buffer.from(dek.ciphertext, 'hex'),
           iv: Buffer.from(dek.iv, 'hex'),
@@ -90,41 +96,71 @@ export class EnvelopeKeyManagementService implements KeyManagementService, OnMod
 
         const plainDek = await this.decryptDEK(encryptedKey);
         const reEncrypted = this.encryptWithKey(plainDek, newMasterKey, newVersion);
-        plainDek.fill(0); // zero plaintext immediately
+        plainDek.fill(0);
 
         await this.persistDek(dek.patientAddress, reEncrypted);
-      } catch (err) {
-        throw new KeyRotationException(dek.patientAddress, err.message);
+        reencryptedCount++;
       }
+    } catch (err) {
+      await this.rotationLogRepo.update(logEntry.id, {
+        phase: 'failed',
+        errorMessage: err.message,
+        completedAt: new Date(),
+        reencryptedCount,
+      });
+      throw new KeyRotationException('batch', err.message);
     }
 
-    // Promote new key as active
-    this.masterKey = newMasterKey;
-    this.masterKeyVersion = newVersion;
-    this.logger.log(`Master key rotation complete — active version: ${newVersion}`);
+    // Promote new key as active; keep old key available for any in-flight requests
+    this.activeMasterKeyVersion = newVersion;
+
+    await this.rotationLogRepo.update(logEntry.id, {
+      phase: 'completed',
+      reencryptedCount,
+      completedAt: new Date(),
+    });
+
+    this.logger.log(`Master key rotation complete — active version: ${newVersion}, re-encrypted: ${reencryptedCount}`);
+    return { reencryptedCount };
+  }
+
+  async getRotationStatus(): Promise<KeyRotationLog[]> {
+    return this.rotationLogRepo.find({ order: { startedAt: 'DESC' }, take: 20 });
   }
 
   // ─── Private helpers ───────────────────────────────────────────────────────
 
-  private loadMasterKey(): void {
+  /**
+   * Loads the active master key plus any previous key still needed during a
+   * rotation window (MASTER_KEY_PREV / MASTER_KEY_PREV_VERSION).
+   */
+  private loadMasterKeys(): void {
     const hex = this.config.get<string>('MASTER_KEY');
     const version = this.config.get<string>('MASTER_KEY_VERSION', 'v1');
 
-    if (!hex) {
-      throw new KeyManagementException('MASTER_KEY environment variable is required');
-    }
+    if (!hex) throw new KeyManagementException('MASTER_KEY environment variable is required');
 
     const key = Buffer.from(hex, 'hex');
-    if (key.length !== KEY_BYTES) {
-      throw new KeyManagementException('MASTER_KEY must be 32 bytes (64 hex chars)');
-    }
+    if (key.length !== KEY_BYTES) throw new KeyManagementException('MASTER_KEY must be 32 bytes (64 hex chars)');
 
-    this.masterKey = key;
-    this.masterKeyVersion = version;
+    this.masterKeys.set(version, key);
+    this.activeMasterKeyVersion = version;
+
+    // Load previous key if present (dual-key support during rotation window)
+    const prevHex = this.config.get<string>('MASTER_KEY_PREV');
+    const prevVersion = this.config.get<string>('MASTER_KEY_PREV_VERSION');
+    if (prevHex && prevVersion) {
+      const prevKey = Buffer.from(prevHex, 'hex');
+      if (prevKey.length === KEY_BYTES) {
+        this.masterKeys.set(prevVersion, prevKey);
+        this.logger.log(`Loaded previous master key version ${prevVersion} for rotation window`);
+      }
+    }
   }
 
-  private encryptWithMasterKey(plaintext: Buffer): EncryptedKey {
-    return this.encryptWithKey(plaintext, this.masterKey, this.masterKeyVersion);
+  private encryptWithActiveKey(plaintext: Buffer): EncryptedKey {
+    const key = this.masterKeys.get(this.activeMasterKeyVersion)!;
+    return this.encryptWithKey(plaintext, key, this.activeMasterKeyVersion);
   }
 
   private encryptWithKey(plaintext: Buffer, key: Buffer, version: string): EncryptedKey {
@@ -135,8 +171,11 @@ export class EnvelopeKeyManagementService implements KeyManagementService, OnMod
     return { ciphertext, iv, authTag, masterKeyVersion: version };
   }
 
-  private decryptWithMasterKey(encryptedKey: EncryptedKey): Buffer {
-    const key = this.resolveKeyForVersion(encryptedKey.masterKeyVersion);
+  private decryptWithKey(encryptedKey: EncryptedKey): Buffer {
+    const key = this.masterKeys.get(encryptedKey.masterKeyVersion);
+    if (!key) {
+      throw new KeyManagementException(`Unknown master key version: ${encryptedKey.masterKeyVersion}`);
+    }
     try {
       const decipher = createDecipheriv(ALGORITHM, key, encryptedKey.iv);
       decipher.setAuthTag(encryptedKey.authTag);
@@ -144,19 +183,6 @@ export class EnvelopeKeyManagementService implements KeyManagementService, OnMod
     } catch {
       throw new KeyManagementException('DEK decryption failed — possible tampering or wrong master key');
     }
-  }
-
-  private resolveKeyForVersion(version: string): Buffer {
-    if (version === this.masterKeyVersion) return this.masterKey;
-
-    // Support one previous version during rotation window
-    const prevHex = this.config.get<string>('MASTER_KEY_PREV');
-    const prevVersion = this.config.get<string>('MASTER_KEY_PREV_VERSION');
-    if (prevHex && version === prevVersion) {
-      return Buffer.from(prevHex, 'hex');
-    }
-
-    throw new KeyManagementException(`Unknown master key version: ${version}`);
   }
 
   private async persistDek(patientAddress: string, encryptedKey: EncryptedKey): Promise<void> {

--- a/src/migrations/1774200000000-CreateKeyRotationLogTable.ts
+++ b/src/migrations/1774200000000-CreateKeyRotationLogTable.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateKeyRotationLogTable1774200000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'key_rotation_log',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true, generationStrategy: 'uuid', default: 'uuid_generate_v4()' },
+          { name: 'old_key_version', type: 'varchar', length: '50' },
+          { name: 'new_key_version', type: 'varchar', length: '50' },
+          { name: 'reencrypted_count', type: 'int', default: '0' },
+          { name: 'operator_id', type: 'varchar', length: '255' },
+          { name: 'phase', type: 'varchar', length: '20' },
+          { name: 'error_message', type: 'text', isNullable: true },
+          { name: 'started_at', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+          { name: 'completed_at', type: 'timestamp', isNullable: true },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('key_rotation_log');
+  }
+}


### PR DESCRIPTION
## Summary

### Branch fix/355-master-key-rotation-dual-key-support

Problem: A service restart mid-rotation would load only the new master key, making DEKs still 
encrypted with the old key un-decryptable.

Changes:
- EnvelopeKeyManagementService — replaced the single masterKey: Buffer with a 
Map<version, Buffer>. On startup it loads the active key plus an optional previous key (
MASTER_KEY_PREV / MASTER_KEY_PREV_VERSION). decryptWithKey looks up the correct key by 
masterKeyVersion on the record — no version is ever "unknown" during the rotation window.
- rotateMasterKey(operatorId) — three-phase: (1) register new key in memory immediately, (2) re-
encrypt all DEKs, (3) promote new version as active. Persists a key_rotation_log row with start 
time, end time, count, operator, and phase.
- New KeyRotationLog entity + migration 1774200000000-CreateKeyRotationLogTable.
- New KeyManagementAdminController with POST /admin/key-management/rotate and 
GET /admin/key-management/rotation-status.

Closes #355 

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Branch fix/354-gdpr-erasure-export-race-condition

Problem: createErasureRequest queued a deletion job without checking for a concurrent export, 
risking partial exports or constraint violations.

Changes:
- GdprService — both createExportRequest and createErasureRequest now run inside withLock(), 
which acquires a per-user Redis SETNX lock (gdpr:lock:<userId>, TTL 30 s) before doing anything.
- createErasureRequest checks for any PENDING or IN_PROGRESS EXPORT request first and throws 
409 Conflict if found.
- assertNoPendingRequest prevents duplicate EXPORT or ERASURE requests from the same user.
- New integration test gdpr-concurrent.spec.ts covering all four scenarios.

Closes #354 

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Branch fix/363-appointment-double-booking-distributed-lock

Problem: checkDoctorAvailability and appointmentRepository.save were two separate non-atomic 
operations — two concurrent requests could both pass the check.

Changes:
- AppointmentService.create now:
  1. Acquires a Redis distributed lock keyed by appointment:lock:<doctorId>:<slotEpochMs> (TTL 10
s) — blocks concurrent requests across API instances before they hit the DB.
  2. Wraps the availability check + conflict count + insert in a single DataSource.transaction 
with a SELECT ... FOR UPDATE pessimistic write lock on the doctor_availability row — serialises 
concurrent DB transactions on the same instance.
  3. Returns 409 Conflict from either path with a user-friendly message.
- New integration test appointment-double-booking.spec.ts including the 10-concurrent-requests 
scenario asserting exactly 1 succeeds.

Closes #363 