### PR TITLE
fix(analytics): eliminate phantom reads in getOverview via REPEATABLE…

### DIFF
--- a/src/analytics/admin-stats.service.spec.ts
+++ b/src/analytics/admin-stats.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { AnalyticsService } from './analytics.service';
 import { User } from '../users/entities/user.entity';
@@ -43,6 +43,7 @@ describe('AnalyticsService — getStats', () => {
         { provide: getRepositoryToken(AccessGrant), useValue: grantRepo },
         { provide: getRepositoryToken(StellarTransaction), useValue: { count: jest.fn().mockResolvedValue(0), createQueryBuilder: jest.fn() } },
         { provide: CACHE_MANAGER, useValue: cache },
+        { provide: getDataSourceToken(), useValue: { transaction: jest.fn() } },
       ],
     }).compile();
 

--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, BadRequestException, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, BadRequestException, UseGuards, Header } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
 import { AnalyticsService } from './analytics.service';
 import { OverviewResponseDto } from './dto/overview-response.dto';
@@ -25,6 +25,7 @@ export class AnalyticsController {
   }
 
   @Get('overview')
+  @Header('Cache-Control', 'max-age=60, stale-while-revalidate=30')
   @ApiOperation({ summary: 'Get system overview metrics' })
   @ApiResponse({
     status: 200,

--- a/src/analytics/analytics.service.spec.ts
+++ b/src/analytics/analytics.service.spec.ts
@@ -1,13 +1,144 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { AnalyticsService } from './analytics.service';
 import { User } from '../users/entities/user.entity';
 import { MedicalRecord } from '../medical-records/entities/medical-record.entity';
-import { AccessGrant } from '../access-control/entities/access-grant.entity';
+import { AccessGrant, GrantStatus } from '../access-control/entities/access-grant.entity';
 import { StellarTransaction } from './entities/stellar-transaction.entity';
 
-describe('AnalyticsService', () => {
+// ─── getOverview — REPEATABLE READ transaction tests ─────────────────────────
+
+describe('AnalyticsService — getOverview', () => {
+  let service: AnalyticsService;
+  let cache: { get: jest.Mock; set: jest.Mock };
+  let txCallback: jest.Mock;
+
+  function makeDataSource(counts: {
+    users: number;
+    records: number;
+    grants: number;
+    activeGrants: number;
+    stellar: number;
+  }) {
+    const emRepo = (n: number) => ({ count: jest.fn().mockResolvedValue(n) });
+
+    const em = {
+      getRepository: jest.fn((entity: any) => {
+        if (entity === User) return emRepo(counts.users);
+        if (entity === MedicalRecord) return emRepo(counts.records);
+        if (entity === StellarTransaction) return emRepo(counts.stellar);
+        // AccessGrant — first call = total, second = active
+        let callIdx = 0;
+        return {
+          count: jest.fn().mockImplementation(() =>
+            callIdx++ === 0
+              ? Promise.resolve(counts.grants)
+              : Promise.resolve(counts.activeGrants),
+          ),
+        };
+      }),
+    };
+
+    txCallback = jest.fn().mockImplementation((_isolation: string, cb: (em: any) => any) =>
+      cb(em),
+    );
+
+    return { transaction: txCallback };
+  }
+
+  async function build(
+    counts = { users: 10, records: 50, grants: 20, activeGrants: 8, stellar: 5 },
+    cachedValue: any = null,
+  ) {
+    cache = {
+      get: jest.fn().mockResolvedValue(cachedValue),
+      set: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsService,
+        { provide: getRepositoryToken(User), useValue: {} },
+        { provide: getRepositoryToken(MedicalRecord), useValue: {} },
+        { provide: getRepositoryToken(AccessGrant), useValue: {} },
+        { provide: getRepositoryToken(StellarTransaction), useValue: {} },
+        { provide: CACHE_MANAGER, useValue: cache },
+        { provide: getDataSourceToken(), useValue: makeDataSource(counts) },
+      ],
+    }).compile();
+
+    service = module.get(AnalyticsService);
+  }
+
+  it('returns correct counts from the transactional snapshot', async () => {
+    await build({ users: 10, records: 50, grants: 20, activeGrants: 8, stellar: 5 });
+    const result = await service.getOverview();
+    expect(result.totalUsers).toBe(10);
+    expect(result.totalRecords).toBe(50);
+    expect(result.totalAccessGrants).toBe(20);
+    expect(result.activeGrants).toBe(8);
+    expect(result.stellarTransactions).toBe(5);
+  });
+
+  it('includes a lastUpdatedAt ISO timestamp', async () => {
+    await build();
+    const result = await service.getOverview();
+    expect(result.lastUpdatedAt).toBeDefined();
+    expect(new Date(result.lastUpdatedAt).getTime()).not.toBeNaN();
+  });
+
+  it('opens the transaction with REPEATABLE READ isolation', async () => {
+    await build();
+    await service.getOverview();
+    expect(txCallback).toHaveBeenCalledWith('REPEATABLE READ', expect.any(Function));
+  });
+
+  it('returns cached result without opening a transaction on cache hit', async () => {
+    const cached = {
+      totalUsers: 99, totalRecords: 999, totalAccessGrants: 50,
+      activeGrants: 30, stellarTransactions: 10,
+      lastUpdatedAt: new Date().toISOString(),
+    };
+    await build(undefined, cached);
+    const result = await service.getOverview();
+    expect(result).toEqual(cached);
+    expect(txCallback).not.toHaveBeenCalled();
+  });
+
+  it('caches the result with a 60-second TTL on cache miss', async () => {
+    await build();
+    await service.getOverview();
+    expect(cache.set).toHaveBeenCalledWith(
+      'analytics:overview',
+      expect.objectContaining({ totalUsers: 10 }),
+      60,
+    );
+  });
+
+  it('does not call cache.set on a cache hit', async () => {
+    const cached = {
+      totalUsers: 1, totalRecords: 1, totalAccessGrants: 1,
+      activeGrants: 1, stellarTransactions: 1,
+      lastUpdatedAt: new Date().toISOString(),
+    };
+    await build(undefined, cached);
+    await service.getOverview();
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('handles all-zero counts (empty platform)', async () => {
+    await build({ users: 0, records: 0, grants: 0, activeGrants: 0, stellar: 0 });
+    const result = await service.getOverview();
+    expect(result.totalUsers).toBe(0);
+    expect(result.totalRecords).toBe(0);
+    expect(result.activeGrants).toBe(0);
+  });
+});
+
+// ─── getActivity / getTopProviders (preserved) ───────────────────────────────
+
+describe('AnalyticsService — getActivity & getTopProviders', () => {
   let service: AnalyticsService;
   let medicalRecordRepository: any;
   let accessGrantRepository: any;
@@ -21,29 +152,12 @@ describe('AnalyticsService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AnalyticsService,
-        {
-          provide: getRepositoryToken(User),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(MedicalRecord),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(AccessGrant),
-          useValue: mockRepository,
-        },
-        {
-          provide: getRepositoryToken(StellarTransaction),
-          useValue: mockRepository,
-        },
-        {
-          provide: CACHE_MANAGER,
-          useValue: {
-            get: jest.fn(),
-            set: jest.fn(),
-          },
-        },
+        { provide: getRepositoryToken(User), useValue: mockRepository },
+        { provide: getRepositoryToken(MedicalRecord), useValue: mockRepository },
+        { provide: getRepositoryToken(AccessGrant), useValue: mockRepository },
+        { provide: getRepositoryToken(StellarTransaction), useValue: mockRepository },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn().mockResolvedValue(null), set: jest.fn() } },
+        { provide: getDataSourceToken(), useValue: { transaction: jest.fn() } },
       ],
     }).compile();
 
@@ -57,7 +171,6 @@ describe('AnalyticsService', () => {
       const from = new Date('2024-01-01');
       const to = new Date('2024-01-03');
 
-      // Mock record uploads query
       const mockRecordQueryBuilder = {
         select: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
@@ -71,7 +184,6 @@ describe('AnalyticsService', () => {
         ]),
       };
 
-      // Mock access events query
       const mockAccessQueryBuilder = {
         select: jest.fn().mockReturnThis(),
         addSelect: jest.fn().mockReturnThis(),
@@ -85,29 +197,15 @@ describe('AnalyticsService', () => {
         ]),
       };
 
-      medicalRecordRepository.createQueryBuilder
-        .mockReturnValueOnce(mockRecordQueryBuilder);
-      accessGrantRepository.createQueryBuilder
-        .mockReturnValueOnce(mockAccessQueryBuilder);
+      medicalRecordRepository.createQueryBuilder.mockReturnValueOnce(mockRecordQueryBuilder);
+      accessGrantRepository.createQueryBuilder.mockReturnValueOnce(mockAccessQueryBuilder);
 
       const result = await service.getActivity(from, to);
 
       expect(result.dailyActivity).toHaveLength(3);
-      expect(result.dailyActivity[0]).toEqual({
-        date: '2024-01-01',
-        recordUploads: 5,
-        accessEvents: 2,
-      });
-      expect(result.dailyActivity[1]).toEqual({
-        date: '2024-01-02',
-        recordUploads: 3,
-        accessEvents: 0,
-      });
-      expect(result.dailyActivity[2]).toEqual({
-        date: '2024-01-03',
-        recordUploads: 0,
-        accessEvents: 4,
-      });
+      expect(result.dailyActivity[0]).toEqual({ date: '2024-01-01', recordUploads: 5, accessEvents: 2 });
+      expect(result.dailyActivity[1]).toEqual({ date: '2024-01-02', recordUploads: 3, accessEvents: 0 });
+      expect(result.dailyActivity[2]).toEqual({ date: '2024-01-03', recordUploads: 0, accessEvents: 4 });
     });
 
     it('should return zero counts for days with no activity', async () => {
@@ -124,70 +222,42 @@ describe('AnalyticsService', () => {
         getRawMany: jest.fn().mockResolvedValue([]),
       };
 
-      medicalRecordRepository.createQueryBuilder
-        .mockReturnValue(mockQueryBuilder);
-      accessGrantRepository.createQueryBuilder
-        .mockReturnValue(mockQueryBuilder);
+      medicalRecordRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+      accessGrantRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
 
       const result = await service.getActivity(from, to);
 
       expect(result.dailyActivity).toHaveLength(2);
-      expect(result.dailyActivity[0]).toEqual({
-        date: '2024-01-01',
-        recordUploads: 0,
-        accessEvents: 0,
-      });
-      expect(result.dailyActivity[1]).toEqual({
-        date: '2024-01-02',
-        recordUploads: 0,
-        accessEvents: 0,
-      });
+      expect(result.dailyActivity[0]).toEqual({ date: '2024-01-01', recordUploads: 0, accessEvents: 0 });
+      expect(result.dailyActivity[1]).toEqual({ date: '2024-01-02', recordUploads: 0, accessEvents: 0 });
     });
 
     it('should handle single day date range', async () => {
       const from = new Date('2024-01-01');
       const to = new Date('2024-01-01');
 
-      const mockRecordQueryBuilder = {
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        getRawMany: jest.fn().mockResolvedValue([
-          { date: '2024-01-01T00:00:00.000Z', count: '10' },
-        ]),
+      const mockRecordQb = {
+        select: jest.fn().mockReturnThis(), addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(), andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(), orderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([{ date: '2024-01-01T00:00:00.000Z', count: '10' }]),
+      };
+      const mockAccessQb = {
+        select: jest.fn().mockReturnThis(), addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(), andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(), orderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([{ date: '2024-01-01T00:00:00.000Z', count: '7' }]),
       };
 
-      const mockAccessQueryBuilder = {
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        andWhere: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        getRawMany: jest.fn().mockResolvedValue([
-          { date: '2024-01-01T00:00:00.000Z', count: '7' },
-        ]),
-      };
-
-      medicalRecordRepository.createQueryBuilder
-        .mockReturnValueOnce(mockRecordQueryBuilder);
-      accessGrantRepository.createQueryBuilder
-        .mockReturnValueOnce(mockAccessQueryBuilder);
+      medicalRecordRepository.createQueryBuilder.mockReturnValueOnce(mockRecordQb);
+      accessGrantRepository.createQueryBuilder.mockReturnValueOnce(mockAccessQb);
 
       const result = await service.getActivity(from, to);
 
       expect(result.dailyActivity).toHaveLength(1);
-      expect(result.dailyActivity[0]).toEqual({
-        date: '2024-01-01',
-        recordUploads: 10,
-        accessEvents: 7,
-      });
+      expect(result.dailyActivity[0]).toEqual({ date: '2024-01-01', recordUploads: 10, accessEvents: 7 });
     });
   });
-});
 
   describe('getTopProviders', () => {
     it('should return providers ranked by active grant count', async () => {
@@ -209,58 +279,39 @@ describe('AnalyticsService', () => {
       const result = await service.getTopProviders();
 
       expect(result.providers).toHaveLength(3);
-      expect(result.providers[0]).toEqual({
-        providerId: 'provider-1',
-        activeGrantCount: 15,
-      });
-      expect(result.providers[1]).toEqual({
-        providerId: 'provider-2',
-        activeGrantCount: 10,
-      });
-      expect(result.providers[2]).toEqual({
-        providerId: 'provider-3',
-        activeGrantCount: 5,
-      });
+      expect(result.providers[0]).toEqual({ providerId: 'provider-1', activeGrantCount: 15 });
+      expect(result.providers[1]).toEqual({ providerId: 'provider-2', activeGrantCount: 10 });
+      expect(result.providers[2]).toEqual({ providerId: 'provider-3', activeGrantCount: 5 });
     });
 
     it('should return empty array when no active grants exist', async () => {
       const mockQueryBuilder = {
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
-        orderBy: jest.fn().mockReturnThis(),
-        getRawMany: jest.fn().mockResolvedValue([]),
+        select: jest.fn().mockReturnThis(), addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(), groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(), getRawMany: jest.fn().mockResolvedValue([]),
       };
 
       accessGrantRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
 
       const result = await service.getTopProviders();
-
-      expect(result.providers).toHaveLength(0);
       expect(result.providers).toEqual([]);
     });
 
     it('should filter only active grants', async () => {
       const mockQueryBuilder = {
-        select: jest.fn().mockReturnThis(),
-        addSelect: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        groupBy: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(), addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(), groupBy: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
-        getRawMany: jest.fn().mockResolvedValue([
-          { providerId: 'provider-1', activeGrantCount: '8' },
-        ]),
+        getRawMany: jest.fn().mockResolvedValue([{ providerId: 'provider-1', activeGrantCount: '8' }]),
       };
 
       accessGrantRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
-
       await service.getTopProviders();
 
-      // Verify that the where clause filters for ACTIVE status
       expect(mockQueryBuilder.where).toHaveBeenCalledWith(
         'grant.status = :status',
-        { status: 'ACTIVE' }
+        { status: 'ACTIVE' },
       );
     });
   });
+});

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { User } from '../users/entities/user.entity';
@@ -26,43 +26,54 @@ export class AnalyticsService {
     private readonly stellarTransactionRepository: Repository<StellarTransaction>,
     @Inject(CACHE_MANAGER)
     private readonly cacheManager: Cache,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
   ) {}
 
   async getOverview(): Promise<OverviewResponseDto> {
-      const cacheKey = 'analytics:overview';
+    const cacheKey = 'analytics:overview';
 
-      // Check cache first
-      const cached = await this.cacheManager.get<OverviewResponseDto>(cacheKey);
-      if (cached) {
-        return cached;
-      }
+    const cached = await this.cacheManager.get<OverviewResponseDto>(cacheKey);
+    if (cached) {
+      return cached;
+    }
 
-      // Execute COUNT queries for all metrics
-      const totalUsers = await this.userRepository.count();
-      const totalRecords = await this.medicalRecordRepository.count();
-      const totalAccessGrants = await this.accessGrantRepository.count();
-      const stellarTransactions = await this.stellarTransactionRepository.count();
+    // All five COUNT queries run inside a single REPEATABLE READ transaction so
+    // every counter reflects the same consistent database snapshot, eliminating
+    // phantom reads caused by concurrent inserts between sequential queries.
+    const result = await this.dataSource.transaction('REPEATABLE READ', async (em) => {
+      const snapshotAt = new Date().toISOString();
 
-      // Count active grants: status is ACTIVE
-      const activeGrants = await this.accessGrantRepository.count({
-        where: {
-          status: GrantStatus.ACTIVE,
-        },
-      });
-
-      const result = {
+      const [
         totalUsers,
         totalRecords,
         totalAccessGrants,
         activeGrants,
         stellarTransactions,
-      };
+      ] = await Promise.all([
+        em.getRepository(User).count(),
+        em.getRepository(MedicalRecord).count(),
+        em.getRepository(AccessGrant).count(),
+        em.getRepository(AccessGrant).count({ where: { status: GrantStatus.ACTIVE } }),
+        em.getRepository(StellarTransaction).count(),
+      ]);
 
-      // Store in cache with 300-second TTL
-      await this.cacheManager.set(cacheKey, result, 300);
+      return {
+        totalUsers,
+        totalRecords,
+        totalAccessGrants,
+        activeGrants,
+        stellarTransactions,
+        lastUpdatedAt: snapshotAt,
+      } satisfies OverviewResponseDto;
+    });
 
-      return result;
-    }
+    // Cache for 60 s — aligns with the Cache-Control: max-age=60 HTTP header
+    // set by the controller so both layers expire at the same cadence.
+    await this.cacheManager.set(cacheKey, result, 60);
+
+    return result;
+  }
 
 
   async getActivity(from: Date, to: Date): Promise<ActivityResponseDto> {

--- a/src/analytics/dto/overview-response.dto.ts
+++ b/src/analytics/dto/overview-response.dto.ts
@@ -1,4 +1,4 @@
-import { IsNumber } from 'class-validator';
+import { IsNumber, IsString } from 'class-validator';
 
 export class OverviewResponseDto {
   @IsNumber()
@@ -15,4 +15,8 @@ export class OverviewResponseDto {
 
   @IsNumber()
   stellarTransactions: number;
+
+  /** ISO-8601 timestamp of when this snapshot was taken inside the transaction. */
+  @IsString()
+  lastUpdatedAt: string;
 }


### PR DESCRIPTION
closes #362
… READ transaction

- Inject DataSource and wrap all five COUNT queries in a single DataSource.transaction('REPEATABLE READ', ...) call using Promise.all. Every counter now reflects the same consistent DB snapshot, eliminating phantom reads caused by concurrent inserts between sequential queries.
- Reduce service-layer cache TTL from 300 s to 60 s to match the new Cache-Control: max-age=60, stale-while-revalidate=30 HTTP header added to the GET /admin/analytics/overview controller endpoint. Both layers now expire at the same cadence so CDN/proxy caches stay coherent.
- Add lastUpdatedAt: string (ISO-8601) to OverviewResponseDto so consumers know the currency of the snapshot they received.
- Unit tests (analytics.service.spec.ts):
    - Correct counts returned from transactional snapshot
    - lastUpdatedAt is a valid ISO timestamp
    - Transaction opened with 'REPEATABLE READ' isolation level
    - Cache hit skips transaction entirely
    - Cache miss writes result with 60 s TTL
    - cache.set not called on cache hit
    - All-zero counts (empty platform)
- Patch admin-stats.service.spec.ts and analytics.service.spec.ts to provide getDataSourceToken() mock so existing tests continue to compile.