### PR TITLE
fix: enforce per-user session limit and add session management endpoints

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -39,6 +39,7 @@ import { ApiKeyGuard } from './guards/api-key.guard';
 import { ProviderDirectoryService } from './services/provider-directory.service';
 
 import { RefreshTokenStoreService } from './services/refresh-token-store.service';
+import { SessionCleanupTask } from './tasks/session-cleanup.task';
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { RefreshTokenStoreService } from './services/refresh-token-store.service
     RolesGuard,
     MfaVerifiedGuard,
     ApiKeyGuard,
+    SessionCleanupTask,
   ],
   controllers: [AuthController, MfaController, ProvidersController],
   exports: [

--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   UseGuards,
   Get,
   Req,
+  Param,
   BadRequestException,
   NotFoundException,
 } from '@nestjs/common';
@@ -221,26 +222,55 @@ export class AuthController {
     return sessions.map((session) => ({
       id: session.id,
       ipAddress: session.ipAddress,
+      userAgent: session.userAgent,
       deviceId: session.deviceId,
+      lastActive: session.updatedAt,
       createdAt: session.createdAt,
       expiresAt: session.expiresAt,
     }));
   }
 
   /**
-   * Revoke session
+   * Terminate a specific session
+   */
+  @Delete('sessions/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Terminate a specific session' })
+  @ApiResponse({ status: 200, description: 'Session terminated' })
+  @ApiResponse({ status: 404, description: 'Session not found' })
+  async deleteSession(
+    @Param('id') id: string,
+    @Req() req: Request,
+  ): Promise<{ message: string }> {
+    const user = req.user as JwtPayload;
+    const session = await this.sessionManagementService.getUserSessions(user.userId).then(
+      (sessions) => sessions.find((s) => s.id === id),
+    );
+    if (!session) {
+      throw new NotFoundException('Session not found');
+    }
+    await this.sessionManagementService.revokeSession(id);
+    return { message: 'Session terminated' };
+  }
+
+  /**
+   * Revoke session (legacy endpoint)
    */
   @Post('sessions/:sessionId/revoke')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'Revoke a specific session' })
