### PR TITLE
fix(#353,#365,#372,#373): add BullMQ idempotency for Stellar transact…

### DIFF
--- a/src/data-residency/config/data-residency.config.ts
+++ b/src/data-residency/config/data-residency.config.ts
@@ -1,0 +1,71 @@
+import { registerAs } from '@nestjs/config';
+import * as Joi from 'joi';
+
+export const DATA_RESIDENCY_CONFIG_KEY = 'dataResidency';
+
+const schema = Joi.object({
+  DB_HOST_EU: Joi.string().required(),
+  DB_PORT_EU: Joi.number().default(5432),
+  DB_NAME_EU: Joi.string().default('healthy_stellar_eu'),
+
+  DB_HOST_US: Joi.string().required(),
+  DB_PORT_US: Joi.number().default(5432),
+  DB_NAME_US: Joi.string().default('healthy_stellar_us'),
+
+  DB_HOST_APAC: Joi.string().required(),
+  DB_PORT_APAC: Joi.number().default(5432),
+  DB_NAME_APAC: Joi.string().default('healthy_stellar_apac'),
+
+  DB_HOST_AFRICA: Joi.string().required(),
+  DB_PORT_AFRICA: Joi.number().default(5432),
+  DB_NAME_AFRICA: Joi.string().default('healthy_stellar_africa'),
+
+  STELLAR_HORIZON_EU_URL: Joi.string().uri().default('https://horizon.eu.stellar.org'),
+  STELLAR_HORIZON_US_URL: Joi.string().uri().default('https://horizon.us.stellar.org'),
+  STELLAR_HORIZON_APAC_URL: Joi.string().uri().default('https://horizon.apac.stellar.org'),
+  STELLAR_HORIZON_AFRICA_URL: Joi.string().uri().default('https://horizon.africa.stellar.org'),
+
+  IPFS_NODES_EU: Joi.string().default('https://ipfs-eu-1.infura.io:5001'),
+  IPFS_NODES_US: Joi.string().default('https://ipfs-us-1.infura.io:5001'),
+  IPFS_NODES_APAC: Joi.string().default('https://ipfs-apac-1.infura.io:5001'),
+  IPFS_NODES_AFRICA: Joi.string().default('https://ipfs-africa-1.infura.io:5001'),
+}).options({ allowUnknown: true });
+
+export function validateDataResidencyConfig(config: Record<string, unknown>) {
+  const { error } = schema.validate(config);
+  if (error) {
+    throw new Error(`Data residency configuration error: ${error.message}`);
+  }
+  return config;
+}
+
+export const dataResidencyConfig = registerAs(DATA_RESIDENCY_CONFIG_KEY, () => ({
+  eu: {
+    dbHost: process.env.DB_HOST_EU,
+    dbPort: parseInt(process.env.DB_PORT_EU || '5432', 10),
+    dbName: process.env.DB_NAME_EU || 'healthy_stellar_eu',
+    horizonUrl: process.env.STELLAR_HORIZON_EU_URL || 'https://horizon.eu.stellar.org',
+    ipfsNodes: (process.env.IPFS_NODES_EU || 'https://ipfs-eu-1.infura.io:5001').split(','),
+  },
+  us: {
+    dbHost: process.env.DB_HOST_US,
+    dbPort: parseInt(process.env.DB_PORT_US || '5432', 10),
+    dbName: process.env.DB_NAME_US || 'healthy_stellar_us',
+    horizonUrl: process.env.STELLAR_HORIZON_US_URL || 'https://horizon.us.stellar.org',
+    ipfsNodes: (process.env.IPFS_NODES_US || 'https://ipfs-us-1.infura.io:5001').split(','),
+  },
+  apac: {
+    dbHost: process.env.DB_HOST_APAC,
+    dbPort: parseInt(process.env.DB_PORT_APAC || '5432', 10),
+    dbName: process.env.DB_NAME_APAC || 'healthy_stellar_apac',
+    horizonUrl: process.env.STELLAR_HORIZON_APAC_URL || 'https://horizon.apac.stellar.org',
+    ipfsNodes: (process.env.IPFS_NODES_APAC || 'https://ipfs-apac-1.infura.io:5001').split(','),
+  },
+  africa: {
+    dbHost: process.env.DB_HOST_AFRICA,
+    dbPort: parseInt(process.env.DB_PORT_AFRICA || '5432', 10),
+    dbName: process.env.DB_NAME_AFRICA || 'healthy_stellar_africa',
+    horizonUrl: process.env.STELLAR_HORIZON_AFRICA_URL || 'https://horizon.africa.stellar.org',
+    ipfsNodes: (process.env.IPFS_NODES_AFRICA || 'https://ipfs-africa-1.infura.io:5001').split(','),
+  },
+}));

--- a/src/data-residency/data-residency.config.spec.ts
+++ b/src/data-residency/data-residency.config.spec.ts
@@ -1,0 +1,61 @@
+import { Test } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { dataResidencyConfig, validateDataResidencyConfig } from '../config/data-residency.config';
+import { DataResidencyService } from '../services/data-residency.service';
+
+async function buildModule(env: Record<string, string>) {
+  // Temporarily override process.env for this test
+  const original = { ...process.env };
+  Object.assign(process.env, env);
+
+  try {
+    const module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          ignoreEnvFile: true,
+          validate: validateDataResidencyConfig,
+          load: [dataResidencyConfig],
+        }),
+      ],
+      providers: [DataResidencyService],
+    }).compile();
+
+    return module;
+  } finally {
+    // Restore env
+    Object.keys(env).forEach((k) => {
+      if (original[k] === undefined) delete process.env[k];
+      else process.env[k] = original[k];
+    });
+  }
+}
+
+const FULL_ENV = {
+  DB_HOST_EU: 'postgres-eu.test',
+  DB_HOST_US: 'postgres-us.test',
+  DB_HOST_APAC: 'postgres-apac.test',
+  DB_HOST_AFRICA: 'postgres-africa.test',
+};
+
+describe('DataResidencyModule – config validation', () => {
+  it('initialises successfully when all required DB_HOST_* vars are present', async () => {
+    const module = await buildModule(FULL_ENV);
+    const service = module.get(DataResidencyService);
+    service.onModuleInit();
+    expect(service.getDatabaseConfig('EU' as any).host).toBe('postgres-eu.test');
+  });
+
+  it('throws a startup error when DB_HOST_EU is missing', async () => {
+    const { DB_HOST_EU: _omit, ...withoutEu } = FULL_ENV;
+    await expect(buildModule(withoutEu)).rejects.toThrow(
+      /DB_HOST_EU/,
+    );
+  });
+
+  it('throws a startup error when DB_HOST_US is missing', async () => {
+    const { DB_HOST_US: _omit, ...withoutUs } = FULL_ENV;
+    await expect(buildModule(withoutUs)).rejects.toThrow(
+      /DB_HOST_US/,
+    );
+  });
+});

--- a/src/data-residency/data-residency.module.ts
+++ b/src/data-residency/data-residency.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { dataResidencyConfig, validateDataResidencyConfig } from './config/data-residency.config';
 import { DataResidencyService } from './services/data-residency.service';
 import { RegionalDatabaseService } from './services/regional-database.service';
 import { RegionalIpfsService } from './services/regional-ipfs.service';
@@ -8,13 +9,11 @@ import { DataResidencyGuard } from './guards/data-residency.guard';
 import { DataRegionHeaderInterceptor } from './interceptors/data-region-header.interceptor';
 import { DataResidencyController } from './controllers/data-residency.controller';
 
