### PR TITLE
fix(tenant): DDL injection prevention, advisory lock, compensating saga

### DIFF
--- a/src/tenant/dto/tenant.dto.ts
+++ b/src/tenant/dto/tenant.dto.ts
@@ -1,17 +1,23 @@
 import { IsString, IsNotEmpty, Matches, IsOptional } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+import { IsString, IsNotEmpty, Matches, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
 export class CreateTenantDto {
   @ApiProperty({ example: 'City Care Hospital' })
   @IsString()
   @IsNotEmpty()
   name: string;
 
-  @ApiProperty({ example: 'citycare', description: 'URL-safe slug for tenant identification' })
+  @ApiProperty({
+    example: 'citycare',
+    description: 'Lowercase letters, digits, and underscores only (3–63 chars)',
+  })
   @IsString()
   @IsNotEmpty()
-  @Matches(/^[a-z0-9-]+$/, {
-    message: 'Slug must contain only lowercase letters, numbers, and hyphens',
+  @Matches(/^[a-z0-9_]{3,63}$/, {
+    message: 'Slug must match ^[a-z0-9_]{3,63}$',
   })
   slug: string;
 

--- a/src/tenant/services/tenant.service.spec.ts
+++ b/src/tenant/services/tenant.service.spec.ts
@@ -1,0 +1,259 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
+import { BadRequestException, ConflictException } from '@nestjs/common';
+import { TenantService } from './tenant.service';
+import { Tenant } from '../entities/tenant.entity';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a DataSource mock with controllable query responses. */
+function makeDataSource(overrides: Partial<{ query: jest.Mock }> = {}) {
+  return {
+    query: jest.fn().mockResolvedValue([{ acquired: true }]),
+    ...overrides,
+  };
+}
+
+function makeTenantRepo(overrides: Partial<Record<string, jest.Mock>> = {}) {
+  return {
+    findOne: jest.fn().mockResolvedValue(null),
+    create: jest.fn().mockImplementation((dto) => dto),
+    save: jest.fn().mockImplementation((t) => Promise.resolve({ id: 'uuid-1', ...t })),
+    find: jest.fn().mockResolvedValue([]),
+    remove: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+async function buildModule(ds: any, repo: any) {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      TenantService,
+      { provide: getRepositoryToken(Tenant), useValue: repo },
+      { provide: getDataSourceToken(), useValue: ds },
+    ],
+  }).compile();
+  return module.get(TenantService);
+}
+
+// ─── Slug allowlist validation ────────────────────────────────────────────────
+
+describe('TenantService — slug allowlist (assertSafeSlug)', () => {
+  let service: TenantService;
+  let ds: ReturnType<typeof makeDataSource>;
+
+  beforeEach(async () => {
+    ds = makeDataSource();
+    service = await buildModule(ds, makeTenantRepo());
+  });
+
+  const valid = ['abc', 'abc123', 'a_b_c', 'a'.repeat(63), 'tenant_01'];
+  const invalid = [
+    'ab',                          // too short
+    'a'.repeat(64),                // too long
+    'ABC',                         // uppercase
+    'abc-def',                     // hyphen
+    'abc def',                     // space
+    'abc"def',                     // double-quote (injection vector)
+    'abc"; DROP SCHEMA public --', // full injection payload
+    '',                            // empty
+    'abc!',                        // special char
+  ];
+
+  it.each(valid)('accepts valid slug "%s"', async (slug) => {
+    await expect(service.provisionTenantSchema(slug)).resolves.not.toThrow();
+  });
+
+  it.each(invalid)('rejects invalid slug "%s"', async (slug) => {
+    await expect(service.provisionTenantSchema(slug)).rejects.toThrow(BadRequestException);
+    // Must never reach the database
+    expect(ds.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects injection payload in create()', async () => {
+    await expect(
+      service.create({ name: 'Evil Corp', slug: 'abc" CASCADE; DROP SCHEMA public --' }),
+    ).rejects.toThrow(BadRequestException);
+    expect(ds.query).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Advisory lock ────────────────────────────────────────────────────────────
+
+describe('TenantService — advisory lock', () => {
+  it('acquires pg_try_advisory_lock keyed on the schema name', async () => {
+    const ds = makeDataSource();
+    // After the lock query, subsequent queries succeed (migrations + seed)
+    ds.query.mockResolvedValue([{ acquired: true }]);
+    const service = await buildModule(ds, makeTenantRepo());
+
+    await service.provisionTenantSchema('myslug');
+
+    expect(ds.query).toHaveBeenCalledWith(
+      expect.stringContaining('pg_try_advisory_lock'),
+      ['tenant_myslug'],
+    );
+  });
+
+  it('throws ConflictException when lock is already held', async () => {
+    const ds = makeDataSource({
+      query: jest.fn().mockResolvedValue([{ acquired: false }]),
+    });
+    const service = await buildModule(ds, makeTenantRepo());
+
+    await expect(service.provisionTenantSchema('myslug')).rejects.toThrow(ConflictException);
+  });
+
+  it('releases the advisory lock in the finally block on success', async () => {
+    const ds = makeDataSource();
+    ds.query.mockResolvedValue([{ acquired: true }]);
+    const service = await buildModule(ds, makeTenantRepo());
+
+    await service.provisionTenantSchema('myslug');
+
+    const unlockCall = ds.query.mock.calls.find(
+      ([sql]: [string]) => sql.includes('pg_advisory_unlock'),
+    );
+    expect(unlockCall).toBeDefined();
+    expect(unlockCall[1]).toEqual(['tenant_myslug']);
+  });
+
+  it('releases the advisory lock in the finally block on failure', async () => {
+    let callCount = 0;
+    const ds = makeDataSource({
+      query: jest.fn().mockImplementation((sql: string) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([{ acquired: true }]); // lock acquired
+        if (sql.includes('CREATE SCHEMA')) return Promise.resolve();
+        if (sql.includes('CREATE TABLE') || sql.includes('CREATE INDEX')) {
+          throw new Error('migration failure');
+        }
+        return Promise.resolve();
+      }),
+    });
+    const service = await buildModule(ds, makeTenantRepo());
+
+    await expect(service.provisionTenantSchema('myslug')).rejects.toThrow('migration failure');
+
+    const unlockCall = ds.query.mock.calls.find(
+      ([sql]: [string]) => sql.includes('pg_advisory_unlock'),
+    );
+    expect(unlockCall).toBeDefined();
+  });
+});
+
+// ─── Compensating saga ────────────────────────────────────────────────────────
+
+describe('TenantService — compensating saga', () => {
+  it('drops the schema when runTenantMigrations throws', async () => {
+    let callCount = 0;
+    const ds = makeDataSource({
+      query: jest.fn().mockImplementation((sql: string) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([{ acquired: true }]); // advisory lock
+        if (sql.includes('CREATE SCHEMA')) return Promise.resolve();
+        if (sql.includes('CREATE TABLE')) throw new Error('migration error');
+        return Promise.resolve(); // DROP SCHEMA + advisory unlock
+      }),
+    });
+    const service = await buildModule(ds, makeTenantRepo());
+
+    await expect(service.provisionTenantSchema('myslug')).rejects.toThrow('migration error');
+
+    const dropCall = ds.query.mock.calls.find(
+      ([sql]: [string]) => sql.includes('DROP SCHEMA IF EXISTS'),
+    );
+    expect(dropCall).toBeDefined();
+    expect(dropCall[0]).toContain('"tenant_myslug"');
+  });
+
+  it('drops the schema when seedTenantData throws', async () => {
+    let callCount = 0;
+    const ds = makeDataSource({
+      query: jest.fn().mockImplementation((sql: string) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([{ acquired: true }]);
+        if (sql.includes('CREATE SCHEMA')) return Promise.resolve();
+        if (sql.includes('INSERT INTO')) throw new Error('seed error');
+        return Promise.resolve();
+      }),
+    });
+    const service = await buildModule(ds, makeTenantRepo());
+
+    await expect(service.provisionTenantSchema('myslug')).rejects.toThrow('seed error');
+
+    const dropCall = ds.query.mock.calls.find(
+      ([sql]: [string]) => sql.includes('DROP SCHEMA IF EXISTS'),
+    );
+    expect(dropCall).toBeDefined();
+  });
+
+  it('does NOT drop the schema when CREATE SCHEMA itself fails (nothing to roll back)', async () => {
+    let callCount = 0;
+    const ds = makeDataSource({
+      query: jest.fn().mockImplementation((sql: string) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([{ acquired: true }]);
+        if (sql.includes('CREATE SCHEMA')) throw new Error('schema creation failed');
+        return Promise.resolve();
+      }),
+    });
+    const service = await buildModule(ds, makeTenantRepo());
+
+    await expect(service.provisionTenantSchema('myslug')).rejects.toThrow('schema creation failed');
+
+    const dropCall = ds.query.mock.calls.find(
+      ([sql]: [string]) => sql.includes('DROP SCHEMA IF EXISTS') && !sql.includes('advisory'),
+    );
+    expect(dropCall).toBeUndefined();
+  });
+
+  it('re-throws the original error even if the compensating DROP also fails', async () => {
+    let callCount = 0;
+    const ds = makeDataSource({
+      query: jest.fn().mockImplementation((sql: string) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([{ acquired: true }]);
+        if (sql.includes('CREATE SCHEMA')) return Promise.resolve();
+        if (sql.includes('CREATE TABLE')) throw new Error('original error');
+        if (sql.includes('DROP SCHEMA')) throw new Error('drop also failed');
+        return Promise.resolve();
+      }),
+    });
+    const service = await buildModule(ds, makeTenantRepo());
+
+    await expect(service.provisionTenantSchema('myslug')).rejects.toThrow('original error');
+  });
+});
+
+// ─── create() integration ─────────────────────────────────────────────────────
+
+describe('TenantService — create()', () => {
+  it('throws ConflictException when slug already exists', async () => {
+    const repo = makeTenantRepo({
+      findOne: jest.fn().mockResolvedValue({ id: 'existing', slug: 'myslug' }),
+    });
+    const service = await buildModule(makeDataSource(), repo);
+
+    await expect(service.create({ name: 'Dup', slug: 'myslug' })).rejects.toThrow(
+      ConflictException,
+    );
+  });
+
+  it('saves tenant record and provisions schema on success', async () => {
+    const ds = makeDataSource();
+    ds.query.mockResolvedValue([{ acquired: true }]);
+    const repo = makeTenantRepo();
+    const service = await buildModule(ds, repo);
+
+    const result = await service.create({ name: 'Good Tenant', slug: 'good_slug' });
+
+    expect(repo.save).toHaveBeenCalled();
+    expect(result.slug).toBe('good_slug');
+    // Advisory lock must have been acquired
+    expect(ds.query).toHaveBeenCalledWith(
+      expect.stringContaining('pg_try_advisory_lock'),
+      ['tenant_good_slug'],
+    );
+  });
+});

--- a/src/tenant/services/tenant.service.ts
+++ b/src/tenant/services/tenant.service.ts
@@ -1,8 +1,29 @@
-import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  ConflictException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { Tenant } from '../entities/tenant.entity';
 import { CreateTenantDto, UpdateTenantDto } from '../dto/tenant.dto';
+
+/**
+ * Strict allowlist for tenant slugs used in DDL identifiers.
+ * Matches ^[a-z0-9_]{3,63}$ — no hyphens, quotes, spaces, or any character
+ * that could escape a quoted PostgreSQL identifier.
+ */
+const SLUG_RE = /^[a-z0-9_]{3,63}$/;
+
+/** Throws BadRequestException if slug does not pass the allowlist. */
+function assertSafeSlug(slug: string): void {
+  if (!SLUG_RE.test(slug)) {
+    throw new BadRequestException(
+      'Tenant slug must match ^[a-z0-9_]{3,63}$ (lowercase letters, digits, underscores only)',
+    );
+  }
+}
 
 @Injectable()
 export class TenantService {
@@ -14,46 +35,91 @@ export class TenantService {
   ) {}
 
   async create(createTenantDto: CreateTenantDto): Promise<Tenant> {
-    // Check if tenant with slug already exists
+    assertSafeSlug(createTenantDto.slug);
+
     const existing = await this.tenantRepository.findOne({
       where: { slug: createTenantDto.slug },
     });
-
     if (existing) {
       throw new ConflictException('Tenant with this slug already exists');
     }
 
-    // Create tenant record
     const tenant = this.tenantRepository.create(createTenantDto);
     await this.tenantRepository.save(tenant);
 
-    // Provision tenant schema
     await this.provisionTenantSchema(tenant.slug);
 
     return tenant;
   }
 
+  /**
+   * Provisions a schema for the given slug with three safety guarantees:
+   *
+   * 1. Slug allowlist — rejects any slug that doesn't match ^[a-z0-9_]{3,63}$
+   *    before it ever touches a SQL string.
+   *
+   * 2. PostgreSQL advisory lock — pg_try_advisory_lock(hashtext(schemaName))
+   *    prevents two concurrent calls for the same slug from racing. If the lock
+   *    is already held the call fails fast with a ConflictException rather than
+   *    producing a half-initialised duplicate schema.
+   *
+   * 3. Compensating saga — DDL statements (CREATE SCHEMA, CREATE TABLE) are
+   *    auto-committed by PostgreSQL and cannot be rolled back inside a
+   *    transaction. Instead we wrap the provisioning steps in try/catch and
+   *    DROP the schema on any failure, leaving the database in a clean state.
+   */
   async provisionTenantSchema(slug: string): Promise<void> {
+    assertSafeSlug(slug);
+
+    // schemaName is safe to interpolate: assertSafeSlug guarantees it contains
+    // only [a-z0-9_] — no characters that can escape a double-quoted identifier.
     const schemaName = `tenant_${slug}`;
 
-    // Create schema
-    await this.dataSource.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    // ── Advisory lock ────────────────────────────────────────────────────────
+    // Use a session-level advisory lock keyed on the schema name so concurrent
+    // provisioning attempts for the same slug are serialised. The lock is
+    // released automatically when the connection is returned to the pool.
+    const [{ acquired }] = await this.dataSource.query<[{ acquired: boolean }]>(
+      `SELECT pg_try_advisory_lock(hashtext($1)) AS acquired`,
+      [schemaName],
+    );
 
-    // Set search path to new schema
-    await this.dataSource.query(`SET search_path TO "${schemaName}", public`);
+    if (!acquired) {
+      throw new ConflictException(
+        `Schema provisioning for "${slug}" is already in progress`,
+      );
+    }
 
-    // Run migrations for tenant schema
-    await this.runTenantMigrations(schemaName);
+    // ── Compensating saga ────────────────────────────────────────────────────
+    // CREATE SCHEMA is DDL and auto-commits, so we track whether the schema was
+    // created and drop it on any subsequent failure (compensating transaction).
+    let schemaCreated = false;
 
-    // Seed base data
-    await this.seedTenantData(schemaName);
+    try {
+      await this.dataSource.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+      schemaCreated = true;
 
-    // Reset search path
-    await this.dataSource.query(`SET search_path TO public`);
+      await this.runTenantMigrations(schemaName);
+      await this.seedTenantData(schemaName);
+    } catch (err) {
+      if (schemaCreated) {
+        // Best-effort rollback: drop the partially initialised schema.
+        await this.dataSource
+          .query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+          .catch(() => {
+            // Log but do not mask the original error.
+          });
+      }
+      throw err;
+    } finally {
+      // Release the advisory lock regardless of outcome.
+      await this.dataSource
+        .query(`SELECT pg_advisory_unlock(hashtext($1))`, [schemaName])
+        .catch(() => {});
+    }
   }
 
   private async runTenantMigrations(schemaName: string): Promise<void> {
-    // Create core tables in tenant schema
     const tables = [
       `CREATE TABLE IF NOT EXISTS "${schemaName}".medical_records (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -91,7 +157,6 @@ export class TenantService {
       await this.dataSource.query(sql);
     }
 
-    // Create indexes
     await this.dataSource.query(
       `CREATE INDEX IF NOT EXISTS idx_medical_records_patient ON "${schemaName}".medical_records(patient_id)`,
     );
@@ -107,8 +172,6 @@ export class TenantService {
   }
 
   private async seedTenantData(schemaName: string): Promise<void> {
-    // Seed initial configuration data for tenant
-    // This can be expanded based on requirements
     await this.dataSource.query(`
       INSERT INTO "${schemaName}".medical_records (patient_id, record_type)
       VALUES ('system', 'initialization')
@@ -122,17 +185,13 @@ export class TenantService {
 
   async findById(id: string): Promise<Tenant> {
     const tenant = await this.tenantRepository.findOne({ where: { id } });
-    if (!tenant) {
-      throw new NotFoundException('Tenant not found');
-    }
+    if (!tenant) throw new NotFoundException('Tenant not found');
     return tenant;
   }
 
   async findBySlug(slug: string): Promise<Tenant> {
     const tenant = await this.tenantRepository.findOne({ where: { slug } });
-    if (!tenant) {
-      throw new NotFoundException('Tenant not found');
-    }
+    if (!tenant) throw new NotFoundException('Tenant not found');
     return tenant;
   }
 
@@ -144,12 +203,9 @@ export class TenantService {
 
   async delete(id: string): Promise<void> {
     const tenant = await this.findById(id);
+    assertSafeSlug(tenant.slug);
     const schemaName = `tenant_${tenant.slug}`;
-
-    // Drop schema (CASCADE will drop all tables)
     await this.dataSource.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
-
-    // Delete tenant record
     await this.tenantRepository.remove(tenant);
   }
 }


### PR DESCRIPTION
closes #347

Security — slug allowlist
- assertSafeSlug() validates against ^[a-z0-9_]{3,63}$ at the service boundary (provisionTenantSchema, create, delete) before the slug ever touches a SQL string. Throws BadRequestException immediately so the database is never reached with an unsafe identifier.
- Tightened CreateTenantDto @Matches regex from ^[a-z0-9-]+$ to ^[a-z0-9_]{3,63}$ (removes hyphens which are not safe in unquoted identifiers, adds length bounds, aligns with service-layer check).

Concurrency — PostgreSQL advisory lock
- provisionTenantSchema acquires pg_try_advisory_lock(hashtext(schemaName)) before any DDL. If the lock is already held (concurrent call for the same slug) a ConflictException is thrown immediately — no race, no duplicate half-initialised schema.
- Lock is released in a finally block via pg_advisory_unlock so it is always freed regardless of success or failure.

Atomicity — compensating saga
- PostgreSQL DDL is auto-committed and cannot be rolled back inside a transaction. Instead, a schemaCreated flag tracks whether CREATE SCHEMA succeeded. Any subsequent failure (runTenantMigrations or seedTenantData) triggers a best-effort DROP SCHEMA IF EXISTS ... CASCADE to restore a clean state. The original error is always re-thrown; a DROP failure is swallowed so it does not mask the root cause.

Tests (tenant.service.spec.ts)
- Slug allowlist: it.each matrix of 5 valid and 9 invalid slugs including the exact injection payload from the issue report.
- Advisory lock: lock query uses correct key, ConflictException on acquired=false, unlock called in finally on both success and failure.
- Compensating saga: DROP called on migration failure, DROP called on seed failure, DROP NOT called when CREATE SCHEMA itself fails, original error preserved when DROP also fails.
- create() integration: ConflictException on duplicate slug, schema provisioned on success.