-  async revokeSession(@Req() req: Request, sessionId: string): Promise<{ message: string }> {
+  async revokeSession(
+    @Param('sessionId') sessionId: string,
+    @Req() req: Request,
+  ): Promise<{ message: string }> {
     const user = req.user as JwtPayload;
-    // Verify session belongs to user
-    const session = await this.sessionManagementService.getSession(sessionId);
-    if (!session || session.userId !== user.userId) {
-      throw new NotFoundException(I18nContext.current()?.t('errors.SESSION_NOT_FOUND') || 'Session not found');
+    const session = await this.sessionManagementService.getUserSessions(user.userId).then(
+      (sessions) => sessions.find((s) => s.id === sessionId),
+    );
+    if (!session) {
+      throw new NotFoundException('Session not found');
     }
-
     await this.sessionManagementService.revokeSession(sessionId);
     return { message: 'Session revoked' };
   }

--- a/src/auth/services/session-management.service.ts
+++ b/src/auth/services/session-management.service.ts
@@ -1,11 +1,11 @@
 import {
   Injectable,
-  BadRequestException,
   UnauthorizedException,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, LessThan } from 'typeorm';
+import { Repository, LessThan, MoreThan } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
 import { SessionEntity } from '../entities/session.entity';
 import { User } from '../entities/user.entity';
 
@@ -26,10 +26,12 @@ export class SessionManagementService {
     private sessionRepository: Repository<SessionEntity>,
     @InjectRepository(User)
     private userRepository: Repository<User>,
+    private configService: ConfigService,
   ) {}
 
   /**
-   * Create a new session
+   * Create a new session, enforcing the per-user session limit.
+   * If the limit is reached, the oldest active session is revoked first.
    */
   async createSession(
     userId: string,
@@ -41,6 +43,8 @@ export class SessionManagementService {
     userAgent: string,
     deviceId?: string,
   ): Promise<SessionEntity> {
+    await this.enforceSessionLimit(userId);
+
     const session = this.sessionRepository.create({
       userId,
       accessToken,
@@ -57,20 +61,43 @@ export class SessionManagementService {
   }
 
   /**
-   * Get active session
+   * Revoke the oldest active sessions when the per-user limit is reached.
+   */
+  private async enforceSessionLimit(userId: string): Promise<void> {
+    const maxSessions = this.configService.get<number>('MAX_SESSIONS_PER_USER', 5);
+
+    const activeSessions = await this.sessionRepository.find({
+      where: { userId, isActive: true },
+      order: { createdAt: 'ASC' },
+    });
+
+    if (activeSessions.length >= maxSessions) {
+      const excess = activeSessions.length - maxSessions + 1;
+      const toRevoke = activeSessions.slice(0, excess);
+      const now = new Date();
+      for (const session of toRevoke) {
+        session.isActive = false;
+        session.revokedAt = now;
+      }
+      await this.sessionRepository.save(toRevoke);
+    }
+  }
+
+  /**
+   * Get active, non-expired session by ID.
    */
   async getSession(sessionId: string): Promise<SessionEntity | null> {
     return this.sessionRepository.findOne({
       where: {
         id: sessionId,
         isActive: true,
-        expiresAt: LessThan(new Date()),
+        expiresAt: MoreThan(new Date()),
       },
     });
   }
 
   /**
-   * Get all active sessions for user
+   * Get all active sessions for user.
    */
   async getUserSessions(userId: string): Promise<SessionEntity[]> {
     return this.sessionRepository.find({
@@ -85,7 +112,7 @@ export class SessionManagementService {
   }
 
   /**
-   * Refresh session tokens
+   * Refresh session tokens.
    */
   async refreshSession(
     sessionId: string,
@@ -117,7 +144,7 @@ export class SessionManagementService {
   }
 
   /**
-   * Revoke session
+   * Revoke session by ID.
    */
   async revokeSession(sessionId: string): Promise<void> {
     const session = await this.sessionRepository.findOne({ where: { id: sessionId } });
@@ -132,7 +159,7 @@ export class SessionManagementService {
   }
 
   /**
-   * Revoke all sessions for user
+   * Revoke all sessions for user.
    */
   async revokeAllUserSessions(userId: string): Promise<void> {
     const sessions = await this.sessionRepository.find({
@@ -151,7 +178,7 @@ export class SessionManagementService {
   }
 
   /**
-   * Check if session is valid
+   * Check if session is valid.
    */
   async isSessionValid(sessionId: string): Promise<boolean> {
     const session = await this.sessionRepository.findOne({ where: { id: sessionId } });
@@ -174,7 +201,7 @@ export class SessionManagementService {
   }
 
   /**
-   * Clean up expired sessions (run periodically)
+   * Mark all currently-active but expired sessions as inactive.
    */
   async cleanupExpiredSessions(): Promise<number> {
     const result = await this.sessionRepository
@@ -188,7 +215,20 @@ export class SessionManagementService {
   }
 
   /**
-   * Enforce session timeout (HIPAA requirement: 15 minutes of inactivity)
+   * Hard-delete sessions whose expiresAt is older than 30 days.
+   * Called by the scheduled cleanup job.
+   */
+  async deleteOldExpiredSessions(): Promise<number> {
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const result = await this.sessionRepository.delete({
+      isActive: false,
+      expiresAt: LessThan(thirtyDaysAgo),
+    });
+    return result.affected || 0;
+  }
+
+  /**
+   * Enforce session timeout (HIPAA requirement: 15 minutes of inactivity).
    */
   async enforceSessionTimeout(sessionId: string, inactivityMinutes: number = 15): Promise<boolean> {
     const session = await this.sessionRepository.findOne({ where: { id: sessionId } });
@@ -212,7 +252,7 @@ export class SessionManagementService {
   }
 
   /**
-   * Get session info for user
+   * Get session info for user.
    */
   async getSessionInfo(sessionId: string): Promise<SessionInfo | null> {
     const session = await this.sessionRepository.findOne({ where: { id: sessionId } });
@@ -233,7 +273,7 @@ export class SessionManagementService {
   }
 
   /**
-   * Update session activity timestamp
+   * Update session activity timestamp.
    */
   async updateSessionActivity(sessionId: string): Promise<void> {
     await this.sessionRepository.update({ id: sessionId }, { updatedAt: new Date() });

--- a/src/auth/tasks/session-cleanup.task.ts
+++ b/src/auth/tasks/session-cleanup.task.ts
@@ -1,0 +1,25 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { SessionManagementService } from '../services/session-management.service';
+
+@Injectable()
+export class SessionCleanupTask {
+  private readonly logger = new Logger(SessionCleanupTask.name);
+
+  constructor(private readonly sessionManagementService: SessionManagementService) {}
+
+  /**
+   * Daily job: hard-delete sessions whose expiresAt is older than 30 days.
+   * Prevents unbounded growth of the sessions table.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async handleExpiredSessionCleanup(): Promise<void> {
+    this.logger.log('SessionCleanupTask started');
+    try {
+      const deleted = await this.sessionManagementService.deleteOldExpiredSessions();
+      this.logger.log(`SessionCleanupTask finished — deleted ${deleted} old session(s)`);
+    } catch (error) {
+      this.logger.error('SessionCleanupTask failed', error instanceof Error ? error.stack : error);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #358 — Session Store Allows Unlimited Concurrent Sessions Per User

- **Session limit**: `createSession` now enforces `MAX_SESSIONS_PER_USER` (env var, default `5`). Before inserting a new session, the oldest active session(s) are automatically revoked when the limit would be exceeded
- **`DELETE /auth/sessions/:id`**: new endpoint allowing authenticated users to terminate a specific session by ID (ownership-verified)
- **`GET /auth/sessions`**: response now includes `userAgent` and `lastActive` fields alongside the existing fields
- **Scheduled cleanup**: new `SessionCleanupTask` runs daily at midnight, hard-deleting sessions with `expiresAt` older than 30 days to prevent unbounded table growth
- **Bug fix**: `getSession` was using `LessThan(new Date())` for `expiresAt` (returning only *expired* sessions) — corrected to `MoreThan(new Date())`

## Test plan

- [ ] Login 6+ times with the same account; verify only 5 active sessions remain (oldest revoked automatically)
- [ ] `GET /auth/sessions` returns `userAgent`, `lastActive`, `ipAddress`, `deviceId`, `createdAt`, `expiresAt`
- [ ] `DELETE /auth/sessions/:id` terminates the target session and returns 200
- [ ] `DELETE /auth/sessions/:id` with another user's session ID returns 404
- [ ] Set `MAX_SESSIONS_PER_USER=2` in env and verify the lower limit is respected
- [ ] Confirm `SessionCleanupTask` logs on startup and runs at midnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)