-/**
- * Data Residency Module
- * Manages region-aware infrastructure for multi-region deployments
- * Ensures compliance with regional data protection regulations
- */
 @Module({
-  imports: [ConfigModule],
+  imports: [
+    ConfigModule.forFeature(dataResidencyConfig),
+    ConfigModule.forRoot({ validate: validateDataResidencyConfig }),
+  ],
   providers: [
     DataResidencyService,
     RegionalDatabaseService,

--- a/src/data-residency/services/data-residency.service.ts
+++ b/src/data-residency/services/data-residency.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { DataResidencyRegion } from '../../enums/data-residency.enum';
+import { DATA_RESIDENCY_CONFIG_KEY } from '../config/data-residency.config';
 
 /**
  * Regional infrastructure configuration
@@ -22,87 +23,66 @@ export interface RegionalConfig {
  * Manages regional configuration for data residency
  */
 @Injectable()
-export class DataResidencyService {
+export class DataResidencyService implements OnModuleInit {
   private readonly logger = new Logger(DataResidencyService.name);
-
-  private readonly regionConfigs: Record<DataResidencyRegion, RegionalConfig> = {
-    [DataResidencyRegion.EU]: {
-      horizonUrl:
-        process.env.STELLAR_HORIZON_EU_URL ||
-        'https://horizon.eu.stellar.org',
-      ipfsNodes: (
-        process.env.IPFS_NODES_EU || 'https://ipfs-eu-1.infura.io:5001'
-      ).split(','),
-      databaseConfig: {
-        host:
-          process.env.DB_HOST_EU ||
-          'postgres-eu.internal.example.com',
-        port: parseInt(process.env.DB_PORT_EU || '5432', 10),
-        database: process.env.DB_NAME_EU || 'healthy_stellar_eu',
-      },
-      awsRegion: 'eu-west-1',
-      dataCenter: 'Frankfurt',
-      description: 'EU Data Center (GDPR Compliant)',
-    },
-    [DataResidencyRegion.US]: {
-      horizonUrl:
-        process.env.STELLAR_HORIZON_US_URL ||
-        'https://horizon.us.stellar.org',
-      ipfsNodes: (
-        process.env.IPFS_NODES_US || 'https://ipfs-us-1.infura.io:5001'
-      ).split(','),
-      databaseConfig: {
-        host:
-          process.env.DB_HOST_US ||
-          'postgres-us.internal.example.com',
-        port: parseInt(process.env.DB_PORT_US || '5432', 10),
-        database: process.env.DB_NAME_US || 'healthy_stellar_us',
-      },
-      awsRegion: 'us-east-1',
-      dataCenter: 'N. Virginia',
-      description: 'US Data Center (HIPAA Compliant)',
-    },
-    [DataResidencyRegion.APAC]: {
-      horizonUrl:
-        process.env.STELLAR_HORIZON_APAC_URL ||
-        'https://horizon.apac.stellar.org',
-      ipfsNodes: (
-        process.env.IPFS_NODES_APAC ||
-        'https://ipfs-apac-1.infura.io:5001'
-      ).split(','),
-      databaseConfig: {
-        host:
-          process.env.DB_HOST_APAC ||
-          'postgres-apac.internal.example.com',
-        port: parseInt(process.env.DB_PORT_APAC || '5432', 10),
-        database: process.env.DB_NAME_APAC || 'healthy_stellar_apac',
-      },
-      awsRegion: 'ap-southeast-1',
-      dataCenter: 'Singapore',
-      description: 'APAC Data Center (PDPA Compliant)',
-    },
-    [DataResidencyRegion.AFRICA]: {
-      horizonUrl:
-        process.env.STELLAR_HORIZON_AFRICA_URL ||
-        'https://horizon.africa.stellar.org',
-      ipfsNodes: (
-        process.env.IPFS_NODES_AFRICA ||
-        'https://ipfs-africa-1.infura.io:5001'
-      ).split(','),
-      databaseConfig: {
-        host:
-          process.env.DB_HOST_AFRICA ||
-          'postgres-africa.internal.example.com',
-        port: parseInt(process.env.DB_PORT_AFRICA || '5432', 10),
-        database: process.env.DB_NAME_AFRICA || 'healthy_stellar_africa',
-      },
-      awsRegion: 'af-south-1',
-      dataCenter: 'Cape Town',
-      description: 'Africa Data Center (POPIA Compliant)',
-    },
-  };
+  private regionConfigs: Record<DataResidencyRegion, RegionalConfig>;
 
   constructor(private configService: ConfigService) {}
+
+  onModuleInit(): void {
+    const cfg = (key: string) => this.configService.get(`${DATA_RESIDENCY_CONFIG_KEY}.${key}`);
+
+    this.regionConfigs = {
+      [DataResidencyRegion.EU]: {
+        horizonUrl: cfg('eu.horizonUrl'),
+        ipfsNodes: cfg('eu.ipfsNodes'),
+        databaseConfig: {
+          host: cfg('eu.dbHost'),
+          port: cfg('eu.dbPort'),
+          database: cfg('eu.dbName'),
+        },
+        awsRegion: 'eu-west-1',
+        dataCenter: 'Frankfurt',
+        description: 'EU Data Center (GDPR Compliant)',
+      },
+      [DataResidencyRegion.US]: {
+        horizonUrl: cfg('us.horizonUrl'),
+        ipfsNodes: cfg('us.ipfsNodes'),
+        databaseConfig: {
+          host: cfg('us.dbHost'),
+          port: cfg('us.dbPort'),
+          database: cfg('us.dbName'),
+        },
+        awsRegion: 'us-east-1',
+        dataCenter: 'N. Virginia',
+        description: 'US Data Center (HIPAA Compliant)',
+      },
+      [DataResidencyRegion.APAC]: {
+        horizonUrl: cfg('apac.horizonUrl'),
+        ipfsNodes: cfg('apac.ipfsNodes'),
+        databaseConfig: {
+          host: cfg('apac.dbHost'),
+          port: cfg('apac.dbPort'),
+          database: cfg('apac.dbName'),
+        },
+        awsRegion: 'ap-southeast-1',
+        dataCenter: 'Singapore',
+        description: 'APAC Data Center (PDPA Compliant)',
+      },
+      [DataResidencyRegion.AFRICA]: {
+        horizonUrl: cfg('africa.horizonUrl'),
+        ipfsNodes: cfg('africa.ipfsNodes'),
+        databaseConfig: {
+          host: cfg('africa.dbHost'),
+          port: cfg('africa.dbPort'),
+          database: cfg('africa.dbName'),
+        },
+        awsRegion: 'af-south-1',
+        dataCenter: 'Cape Town',
+        description: 'Africa Data Center (POPIA Compliant)',
+      },
+    };
+  }
 
   /**
    * Get regional configuration for a specific region

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,23 +1,17 @@
 import { Controller, Get, UseGuards, Version, VERSION_NEUTRAL } from '@nestjs/common';
-import { Controller, Get, Version, VERSION_NEUTRAL, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
 import { RedisHealthIndicator } from './indicators/redis.health';
 import { IpfsHealthIndicator } from './indicators/ipfs.health';
 import { StellarHealthIndicator } from './indicators/stellar.health';
 import { DetailedHealthIndicator } from './indicators/detailed-health.indicator';
-import { DetailedHealthIndicator } from './indicators/detailed.health';
 import { Public } from '../common/decorators/public.decorator';
- feat/detailed-health-endpoint
-import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { RolesGuard } from '../auth/guards/roles.guard';
-import { Roles } from '../auth/decorators/roles.decorator';
-import { UserRole } from '../auth/entities/user.entity';
-
-import { CircuitBreakerService } from '../common/circuit-breaker/circuit-breaker.service';
- main
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AdminGuard } from '../auth/guards/admin.guard';
+import { CircuitBreakerService } from '../common/circuit-breaker/circuit-breaker.service';
+import { RegionalDatabaseService } from '../data-residency/services/regional-database.service';
+import { RegionalIpfsService } from '../data-residency/services/regional-ipfs.service';
+import { DataResidencyRegion } from '../enums/data-residency.enum';
 
 @ApiTags('health')
 @Version(VERSION_NEUTRAL)
@@ -30,12 +24,10 @@ export class HealthController {
     private redis: RedisHealthIndicator,
     private ipfs: IpfsHealthIndicator,
     private stellar: StellarHealthIndicator,
- feat/detailed-health-endpoint
-    private detailed: DetailedHealthIndicator,
-
-    private circuitBreaker: CircuitBreakerService,
- main
     private detailedHealth: DetailedHealthIndicator,
+    private circuitBreaker: CircuitBreakerService,
+    private regionalDatabase: RegionalDatabaseService,
+    private regionalIpfs: RegionalIpfsService,
   ) {}
 
   @Get()
@@ -59,12 +51,9 @@ export class HealthController {
       () => this.stellar.isHealthy('stellar'),
     ]);
 
-    // Add circuit breaker states to health check response
-    const circuitBreakerStates = this.circuitBreaker.getAllStates();
-
     return {
       ...healthChecks,
-      circuitBreakers: circuitBreakerStates,
+      circuitBreakers: this.circuitBreaker.getAllStates(),
     };
   }
 
@@ -89,17 +78,30 @@ export class HealthController {
     };
   }
 
-  @Get('detailed')
-  @HealthCheck()
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(UserRole.ADMIN)
-  @ApiBearerAuth()
-  @ApiOperation({ summary: 'Detailed diagnostics (admin only)' })
-  @ApiResponse({ status: 200, description: 'Detailed health diagnostics' })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
-  @ApiResponse({ status: 503, description: 'Critical dependency down' })
-  async checkDetailed() {
-    return this.health.check([() => this.detailed.getDetailedHealth()]);
+  @Get('data-residency')
+  @ApiOperation({ summary: 'Regional database and IPFS node connectivity' })
+  @ApiResponse({ status: 200, description: 'Per-region health status' })
+  async checkDataResidency() {
+    const regions = Object.values(DataResidencyRegion);
+
+    const [dbHealth, ipfsHealth] = await Promise.all([
+      this.regionalDatabase.getRegionalHealthStatus(),
+      Promise.all(
+        regions.map(async (region) => ({
+          region,
+          nodes: await this.regionalIpfs.checkRegionalNodesHealth(region),
+        })),
+      ),
+    ]);
+
+    const ipfsResult = Object.fromEntries(
+      ipfsHealth.map(({ region, nodes }) => [region, nodes]),
+    );
+
+    return {
+      database: dbHealth,
+      ipfs: ipfsResult,
+      timestamp: new Date().toISOString(),
+    };
   }
 }

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -7,18 +7,23 @@ import { HealthController } from './health.controller';
 import { RedisHealthIndicator } from './indicators/redis.health';
 import { IpfsHealthIndicator } from './indicators/ipfs.health';
 import { StellarHealthIndicator } from './indicators/stellar.health';
- feat/detailed-health-endpoint
 import { DetailedHealthIndicator } from './indicators/detailed-health.indicator';
+import { CircuitBreakerModule } from '../common/circuit-breaker/circuit-breaker.module';
+import { DataResidencyModule } from '../data-residency/data-residency.module';
 import { QUEUE_NAMES } from '../queues/queue.constants';
 
 @Module({
   imports: [
     TerminusModule,
     HttpModule,
+    CircuitBreakerModule,
+    TypeOrmModule,
+    DataResidencyModule,
     BullModule.registerQueue(
       { name: QUEUE_NAMES.STELLAR_TRANSACTIONS },
       { name: QUEUE_NAMES.IPFS_UPLOADS },
       { name: QUEUE_NAMES.EMAIL_NOTIFICATIONS },
+      { name: QUEUE_NAMES.REPORTS },
     ),
   ],
   controllers: [HealthController],
@@ -28,26 +33,5 @@ import { QUEUE_NAMES } from '../queues/queue.constants';
     StellarHealthIndicator,
     DetailedHealthIndicator,
   ],
-import { DetailedHealthIndicator } from './indicators/detailed.health';
-import { CircuitBreakerModule } from '../common/circuit-breaker/circuit-breaker.module';
-import { QUEUE_NAMES } from '../queues/queue.constants';
-
-@Module({
-  imports: [
-    TerminusModule,
-    HttpModule,
-    CircuitBreakerModule,
-    TypeOrmModule,
-    BullModule.registerQueue(
-      { name: QUEUE_NAMES.STELLAR_TRANSACTIONS },
-      { name: QUEUE_NAMES.IPFS_UPLOADS },
-      { name: QUEUE_NAMES.EMAIL_NOTIFICATIONS },
-      { name: QUEUE_NAMES.REPORTS },
-    ),
-  ],
-  controllers: [HealthController],
-  providers: [RedisHealthIndicator, IpfsHealthIndicator, StellarHealthIndicator],
- main
-  providers: [RedisHealthIndicator, IpfsHealthIndicator, StellarHealthIndicator, DetailedHealthIndicator],
 })
 export class HealthModule {}

--- a/src/laboratory/controllers/critical-values.controller.ts
+++ b/src/laboratory/controllers/critical-values.controller.ts
@@ -1,0 +1,68 @@
+import { Controller, Get, Post, Put, Delete, Body, Param, Request } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { CriticalValueDefinitionsService } from '../services/critical-value-definitions.service';
+import { CriticalAlertsService } from '../services/critical-alerts.service';
+import { CreateCriticalValueDefinitionDto } from '../dto/create-critical-value-definition.dto';
+
+@ApiTags('Laboratory - Critical Values')
+@Controller('laboratory/critical-values')
+export class CriticalValuesController {
+  constructor(
+    private readonly definitionsService: CriticalValueDefinitionsService,
+    private readonly alertsService: CriticalAlertsService,
+  ) {}
+
+  // ── Admin: threshold definitions ──────────────────────────────────────────
+
+  @Post('definitions')
+  @ApiOperation({ summary: 'Create a critical value threshold definition' })
+  @ApiResponse({ status: 201 })
+  createDefinition(@Body() dto: CreateCriticalValueDefinitionDto, @Request() req: any) {
+    return this.definitionsService.create(dto, req.user?.id || 'system');
+  }
+
+  @Get('definitions')
+  @ApiOperation({ summary: 'List all active critical value definitions' })
+  findDefinitions() {
+    return this.definitionsService.findAll();
+  }
+
+  @Put('definitions/:id')
+  @ApiOperation({ summary: 'Update a critical value definition' })
+  updateDefinition(
+    @Param('id') id: string,
+    @Body() dto: Partial<CreateCriticalValueDefinitionDto>,
+  ) {
+    return this.definitionsService.update(id, dto);
+  }
+
+  @Delete('definitions/:id')
+  @ApiOperation({ summary: 'Deactivate a critical value definition' })
+  removeDefinition(@Param('id') id: string) {
+    return this.definitionsService.remove(id);
+  }
+
+  // ── Supervisor: unacknowledged alerts ─────────────────────────────────────
+
+  @Get('unacknowledged')
+  @ApiOperation({ summary: 'List all unacknowledged critical value alerts' })
+  @ApiResponse({ status: 200, description: 'Unacknowledged critical alerts' })
+  getUnacknowledged() {
+    return this.alertsService.findUnacknowledged();
+  }
+
+  // ── Provider: acknowledge an alert ────────────────────────────────────────
+
+  @Post(':id/acknowledge')
+  @ApiOperation({ summary: 'Acknowledge a critical value alert' })
+  acknowledge(
+    @Param('id') id: string,
+    @Body('notes') notes: string,
+    @Body('followUpActions') followUpActions: string,
+    @Request() req: any,
+  ) {
+    const userId = req.user?.id || 'system';
+    const userName = req.user?.name;
+    return this.alertsService.acknowledge(id, userId, userName, notes, followUpActions);
+  }
+}

--- a/src/laboratory/dto/create-critical-value-definition.dto.ts
+++ b/src/laboratory/dto/create-critical-value-definition.dto.ts
@@ -1,0 +1,35 @@
+import { IsString, IsNotEmpty, IsNumber, IsOptional, IsEnum } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { CriticalSeverity } from '../entities/critical-value-definition.entity';
+
+export class CreateCriticalValueDefinitionDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  testCode: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  testName: string;
+
+  @ApiPropertyOptional()
+  @IsNumber()
+  @IsOptional()
+  criticalLow?: number;
+
+  @ApiPropertyOptional()
+  @IsNumber()
+  @IsOptional()
+  criticalHigh?: number;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  unit?: string;
+
+  @ApiPropertyOptional({ enum: CriticalSeverity })
+  @IsEnum(CriticalSeverity)
+  @IsOptional()
+  severity?: CriticalSeverity;
+}

--- a/src/laboratory/entities/critical-value-definition.entity.ts
+++ b/src/laboratory/entities/critical-value-definition.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum CriticalSeverity {
+  HIGH = 'high',
+  CRITICAL = 'critical',
+}
+
+@Entity('critical_value_definitions')
+@Index(['testCode'], { unique: true })
+export class CriticalValueDefinition {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  testCode: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  testName: string;
+
+  @Column({ type: 'decimal', precision: 15, scale: 4, nullable: true })
+  criticalLow: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 4, nullable: true })
+  criticalHigh: number;
+
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  unit: string;
+
+  @Column({ type: 'enum', enum: CriticalSeverity, default: CriticalSeverity.CRITICAL })
+  severity: CriticalSeverity;
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @Column({ type: 'uuid', nullable: true })
+  createdBy: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/laboratory/events/critical-value-detected.event.ts
+++ b/src/laboratory/events/critical-value-detected.event.ts
@@ -1,0 +1,13 @@
+export const CRITICAL_VALUE_DETECTED = 'laboratory.critical_value.detected';
+
+export class CriticalValueDetectedEvent {
+  constructor(
+    public readonly alertId: string,
+    public readonly resultValueId: string,
+    public readonly providerId: string,
+    public readonly testName: string,
+    public readonly value: number,
+    public readonly unit: string,
+    public readonly patientId: string,
+  ) {}
+}

--- a/src/laboratory/handlers/critical-value.handler.spec.ts
+++ b/src/laboratory/handlers/critical-value.handler.spec.ts
@@ -1,0 +1,99 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CriticalValueEventHandler } from './critical-value.handler';
+import { CriticalAlertsService } from '../services/critical-alerts.service';
+import { NotificationsService } from '../../notifications/services/notifications.service';
+import { CriticalValueDetectedEvent } from '../events/critical-value-detected.event';
+import { AlertStatus, NotificationMethod } from '../entities/critical-value-alert.entity';
+
+const mockAlert = (overrides: Partial<any> = {}) => ({
+  id: 'alert-1',
+  notifiedTo: 'provider-1',
+  status: AlertStatus.NOTIFIED,
+  notificationDate: new Date(Date.now() - 20 * 60 * 1000), // 20 min ago
+  notificationLog: [],
+  ...overrides,
+});
+
+describe('CriticalValueEventHandler', () => {
+  let handler: CriticalValueEventHandler;
+  let alertsService: jest.Mocked<CriticalAlertsService>;
+  let notificationsService: jest.Mocked<NotificationsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CriticalValueEventHandler,
+        {
+          provide: CriticalAlertsService,
+          useValue: {
+            notifyProvider: jest.fn().mockResolvedValue(undefined),
+            findPendingEscalation: jest.fn().mockResolvedValue([]),
+            escalate: jest.fn().mockResolvedValue(mockAlert({ status: AlertStatus.ESCALATED })),
+          },
+        },
+        {
+          provide: NotificationsService,
+          useValue: { emitRecordAmended: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    handler = module.get(CriticalValueEventHandler);
+    alertsService = module.get(CriticalAlertsService);
+    notificationsService = module.get(NotificationsService);
+  });
+
+  describe('handleCriticalValueDetected', () => {
+    it('notifies the provider when a critical value event is received', async () => {
+      const event = new CriticalValueDetectedEvent(
+        'alert-1', 'rv-1', 'provider-1', 'Potassium', 6.8, 'mEq/L', 'patient-1',
+      );
+
+      await handler.handleCriticalValueDetected(event);
+
+      expect(alertsService.notifyProvider).toHaveBeenCalledWith(
+        'alert-1', 'Potassium', 6.8, 'mEq/L', 'patient-1',
+      );
+    });
+  });
+
+  describe('escalateUnacknowledgedAlerts', () => {
+    it('does nothing when no alerts are overdue', async () => {
+      alertsService.findPendingEscalation.mockResolvedValue([]);
+
+      await handler.escalateUnacknowledgedAlerts();
+
+      expect(alertsService.escalate).not.toHaveBeenCalled();
+      expect(notificationsService.emitRecordAmended).not.toHaveBeenCalled();
+    });
+
+    it('escalates overdue alerts and emits escalation notification', async () => {
+      const overdueAlert = mockAlert();
+      alertsService.findPendingEscalation.mockResolvedValue([overdueAlert]);
+
+      await handler.escalateUnacknowledgedAlerts();
+
+      expect(alertsService.escalate).toHaveBeenCalledWith(
+        'alert-1', 'system', 'No acknowledgment within 15 minutes',
+      );
+      expect(notificationsService.emitRecordAmended).toHaveBeenCalledWith(
+        'system',
+        'alert-1',
+        expect.objectContaining({
+          type: 'critical_value_escalation',
+          originalProviderId: 'provider-1',
+        }),
+      );
+    });
+
+    it('escalates multiple overdue alerts independently', async () => {
+      const alerts = [mockAlert({ id: 'alert-1' }), mockAlert({ id: 'alert-2', notifiedTo: 'provider-2' })];
+      alertsService.findPendingEscalation.mockResolvedValue(alerts);
+
+      await handler.escalateUnacknowledgedAlerts();
+
+      expect(alertsService.escalate).toHaveBeenCalledTimes(2);
+      expect(notificationsService.emitRecordAmended).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/laboratory/handlers/critical-value.handler.ts
+++ b/src/laboratory/handlers/critical-value.handler.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { CriticalAlertsService } from '../services/critical-alerts.service';
+import {
+  CRITICAL_VALUE_DETECTED,
+  CriticalValueDetectedEvent,
+} from '../events/critical-value-detected.event';
+import { NotificationsService } from '../../notifications/services/notifications.service';
+import { AlertStatus } from '../entities/critical-value-alert.entity';
+
+const ESCALATION_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+@Injectable()
+export class CriticalValueEventHandler {
+  private readonly logger = new Logger(CriticalValueEventHandler.name);
+
+  constructor(
+    private readonly criticalAlertsService: CriticalAlertsService,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  @OnEvent(CRITICAL_VALUE_DETECTED, { async: true })
+  async handleCriticalValueDetected(event: CriticalValueDetectedEvent): Promise<void> {
+    this.logger.log(
+      `Critical value detected — alertId: ${event.alertId}, provider: ${event.providerId}`,
+    );
+
+    await this.criticalAlertsService.notifyProvider(
+      event.alertId,
+      event.testName,
+      event.value,
+      event.unit,
+      event.patientId,
+    );
+  }
+
+  /**
+   * Every minute, check for NOTIFIED alerts older than 15 minutes and escalate them.
+   */
+  @Cron(CronExpression.EVERY_MINUTE)
+  async escalateUnacknowledgedAlerts(): Promise<void> {
+    const overdue = await this.criticalAlertsService.findPendingEscalation(ESCALATION_WINDOW_MS);
+
+    for (const alert of overdue) {
+      this.logger.warn(
+        `Escalating unacknowledged critical alert ${alert.id} (notified at ${alert.notificationDate})`,
+      );
+
+      await this.criticalAlertsService.escalate(alert.id, 'system', 'No acknowledgment within 15 minutes');
+
+      // Notify charge nurse via metadata flag so the notification layer can route it
+      this.notificationsService.emitRecordAmended('system', alert.id, {
+        type: 'critical_value_escalation',
+        originalProviderId: alert.notifiedTo,
+        alertId: alert.id,
+        escalatedAt: new Date().toISOString(),
+      });
+    }
+  }
+}

--- a/src/laboratory/laboratory.module.ts
+++ b/src/laboratory/laboratory.module.ts
@@ -3,14 +3,45 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { LabTest } from './entities/lab-test.entity';
 import { LabOrder } from './entities/lab-order.entity';
 import { LabResult } from './entities/lab-result.entity';
+import { LabResultValue } from './entities/lab-result-value.entity';
+import { LabOrderItem } from './entities/lab-order-item.entity';
+import { LabTestParameter } from './entities/lab-test-parameter.entity';
 import { Specimen } from './entities/specimen.entity';
+import { CriticalValueAlert } from './entities/critical-value-alert.entity';
+import { CriticalValueDefinition } from './entities/critical-value-definition.entity';
 import { LaboratoryController } from './controllers/laboratory.controller';
 import { LaboratoryService } from './services/laboratory.service';
+import { LabResultsService } from './services/lab-results.service';
+import { CriticalAlertsService } from './services/critical-alerts.service';
+import { CriticalValueDefinitionsService } from './services/critical-value-definitions.service';
+import { CriticalValueEventHandler } from './handlers/critical-value.handler';
+import { LabResultsController } from './controllers/lab-results.controller';
+import { CriticalValuesController } from './controllers/critical-values.controller';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([LabTest, LabOrder, LabResult, Specimen])],
-  controllers: [LaboratoryController],
-  providers: [LaboratoryService],
-  exports: [LaboratoryService],
+  imports: [
+    TypeOrmModule.forFeature([
+      LabTest,
+      LabOrder,
+      LabResult,
+      LabResultValue,
+      LabOrderItem,
+      LabTestParameter,
+      Specimen,
+      CriticalValueAlert,
+      CriticalValueDefinition,
+    ]),
+    NotificationsModule,
+  ],
+  controllers: [LaboratoryController, LabResultsController, CriticalValuesController],
+  providers: [
+    LaboratoryService,
+    LabResultsService,
+    CriticalAlertsService,
+    CriticalValueDefinitionsService,
+    CriticalValueEventHandler,
+  ],
+  exports: [LaboratoryService, CriticalAlertsService],
 })
 export class LaboratoryModule {}

--- a/src/laboratory/services/critical-alerts.service.ts
+++ b/src/laboratory/services/critical-alerts.service.ts
@@ -1,12 +1,13 @@
 import { Injectable, NotFoundException, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, In, IsNull } from 'typeorm';
 import {
   CriticalValueAlert,
   AlertStatus,
   NotificationMethod,
 } from '../entities/critical-value-alert.entity';
 import { LabResultValue } from '../entities/lab-result-value.entity';
+import { NotificationsService } from '../../notifications/services/notifications.service';
 
 @Injectable()
 export class CriticalAlertsService {
@@ -17,6 +18,7 @@ export class CriticalAlertsService {
     private alertRepository: Repository<CriticalValueAlert>,
     @InjectRepository(LabResultValue)
     private resultValueRepository: Repository<LabResultValue>,
+    private readonly notificationsService: NotificationsService,
   ) {}
 
   async create(data: {
@@ -201,4 +203,62 @@ export class CriticalAlertsService {
 
     return saved;
   }
+
+  /**
+   * Notify the ordering provider via NotificationsService and mark alert as NOTIFIED.
+   */
+  async notifyProvider(
+    alertId: string,
+    testName: string,
+    value: number,
+    unit: string,
+    patientId: string,
+  ): Promise<void> {
+    const alert = await this.findOne(alertId);
+
+    this.notificationsService.emitRecordAmended(alert.notifiedTo, alertId, {
+      type: 'critical_value',
+      testName,
+      value,
+      unit,
+      patientId,
+      alertId,
+      notifiedAt: new Date().toISOString(),
+    });
+
+    await this.notify(alertId, NotificationMethod.SYSTEM, 'system', 'system');
+    this.logger.log(`Provider ${alert.notifiedTo} notified for critical alert ${alertId}`);
+  }
+
+  /**
+   * Returns alerts that are PENDING or NOTIFIED and have not been acknowledged,
+   * used by the supervisor endpoint.
+   */
+  async findUnacknowledged(): Promise<CriticalValueAlert[]> {
+    return this.alertRepository.find({
+      where: { status: In([AlertStatus.PENDING, AlertStatus.NOTIFIED, AlertStatus.ESCALATED]) },
+      relations: [
+        'resultValue',
+        'resultValue.parameter',
+        'resultValue.labResult',
+        'resultValue.labResult.orderItem',
+        'resultValue.labResult.orderItem.labOrder',
+      ],
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  /**
+   * Returns NOTIFIED alerts older than the given threshold (ms) that have not been acknowledged.
+   * Used by the escalation scheduler.
+   */
+  async findPendingEscalation(olderThanMs: number): Promise<CriticalValueAlert[]> {
+    const cutoff = new Date(Date.now() - olderThanMs);
+    return this.alertRepository
+      .createQueryBuilder('alert')
+      .where('alert.status = :status', { status: AlertStatus.NOTIFIED })
+      .andWhere('alert.notificationDate < :cutoff', { cutoff })
+      .getMany();
+  }
 }
+

--- a/src/laboratory/services/critical-value-definitions.service.ts
+++ b/src/laboratory/services/critical-value-definitions.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CriticalValueDefinition } from '../entities/critical-value-definition.entity';
+import { CreateCriticalValueDefinitionDto } from '../dto/create-critical-value-definition.dto';
+
+@Injectable()
+export class CriticalValueDefinitionsService {
+  constructor(
+    @InjectRepository(CriticalValueDefinition)
+    private readonly repo: Repository<CriticalValueDefinition>,
+  ) {}
+
+  create(dto: CreateCriticalValueDefinitionDto, userId: string): Promise<CriticalValueDefinition> {
+    return this.repo.save(this.repo.create({ ...dto, createdBy: userId }));
+  }
+
+  findAll(): Promise<CriticalValueDefinition[]> {
+    return this.repo.find({ where: { isActive: true }, order: { testCode: 'ASC' } });
+  }
+
+  async findOne(id: string): Promise<CriticalValueDefinition> {
+    const def = await this.repo.findOne({ where: { id } });
+    if (!def) throw new NotFoundException(`CriticalValueDefinition ${id} not found`);
+    return def;
+  }
+
+  async update(id: string, dto: Partial<CreateCriticalValueDefinitionDto>): Promise<CriticalValueDefinition> {
+    await this.findOne(id);
+    await this.repo.update(id, dto);
+    return this.findOne(id);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.findOne(id);
+    await this.repo.update(id, { isActive: false });
+  }
+}

--- a/src/laboratory/services/lab-results.service.ts
+++ b/src/laboratory/services/lab-results.service.ts
@@ -1,12 +1,17 @@
 import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { LabResult, ResultStatus } from '../entities/lab-result.entity';
 import { LabResultValue, AbnormalFlag } from '../entities/lab-result-value.entity';
 import { LabOrderItem, OrderItemStatus } from '../entities/lab-order-item.entity';
 import { LabTestParameter } from '../entities/lab-test-parameter.entity';
 import { CreateLabResultDto } from '../dto/create-lab-result.dto';
 import { CriticalAlertsService } from './critical-alerts.service';
+import {
+  CRITICAL_VALUE_DETECTED,
+  CriticalValueDetectedEvent,
+} from '../events/critical-value-detected.event';
 
 @Injectable()
 export class LabResultsService {
@@ -22,6 +27,7 @@ export class LabResultsService {
     @InjectRepository(LabTestParameter)
     private parameterRepository: Repository<LabTestParameter>,
     private criticalAlertsService: CriticalAlertsService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async create(createDto: CreateLabResultDto, userId: string): Promise<LabResult> {
@@ -224,10 +230,25 @@ export class LabResultsService {
         value.abnormalFlag === AbnormalFlag.CRITICAL_LOW ||
         value.abnormalFlag === AbnormalFlag.CRITICAL_HIGH
       ) {
-        await this.criticalAlertsService.create({
+        const alert = await this.criticalAlertsService.create({
           resultValueId: value.id,
           notifiedTo: providerId,
         });
+
+        const patientId = labResult.orderItem?.labOrder?.patientId ?? 'unknown';
+
+        this.eventEmitter.emit(
+          CRITICAL_VALUE_DETECTED,
+          new CriticalValueDetectedEvent(
+            alert.id,
+            value.id,
+            providerId,
+            value.parameter?.parameterName ?? 'Unknown test',
+            value.numericValue,
+            value.parameter?.unit ?? '',
+            patientId,
+          ),
+        );
       }
     }
   }

--- a/src/pharmacy/entities/drug.entity.ts
+++ b/src/pharmacy/entities/drug.entity.ts
@@ -7,6 +7,14 @@ import {
   Index,
 } from 'typeorm';
 
+export enum ControlledSubstanceSchedule {
+  SCHEDULE_I = 'CI',
+  SCHEDULE_II = 'CII',
+  SCHEDULE_III = 'CIII',
+  SCHEDULE_IV = 'CIV',
+  SCHEDULE_V = 'CV',
+}
+
 @Entity('drugs')
 export class Drug {
   @PrimaryGeneratedColumn('uuid')
@@ -63,6 +71,9 @@ export class Drug {
 
   @Column({ default: false })
   controlledSubstance: boolean;
+
+  @Column({ nullable: true, type: 'enum', enum: ControlledSubstanceSchedule })
+  controlledSubstanceSchedule: ControlledSubstanceSchedule;
 
   @Column({ nullable: true })
   scheduleClass: string;

--- a/src/pharmacy/entities/prescription.entity.ts
+++ b/src/pharmacy/entities/prescription.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
   Index,
 } from 'typeorm';
+import { ControlledSubstanceSchedule } from './drug.entity';
 
 @Entity('prescriptions')
 export class Prescription {
@@ -40,6 +41,9 @@ export class Prescription {
 
   @Column()
   refillsRemaining: number;
+
+  @Column({ nullable: true, type: 'enum', enum: ControlledSubstanceSchedule })
+  controlledSubstanceSchedule: ControlledSubstanceSchedule;
 
   @Column('text')
   instructions: string;

--- a/src/pharmacy/errors/prescription-validation.error.ts
+++ b/src/pharmacy/errors/prescription-validation.error.ts
@@ -1,0 +1,14 @@
+export enum PrescriptionValidationErrorCode {
+  DEA_NUMBER_REQUIRED = 'DEA_NUMBER_REQUIRED',
+  SCHEDULE_II_NO_REFILLS = 'SCHEDULE_II_NO_REFILLS',
+  SCHEDULE_II_EXPIRED = 'SCHEDULE_II_EXPIRED',
+  PDMP_FLAG = 'PDMP_FLAG',
+}
+
+export class PrescriptionValidationError {
+  constructor(
+    public readonly code: PrescriptionValidationErrorCode,
+    public readonly description: string,
+    public readonly severity: 'major' | 'critical' = 'critical',
+  ) {}
+}

--- a/src/pharmacy/pharmacy.module.ts
+++ b/src/pharmacy/pharmacy.module.ts
@@ -1,14 +1,23 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpModule } from '@nestjs/axios';
+import { ConfigModule } from '@nestjs/config';
 import { Drug } from './entities/drug.entity';
 import { Prescription } from './entities/prescription.entity';
+import { SafetyAlert } from './entities/safety-alert.entity';
 import { PharmacyController } from './controllers/pharmacy.controller';
 import { PharmacyService } from './services/pharmacy.service';
+import { PrescriptionValidationService } from './services/prescription-validation.service';
+import { PdmpService } from './services/pdmp.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Drug, Prescription])],
+  imports: [
+    TypeOrmModule.forFeature([Drug, Prescription, SafetyAlert]),
+    HttpModule,
+    ConfigModule,
+  ],
   controllers: [PharmacyController],
-  providers: [PharmacyService],
-  exports: [PharmacyService],
+  providers: [PharmacyService, PrescriptionValidationService, PdmpService],
+  exports: [PharmacyService, PrescriptionValidationService],
 })
 export class PharmacyModule {}

--- a/src/pharmacy/services/pdmp.service.ts
+++ b/src/pharmacy/services/pdmp.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+
+export interface PdmpRecord {
+  prescriptionDate: string;
+  drugName: string;
+  schedule: string;
+  quantity: number;
+  daysSupply: number;
+  prescriberId: string;
+  pharmacyId: string;
+}
+
+export interface PdmpHistory {
+  patientId: string;
+  records: PdmpRecord[];
+  multiplePrescriberCount: number;
+  multiplePharmacyCount: number;
+}
+
+@Injectable()
+export class PdmpService {
+  private readonly logger = new Logger(PdmpService.name);
+  private readonly pdmpUrl: string;
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {
+    this.pdmpUrl = this.configService.get<string>('PDMP_API_URL', '');
+  }
+
+  /**
+   * Fetch the patient's 90-day controlled substance history from the PDMP.
+   * Returns null if PDMP_API_URL is not configured (non-blocking).
+   */
+  async getPatientHistory(patientId: string): Promise<PdmpHistory | null> {
+    if (!this.pdmpUrl) {
+      this.logger.warn('PDMP_API_URL not configured — skipping PDMP check');
+      return null;
+    }
+
+    try {
+      const { data } = await firstValueFrom(
+        this.httpService.get<PdmpHistory>(`${this.pdmpUrl}/patients/${patientId}/history`, {
+          params: { days: 90 },
+          timeout: 5000,
+        }),
+      );
+      return data;
+    } catch (error) {
+      this.logger.error(`PDMP lookup failed for patient ${patientId}: ${(error as Error).message}`);
+      return null;
+    }
+  }
+}

--- a/src/pharmacy/services/prescription-validation.service.spec.ts
+++ b/src/pharmacy/services/prescription-validation.service.spec.ts
@@ -1,0 +1,203 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PrescriptionValidationService } from './prescription-validation.service';
+import { PdmpService } from './pdmp.service';
+import { Prescription } from '../entities/prescription.entity';
+import { Drug } from '../entities/drug.entity';
+import { SafetyAlert } from '../entities/safety-alert.entity';
+import { ControlledSubstanceSchedule } from '../entities/drug.entity';
+import { PrescriptionValidationErrorCode } from '../errors/prescription-validation.error';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const basePrescription = (overrides: Partial<Prescription> = {}): Prescription =>
+  ({
+    id: 'rx-1',
+    patientId: 'patient-1',
+    providerId: 'provider-1',
+    refills: 0,
+    prescribedDate: new Date(),
+    controlledSubstanceSchedule: null,
+    items: [],
+    ...overrides,
+  } as any);
+
+const basePatientFactors = () => ({
+  age: 40,
+  allergies: [],
+  medicalConditions: [],
+});
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+describe('PrescriptionValidationService – DEA / Schedule II / PDMP', () => {
+  let service: PrescriptionValidationService;
+  let pdmpService: jest.Mocked<PdmpService>;
+  let prescriptionRepo: { findOne: jest.Mock };
+
+  beforeEach(async () => {
+    prescriptionRepo = { findOne: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PrescriptionValidationService,
+        {
+          provide: getRepositoryToken(Prescription),
+          useValue: prescriptionRepo,
+        },
+        {
+          provide: getRepositoryToken(Drug),
+          useValue: { findOne: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(SafetyAlert),
+          useValue: { find: jest.fn() },
+        },
+        {
+          provide: PdmpService,
+          useValue: { getPatientHistory: jest.fn().mockResolvedValue(null) },
+        },
+      ],
+    }).compile();
+
+    service = module.get(PrescriptionValidationService);
+    pdmpService = module.get(PdmpService);
+  });
+
+  // ── DEA number ─────────────────────────────────────────────────────────────
+
+  it('rejects a Schedule II prescription when no DEA number is provided', async () => {
+    prescriptionRepo.findOne.mockResolvedValue(
+      basePrescription({ controlledSubstanceSchedule: ControlledSubstanceSchedule.SCHEDULE_II }),
+    );
+
+    const result = await service.validatePrescription('rx-1', basePatientFactors());
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((e) => e.code === PrescriptionValidationErrorCode.DEA_NUMBER_REQUIRED)).toBe(true);
+  });
+
+  it('passes DEA check when a DEA number is supplied for a Schedule II prescription', async () => {
+    prescriptionRepo.findOne.mockResolvedValue(
+      basePrescription({ controlledSubstanceSchedule: ControlledSubstanceSchedule.SCHEDULE_II }),
+    );
+
+    const result = await service.validatePrescription('rx-1', basePatientFactors(), 'AB1234563');
+
+    expect(result.errors.some((e) => e.code === PrescriptionValidationErrorCode.DEA_NUMBER_REQUIRED)).toBe(false);
+  });
+
+  // ── No refills on CII ──────────────────────────────────────────────────────
+
+  it('rejects a Schedule II prescription that has refills > 0', async () => {
+    prescriptionRepo.findOne.mockResolvedValue(
+      basePrescription({
+        controlledSubstanceSchedule: ControlledSubstanceSchedule.SCHEDULE_II,
+        refills: 2,
+      }),
+    );
+
+    const result = await service.validatePrescription('rx-1', basePatientFactors(), 'AB1234563');
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((e) => e.code === PrescriptionValidationErrorCode.SCHEDULE_II_NO_REFILLS)).toBe(true);
+  });
+
+  it('accepts a Schedule II prescription with 0 refills', async () => {
+    prescriptionRepo.findOne.mockResolvedValue(
+      basePrescription({
+        controlledSubstanceSchedule: ControlledSubstanceSchedule.SCHEDULE_II,
+        refills: 0,
+      }),
+    );
+
+    const result = await service.validatePrescription('rx-1', basePatientFactors(), 'AB1234563');
+
+    expect(result.errors.some((e) => e.code === PrescriptionValidationErrorCode.SCHEDULE_II_NO_REFILLS)).toBe(false);
+  });
+
+  // ── Fill age limit ─────────────────────────────────────────────────────────
+
+  it('rejects a Schedule II prescription older than 90 days', async () => {
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 91);
+
+    prescriptionRepo.findOne.mockResolvedValue(
+      basePrescription({
+        controlledSubstanceSchedule: ControlledSubstanceSchedule.SCHEDULE_II,
+        prescribedDate: oldDate,
+        refills: 0,
+      }),
+    );
+
+    const result = await service.validatePrescription('rx-1', basePatientFactors(), 'AB1234563');
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((e) => e.code === PrescriptionValidationErrorCode.SCHEDULE_II_EXPIRED)).toBe(true);
+  });
+
+  it('accepts a Schedule II prescription written today', async () => {
+    prescriptionRepo.findOne.mockResolvedValue(
+      basePrescription({
+        controlledSubstanceSchedule: ControlledSubstanceSchedule.SCHEDULE_II,
+        prescribedDate: new Date(),
+        refills: 0,
+      }),
+    );
+
+    const result = await service.validatePrescription('rx-1', basePatientFactors(), 'AB1234563');
+
+    expect(result.errors.some((e) => e.code === PrescriptionValidationErrorCode.SCHEDULE_II_EXPIRED)).toBe(false);
+  });
+
+  // ── PDMP ───────────────────────────────────────────────────────────────────
+
+  it('flags a PDMP hit when patient has 3+ prescribers in 90 days', async () => {
+    prescriptionRepo.findOne.mockResolvedValue(basePrescription());
+    pdmpService.getPatientHistory.mockResolvedValue({
+      patientId: 'patient-1',
+      records: [],
+      multiplePrescriberCount: 4,
+      multiplePharmacyCount: 1,
+    });
+
+    const result = await service.validatePrescription('rx-1', basePatientFactors());
+
+    expect(result.errors.some((e) => e.code === PrescriptionValidationErrorCode.PDMP_FLAG)).toBe(true);
+  });
+
+  it('does not flag PDMP when history is clean', async () => {
+    prescriptionRepo.findOne.mockResolvedValue(basePrescription());
+    pdmpService.getPatientHistory.mockResolvedValue({
+      patientId: 'patient-1',
+      records: [],
+      multiplePrescriberCount: 1,
+      multiplePharmacyCount: 1,
+    });
+
+    const result = await service.validatePrescription('rx-1', basePatientFactors());
+
+    expect(result.errors.some((e) => e.code === PrescriptionValidationErrorCode.PDMP_FLAG)).toBe(false);
+  });
+
+  it('skips PDMP check gracefully when service returns null', async () => {
+    prescriptionRepo.findOne.mockResolvedValue(basePrescription());
+    pdmpService.getPatientHistory.mockResolvedValue(null);
+
+    const result = await service.validatePrescription('rx-1', basePatientFactors());
+
+    expect(result.errors.some((e) => e.code === PrescriptionValidationErrorCode.PDMP_FLAG)).toBe(false);
+  });
+
+  // ── Non-controlled prescriptions unaffected ────────────────────────────────
+
+  it('does not apply DEA/schedule rules to non-controlled prescriptions', async () => {
+    prescriptionRepo.findOne.mockResolvedValue(
+      basePrescription({ controlledSubstanceSchedule: null }),
+    );
+
+    const result = await service.validatePrescription('rx-1', basePatientFactors());
+
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/src/pharmacy/services/prescription-validation.service.ts
+++ b/src/pharmacy/services/prescription-validation.service.ts
@@ -3,7 +3,15 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Prescription } from '../entities/prescription.entity';
 import { Drug } from '../entities/drug.entity';
+import { ControlledSubstanceSchedule } from '../entities/drug.entity';
 import { SafetyAlert } from '../entities/safety-alert.entity';
+import { PdmpService } from './pdmp.service';
+import {
+  PrescriptionValidationError,
+  PrescriptionValidationErrorCode,
+} from '../errors/prescription-validation.error';
+
+const SCHEDULE_II_MAX_AGE_DAYS = 90;
 
 export interface PatientFactors {
   age: number;
@@ -19,6 +27,7 @@ export interface PatientFactors {
 
 export interface ValidationResult {
   isValid: boolean;
+  errors: PrescriptionValidationError[];
   alerts: Array<{
     type: string;
     severity: 'minor' | 'moderate' | 'major' | 'critical';
@@ -36,11 +45,13 @@ export class PrescriptionValidationService {
     private drugRepository: Repository<Drug>,
     @InjectRepository(SafetyAlert)
     private alertRepository: Repository<SafetyAlert>,
+    private readonly pdmpService: PdmpService,
   ) {}
 
   async validatePrescription(
     prescriptionId: string,
     patientFactors: PatientFactors,
+    prescriberDeaNumber?: string,
   ): Promise<ValidationResult> {
     const prescription = await this.prescriptionRepository.findOne({
       where: { id: prescriptionId },
@@ -50,6 +61,12 @@ export class PrescriptionValidationService {
     if (!prescription) {
       return {
         isValid: false,
+        errors: [
+          new PrescriptionValidationError(
+            PrescriptionValidationErrorCode.DEA_NUMBER_REQUIRED,
+            'Prescription not found',
+          ),
+        ],
         alerts: [
           {
             type: 'prescription-not-found',
@@ -61,74 +78,127 @@ export class PrescriptionValidationService {
       };
     }
 
+    const errors: PrescriptionValidationError[] = [];
     const alerts = [];
 
-    // Validate each drug in the prescription
+    // ── DEA / Schedule II rules ──────────────────────────────────────────────
+    const controlledErrors = await this.validateControlledSubstance(
+      prescription,
+      prescriberDeaNumber,
+    );
+    errors.push(...controlledErrors);
+
+    // ── PDMP check ───────────────────────────────────────────────────────────
+    const pdmpErrors = await this.validatePdmp(prescription.patientId);
+    errors.push(...pdmpErrors);
+
+    // ── Per-drug clinical rules ──────────────────────────────────────────────
     for (const item of prescription.items) {
       const drug = item.drug;
 
-      // Age-based validation
       const ageAlerts = this.validateAgeAppropriate(drug, patientFactors.age, item);
       alerts.push(...ageAlerts);
 
-      // Renal function validation
       if (patientFactors.renalFunction && patientFactors.renalFunction !== 'normal') {
-        const renalAlerts = this.validateRenalDosing(drug, patientFactors.renalFunction, item);
-        alerts.push(...renalAlerts);
+        alerts.push(...this.validateRenalDosing(drug, patientFactors.renalFunction, item));
       }
 
-      // Hepatic function validation
       if (patientFactors.hepaticFunction && patientFactors.hepaticFunction !== 'normal') {
-        const hepaticAlerts = this.validateHepaticDosing(
-          drug,
-          patientFactors.hepaticFunction,
-          item,
-        );
-        alerts.push(...hepaticAlerts);
+        alerts.push(...this.validateHepaticDosing(drug, patientFactors.hepaticFunction, item));
       }
 
-      // Pregnancy validation
       if (patientFactors.pregnancy) {
-        const pregnancyAlerts = this.validatePregnancySafety(drug, item);
-        alerts.push(...pregnancyAlerts);
+        alerts.push(...this.validatePregnancySafety(drug, item));
       }
 
-      // Breastfeeding validation
       if (patientFactors.breastfeeding) {
-        const breastfeedingAlerts = this.validateBreastfeedingSafety(drug, item);
-        alerts.push(...breastfeedingAlerts);
+        alerts.push(...this.validateBreastfeedingSafety(drug, item));
       }
 
-      // Weight-based dosing validation
       if (patientFactors.weight) {
-        const weightAlerts = this.validateWeightBasedDosing(drug, patientFactors.weight, item);
-        alerts.push(...weightAlerts);
+        alerts.push(...this.validateWeightBasedDosing(drug, patientFactors.weight, item));
       }
 
-      // Medical condition contraindications
-      const conditionAlerts = this.validateMedicalConditions(
-        drug,
-        patientFactors.medicalConditions,
-        item,
-      );
-      alerts.push(...conditionAlerts);
-
-      // Dosage form and route validation
-      const routeAlerts = this.validateRouteAndForm(drug, item);
-      alerts.push(...routeAlerts);
+      alerts.push(...this.validateMedicalConditions(drug, patientFactors.medicalConditions, item));
+      alerts.push(...this.validateRouteAndForm(drug, item));
     }
 
-    // Overall prescription validation
-    const overallAlerts = this.validateOverallPrescription(prescription, patientFactors);
-    alerts.push(...overallAlerts);
+    alerts.push(...this.validateOverallPrescription(prescription, patientFactors));
 
-    const criticalAlerts = alerts.filter((alert) => alert.severity === 'critical');
-    const isValid = criticalAlerts.length === 0;
+    const criticalAlerts = alerts.filter((a) => a.severity === 'critical');
+    const isValid = errors.length === 0 && criticalAlerts.length === 0;
 
-    return {
-      isValid,
-      alerts,
-    };
+    return { isValid, errors, alerts };
+  }
+
+  // ── DEA / Schedule II validation ──────────────────────────────────────────
+
+  private async validateControlledSubstance(
+    prescription: Prescription,
+    prescriberDeaNumber?: string,
+  ): Promise<PrescriptionValidationError[]> {
+    const errors: PrescriptionValidationError[] = [];
+    const schedule = prescription.controlledSubstanceSchedule;
+
+    if (!schedule) return errors;
+
+    // All controlled substances require a DEA number
+    if (!prescriberDeaNumber?.trim()) {
+      errors.push(
+        new PrescriptionValidationError(
+          PrescriptionValidationErrorCode.DEA_NUMBER_REQUIRED,
+          `A valid DEA registration number is required to prescribe Schedule ${schedule} controlled substances.`,
+        ),
+      );
+    }
+
+    if (schedule === ControlledSubstanceSchedule.SCHEDULE_II) {
+      // CII: no refills allowed
+      if (prescription.refills > 0) {
+        errors.push(
+          new PrescriptionValidationError(
+            PrescriptionValidationErrorCode.SCHEDULE_II_NO_REFILLS,
+            `Schedule II prescriptions may not have refills. This prescription specifies ${prescription.refills} refill(s).`,
+          ),
+        );
+      }
+
+      // CII: must be filled within 90 days of the written date
+      const writtenDate = new Date(prescription.prescribedDate);
+      const ageInDays = (Date.now() - writtenDate.getTime()) / 86_400_000;
+      if (ageInDays > SCHEDULE_II_MAX_AGE_DAYS) {
+        errors.push(
+          new PrescriptionValidationError(
+            PrescriptionValidationErrorCode.SCHEDULE_II_EXPIRED,
+            `Schedule II prescription is ${Math.floor(ageInDays)} days old. Maximum fill age is ${SCHEDULE_II_MAX_AGE_DAYS} days.`,
+          ),
+        );
+      }
+    }
+
+    return errors;
+  }
+
+  // ── PDMP validation ───────────────────────────────────────────────────────
+
+  private async validatePdmp(patientId: string): Promise<PrescriptionValidationError[]> {
+    const history = await this.pdmpService.getPatientHistory(patientId);
+    if (!history) return [];
+
+    const errors: PrescriptionValidationError[] = [];
+
+    // Flag if patient has received controlled substances from 3+ prescribers or pharmacies in 90 days
+    if (history.multiplePrescriberCount >= 3 || history.multiplePharmacyCount >= 3) {
+      errors.push(
+        new PrescriptionValidationError(
+          PrescriptionValidationErrorCode.PDMP_FLAG,
+          `PDMP history indicates potential misuse: ${history.multiplePrescriberCount} prescribers and ${history.multiplePharmacyCount} pharmacies in the past 90 days.`,
+          'major',
+        ),
+      );
+    }
+
+    return errors;
   }
 
   private validateAgeAppropriate(drug: Drug, age: number, item: any): any[] {

--- a/src/queues/processors/stellar-transaction.processor.spec.ts
+++ b/src/queues/processors/stellar-transaction.processor.spec.ts
@@ -1,84 +1,147 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { StellarTransactionProcessor } from './stellar-transaction.processor';
+import { StellarContractService } from '../../blockchain/stellar-contract.service';
 import { JOB_TYPES } from '../queue.constants';
 
+// ---------------------------------------------------------------------------
+// Redis mock
+// ---------------------------------------------------------------------------
+const redisStore: Record<string, string> = {};
+const mockRedis = {
+  get: jest.fn((key: string) => Promise.resolve(redisStore[key] ?? null)),
+  set: jest.fn((key: string, value: string) => {
+    redisStore[key] = value;
+    return Promise.resolve('OK');
+  }),
+  disconnect: jest.fn(),
+};
+
+jest.mock('ioredis', () => {
+  return jest.fn().mockImplementation(() => mockRedis);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const makeJob = (overrides: Partial<any> = {}): any => ({
+  id: 'job-1',
+  attemptsMade: 0,
+  progress: jest.fn(),
+  data: {
+    operationType: JOB_TYPES.ANCHOR_RECORD,
+    params: { patientId: 'p1', cid: 'cid1' },
+    initiatedBy: 'user-1',
+    correlationId: 'corr-123',
+    traceContext: null,
+  },
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
 describe('StellarTransactionProcessor', () => {
   let processor: StellarTransactionProcessor;
+  let stellarContractService: jest.Mocked<StellarContractService>;
 
   beforeEach(async () => {
+    // Clear Redis store and mocks between tests
+    Object.keys(redisStore).forEach((k) => delete redisStore[k]);
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [StellarTransactionProcessor],
+      providers: [
+        StellarTransactionProcessor,
+        {
+          provide: StellarContractService,
+          useValue: {
+            anchorRecord: jest.fn().mockResolvedValue({ txHash: 'tx-abc' }),
+            grantAccess: jest.fn().mockResolvedValue({ txHash: 'tx-def' }),
+            revokeAccess: jest.fn().mockResolvedValue({ txHash: 'tx-ghi' }),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(undefined) },
+        },
+      ],
     }).compile();
 
     processor = module.get<StellarTransactionProcessor>(StellarTransactionProcessor);
+    stellarContractService = module.get(StellarContractService);
+
+    // Trigger onModuleInit so the Redis instance is created
+    processor.onModuleInit();
   });
 
-  describe('process', () => {
-    it('should process anchorRecord job successfully', async () => {
-      const mockJob = {
-        id: 'job-1',
-        data: {
-          operationType: JOB_TYPES.ANCHOR_RECORD,
-          params: { recordId: '123' },
-          initiatedBy: 'user-1',
-          correlationId: 'corr-123',
-        },
-      } as any;
+  afterEach(() => processor.onModuleDestroy());
 
-      const result = await processor.process(mockJob);
+  // -------------------------------------------------------------------------
+  // Happy-path tests (unchanged behaviour)
+  // -------------------------------------------------------------------------
+  it('processes anchorRecord and returns anchored status', async () => {
+    const result = await processor.process(makeJob());
+    expect(result.status).toBe('anchored');
+    expect(result.txHash).toBe('tx-abc');
+  });
 
-      expect(result).toHaveProperty('txHash');
-      expect(result.status).toBe('anchored');
-    });
+  it('processes grantAccess and returns access_granted status', async () => {
+    const result = await processor.process(
+      makeJob({ data: { operationType: JOB_TYPES.GRANT_ACCESS, params: { patientId: 'p1', granteeId: 'g1', recordId: 'r1' }, initiatedBy: 'user-1', correlationId: 'corr-456', traceContext: null } }),
+    );
+    expect(result.status).toBe('access_granted');
+  });
 
-    it('should process grantAccess job successfully', async () => {
-      const mockJob = {
-        id: 'job-2',
-        data: {
-          operationType: JOB_TYPES.GRANT_ACCESS,
-          params: { userId: '456' },
-          initiatedBy: 'user-1',
-          correlationId: 'corr-456',
-        },
-      } as any;
+  it('processes revokeAccess and returns access_revoked status', async () => {
+    const result = await processor.process(
+      makeJob({ data: { operationType: JOB_TYPES.REVOKE_ACCESS, params: { patientId: 'p1', granteeId: 'g1', recordId: 'r1' }, initiatedBy: 'user-1', correlationId: 'corr-789', traceContext: null } }),
+    );
+    expect(result.status).toBe('access_revoked');
+  });
 
-      const result = await processor.process(mockJob);
+  it('throws for unknown operation type', async () => {
+    await expect(
+      processor.process(makeJob({ data: { operationType: 'unknown', params: {}, initiatedBy: 'u', correlationId: 'c', traceContext: null } })),
+    ).rejects.toThrow('Unknown operation type: unknown');
+  });
 
-      expect(result).toHaveProperty('txHash');
-      expect(result.status).toBe('access_granted');
-    });
+  // -------------------------------------------------------------------------
+  // Idempotency / retry tests
+  // -------------------------------------------------------------------------
+  it('writes result to Redis after a successful submission', async () => {
+    await processor.process(makeJob());
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      'stellar:idempotency:corr-123',
+      expect.any(String),
+      'EX',
+      86400,
+    );
+  });
 
-    it('should process revokeAccess job successfully', async () => {
-      const mockJob = {
-        id: 'job-3',
-        data: {
-          operationType: JOB_TYPES.REVOKE_ACCESS,
-          params: { userId: '789' },
-          initiatedBy: 'user-1',
-          correlationId: 'corr-789',
-        },
-      } as any;
+  it('returns cached result on retry without re-submitting to Stellar', async () => {
+    // First run — succeeds and populates cache
+    const firstResult = await processor.process(makeJob());
+    expect(stellarContractService.anchorRecord).toHaveBeenCalledTimes(1);
 
-      const result = await processor.process(mockJob);
+    // Simulate mid-job crash: cache is populated but BullMQ retries the job
+    const retryResult = await processor.process(makeJob({ id: 'job-1-retry', attemptsMade: 1 }));
 
-      expect(result).toHaveProperty('txHash');
-      expect(result.status).toBe('access_revoked');
-    });
+    // Should return the same result without calling Stellar again
+    expect(stellarContractService.anchorRecord).toHaveBeenCalledTimes(1);
+    expect(retryResult).toEqual(firstResult);
+  });
 
-    it('should throw error for unknown operation type', async () => {
-      const mockJob = {
-        id: 'job-4',
-        data: {
-          operationType: 'unknownOperation',
-          params: {},
-          initiatedBy: 'user-1',
-          correlationId: 'corr-999',
-        },
-      } as any;
+  it('uses deterministic jobId equal to correlationId (BullMQ deduplication)', async () => {
+    // The queue service sets jobId = correlationId; verify the processor
+    // reads correlationId from job.data (not job.id) for the idempotency key
+    // so that even a re-enqueued job with a different BullMQ id is deduplicated.
+    const cachedResult = { txHash: 'tx-cached', status: 'anchored', fromCache: true };
+    redisStore['stellar:idempotency:corr-123'] = JSON.stringify(cachedResult);
 
-      await expect(processor.process(mockJob)).rejects.toThrow(
-        'Unknown operation type: unknownOperation',
-      );
-    });
+    const result = await processor.process(makeJob({ id: 'different-bullmq-id' }));
+
+    expect(stellarContractService.anchorRecord).not.toHaveBeenCalled();
+    expect(result).toEqual(cachedResult);
   });
 });

--- a/src/queues/processors/stellar-transaction.processor.ts
+++ b/src/queues/processors/stellar-transaction.processor.ts
@@ -1,27 +1,72 @@
 import { Processor, WorkerHost } from '@nestjs/bullmq';
-import { Logger, Inject } from '@nestjs/common';
+import { Logger, Inject, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { context, propagation, trace } from '@opentelemetry/api';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
 import { QUEUE_NAMES, JOB_TYPES } from '../queue.constants';
 import { StellarTransactionJobDto } from '../dto/stellar-transaction-job.dto';
 import { StellarContractService } from '../../blockchain/stellar-contract.service';
 
+const IDEMPOTENCY_TTL_SECONDS = 86400; // 24 hours
+
 @Processor(QUEUE_NAMES.STELLAR_TRANSACTIONS, {
   concurrency: 5,
 })
-export class StellarTransactionProcessor extends WorkerHost {
+export class StellarTransactionProcessor extends WorkerHost implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(StellarTransactionProcessor.name);
   private readonly tracer = trace.getTracer('healthy-stellar-backend');
+  private redis: Redis;
 
   constructor(
     @Inject(StellarContractService)
     private readonly stellarContractService: StellarContractService,
+    private readonly configService: ConfigService,
   ) {
     super();
   }
 
+  onModuleInit(): void {
+    this.redis = new Redis({
+      host: this.configService.get('REDIS_HOST', 'localhost'),
+      port: this.configService.get('REDIS_PORT', 6379),
+      password: this.configService.get('REDIS_PASSWORD'),
+      db: this.configService.get('REDIS_DB', 0),
+      maxRetriesPerRequest: null,
+    });
+  }
+
+  onModuleDestroy(): void {
+    this.redis?.disconnect();
+  }
+
+  private idempotencyKey(correlationId: string): string {
+    return `stellar:idempotency:${correlationId}`;
+  }
+
+  private async getCachedResult(correlationId: string): Promise<any | null> {
+    const raw = await this.redis.get(this.idempotencyKey(correlationId));
+    return raw ? JSON.parse(raw) : null;
+  }
+
+  private async cacheResult(correlationId: string, result: any): Promise<void> {
+    await this.redis.set(
+      this.idempotencyKey(correlationId),
+      JSON.stringify(result),
+      'EX',
+      IDEMPOTENCY_TTL_SECONDS,
+    );
+  }
+
   async process(job: Job<StellarTransactionJobDto>): Promise<any> {
     const { operationType, params, initiatedBy, correlationId, traceContext } = job.data;
+
+    // Idempotency check — short-circuit if this correlationId already succeeded
+    const cached = await this.getCachedResult(correlationId);
+    if (cached) {
+      this.logger.log(`[Idempotency] Returning cached result for correlation: ${correlationId}`);
+      return cached;
+    }
 
     // Extract trace context from job data
     const extractedContext = traceContext
@@ -62,6 +107,8 @@ export class StellarTransactionProcessor extends WorkerHost {
             default:
               throw new Error(`Unknown operation type: ${operationType}`);
           }
+
+          await this.cacheResult(correlationId, result);
 
           span.addEvent('queue.job.completed', {
             'queue.result': JSON.stringify(result),


### PR DESCRIPTION
This PR addresses four reliability, compliance, and patient-safety issues across the backend.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


#353 — Stellar Transaction Processor: BullMQ Retry Idempotency

- Injected ioredis into StellarTransactionProcessor using the same pattern as RedisLockService
- Before submitting any on-chain transaction, the processor checks a Redis key scoped to 
correlationId; if a successful result is cached, it short-circuits and returns it without re-
submitting
- After a confirmed submission, the result is written to Redis with a 24-hour TTL
- QueueService.dispatchStellarTransaction already sets jobId = correlationId, providing BullMQ
-level deduplication at enqueue time
- Added tests covering: happy paths, cache write after success, retry short-circuit, and 
deduplication via correlationId regardless of BullMQ job ID

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


#365 — Data Residency Service: Replace process.env with Validated ConfigService

- Created src/data-residency/config/data-residency.config.ts with a Joi schema that marks all 
four DB_HOST_* variables as required() and throws a descriptive error at startup if any are 
missing
- DataResidencyService now implements OnModuleInit and builds regionConfigs from 
this.configService.get() calls — zero direct process.env reads remain
- DataResidencyModule registers the config factory via ConfigModule.forFeature and wires 
validateDataResidencyConfig into ConfigModule.forRoot
- Also resolved unmerged conflict debris in health.module.ts and health.controller.ts
- Added GET /health/data-residency endpoint that tests connectivity to each regional database 
and IPFS node in parallel
- Integration test asserts startup throws with the offending variable name when DB_HOST_EU (or
any required host) is absent

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


#372 — Laboratory: Critical Value Alerting and Notification Pipeline

- Added CriticalValueDefinition entity for admin-configurable test-code-specific thresholds (
low, high, unit, severity)
- LabResultsService.createCriticalAlerts now emits a CriticalValueDetectedEvent via 
EventEmitter2 after creating each alert
- CriticalValueEventHandler listens for the event and notifies the ordering provider via 
NotificationsService, recording the notification timestamp on the alert
- A @Cron(EVERY_MINUTE) job escalates any NOTIFIED alert that has not been acknowledged within
15 minutes, emitting a critical_value_escalation notification for charge-nurse routing
- New endpoints: admin CRUD for threshold definitions, 
GET /laboratory/critical-values/unacknowledged for clinical supervisors, and 
POST /laboratory/critical-values/:id/acknowledge for providers
- Tests cover: provider notification on event, no-op when no overdue alerts, and independent 
escalation of multiple overdue alerts

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


#373 — Pharmacy: DEA Schedule II Prescription Validation and PDMP Integration

- Added ControlledSubstanceSchedule enum (CI–CV) to Drug entity and a 
controlledSubstanceSchedule column to Prescription entity
- PrescriptionValidationService.validatePrescription now accepts an optional 
prescriberDeaNumber and applies schedule-based rules: DEA number required for all controlled 
substances, Schedule II prescriptions must have 0 refills, and must be filled within 90 days 
of the written date
- Created PdmpService which calls PDMP_API_URL/patients/:id/history?days=90; flags patients 
with 3+ prescribers or pharmacies in 90 days; non-blocking if URL is unconfigured or the 
request fails
- All validation failures are returned as structured PrescriptionValidationError objects with 
code and description fields for downstream EHR display
- ValidationResult now includes an errors array alongside the existing alerts array
- Tests cover all new rules: DEA required/present, CII refills rejected/accepted, 90-day 
expiry, PDMP flag, clean PDMP history, null PDMP response, and non-controlled prescriptions 
unaffected

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


Closes #353
Closes #365
Closes #372
Closes #373
