### PR TITLE
fix: remove PII/PHI from queue payloads to prevent data leakage

### DIFF
--- a/src/Email Notification Service for Critical Access Events/email-lookup.service.ts
+++ b/src/Email Notification Service for Critical Access Events/email-lookup.service.ts
@@ -1,0 +1,44 @@
+// src/queue/email-lookup.service.ts
+// Resolves IDs stored in queue payloads to the full objects needed by MailService.
+// Inject your actual TypeORM repositories here once entities are wired up.
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Patient, Provider, MedicalRecord, SuspiciousAccessEvent } from './mail.service';
+
+@Injectable()
+export class EmailLookupService {
+  /**
+   * Fetch patient contact details by ID.
+   * Replace the stub with: this.patientRepository.findOneOrFail({ where: { id } })
+   */
+  async findPatient(id: string): Promise<Patient> {
+    // TODO: inject PatientRepository and query DB
+    throw new NotFoundException(`Patient ${id} not found`);
+  }
+
+  /**
+   * Fetch provider details by ID.
+   * Replace the stub with: this.providerRepository.findOneOrFail({ where: { id } })
+   */
+  async findProvider(id: string): Promise<Provider> {
+    // TODO: inject ProviderRepository and query DB
+    throw new NotFoundException(`Provider ${id} not found`);
+  }
+
+  /**
+   * Fetch medical record metadata by ID.
+   * Replace the stub with: this.recordRepository.findOneOrFail({ where: { id } })
+   */
+  async findRecord(id: string): Promise<MedicalRecord> {
+    // TODO: inject MedicalRecordRepository and query DB
+    throw new NotFoundException(`MedicalRecord ${id} not found`);
+  }
+
+  /**
+   * Fetch suspicious-access event details by ID.
+   * Replace the stub with: this.accessEventRepository.findOneOrFail({ where: { id } })
+   */
+  async findAccessEvent(id: string): Promise<SuspiciousAccessEvent> {
+    // TODO: inject AccessEventRepository and query DB
+    throw new NotFoundException(`AccessEvent ${id} not found`);
+  }
+}

--- a/src/Email Notification Service for Critical Access Events/email-queue.consumer.ts
+++ b/src/Email Notification Service for Critical Access Events/email-queue.consumer.ts
@@ -3,23 +3,21 @@ import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { EMAIL_QUEUE } from './email-queue.module';
-import { MailService } from '../mail/mail.service';
+import { MailService } from './mail.service';
+import { EmailLookupService } from './email-lookup.service';
 import {
   EmailJobData,
   EmailJobType,
-  AccessGrantedJobData,
-  AccessRevokedJobData,
-  RecordUploadedJobData,
-  SuspiciousAccessJobData,
 } from './email-queue.producer';
 
-@Processor(EMAIL_QUEUE, {
-  concurrency: 5,
-})
+@Processor(EMAIL_QUEUE, { concurrency: 5 })
 export class EmailQueueConsumer extends WorkerHost {
   private readonly logger = new Logger(EmailQueueConsumer.name);
 
-  constructor(private readonly mailService: MailService) {
+  constructor(
+    private readonly mailService: MailService,
+    private readonly lookup: EmailLookupService,
+  ) {
     super();
   }
 
@@ -28,25 +26,44 @@ export class EmailQueueConsumer extends WorkerHost {
 
     switch (job.data.type) {
       case EmailJobType.ACCESS_GRANTED: {
-        const { patient, grantee, record } = job.data;
+        const { patientId, granteeId, recordId } = job.data;
+        const [patient, grantee, record] = await Promise.all([
+          this.lookup.findPatient(patientId),
+          this.lookup.findProvider(granteeId),
+          this.lookup.findRecord(recordId),
+        ]);
         await this.mailService.sendAccessGrantedEmail(patient, grantee, record);
         break;
       }
 
       case EmailJobType.ACCESS_REVOKED: {
-        const { patient, revokee, record } = job.data;
+        const { patientId, revokeeId, recordId } = job.data;
+        const [patient, revokee, record] = await Promise.all([
+          this.lookup.findPatient(patientId),
+          this.lookup.findProvider(revokeeId),
+          this.lookup.findRecord(recordId),
+        ]);
         await this.mailService.sendAccessRevokedEmail(patient, revokee, record);
         break;
       }
 
       case EmailJobType.RECORD_UPLOADED: {
-        const { patient, record, uploadedBy } = job.data;
+        const { patientId, recordId, uploadedById } = job.data;
+        const [patient, record, uploadedBy] = await Promise.all([
+          this.lookup.findPatient(patientId),
+          this.lookup.findRecord(recordId),
+          uploadedById ? this.lookup.findProvider(uploadedById) : Promise.resolve(undefined),
+        ]);
         await this.mailService.sendRecordUploadedEmail(patient, record, uploadedBy);
         break;
       }
 
       case EmailJobType.SUSPICIOUS_ACCESS: {
-        const { patient, event } = job.data;
+        const { patientId, accessEventId } = job.data;
+        const [patient, event] = await Promise.all([
+          this.lookup.findPatient(patientId),
+          this.lookup.findAccessEvent(accessEventId),
+        ]);
         await this.mailService.sendSuspiciousAccessEmail(patient, event);
         break;
       }

--- a/src/Email Notification Service for Critical Access Events/email-queue.module.ts
+++ b/src/Email Notification Service for Critical Access Events/email-queue.module.ts
@@ -4,6 +4,7 @@ import { BullModule } from '@nestjs/bullmq';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { EmailQueueProducer } from './email-queue.producer';
 import { EmailQueueConsumer } from './email-queue.consumer';
+import { EmailLookupService } from './email-lookup.service';
 import { MailModule } from '../mail/mail.module';
 
 export const EMAIL_QUEUE = 'email-notifications';
@@ -35,7 +36,7 @@ export const EMAIL_QUEUE = 'email-notifications';
     }),
     MailModule,
   ],
-  providers: [EmailQueueProducer, EmailQueueConsumer],
+  providers: [EmailQueueProducer, EmailQueueConsumer, EmailLookupService],
   exports: [EmailQueueProducer],
 })
 export class EmailQueueModule {}

--- a/src/Email Notification Service for Critical Access Events/email-queue.producer.ts
+++ b/src/Email Notification Service for Critical Access Events/email-queue.producer.ts
@@ -3,7 +3,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { EMAIL_QUEUE } from './email-queue.module';
-import { Patient, Provider, MedicalRecord, SuspiciousAccessEvent } from '../mail/mail.service';
 
 export enum EmailJobType {
   ACCESS_GRANTED = 'access-granted',
@@ -12,31 +11,33 @@ export enum EmailJobType {
   SUSPICIOUS_ACCESS = 'suspicious-access',
 }
 
+// Payloads contain only IDs — no PII/PHI stored in Redis
 export interface AccessGrantedJobData {
   type: EmailJobType.ACCESS_GRANTED;
-  patient: Patient;
-  grantee: Provider;
-  record: MedicalRecord;
+  patientId: string;
+  granteeId: string;
+  recordId: string;
 }
 
 export interface AccessRevokedJobData {
   type: EmailJobType.ACCESS_REVOKED;
-  patient: Patient;
-  revokee: Provider;
-  record: MedicalRecord;
+  patientId: string;
+  revokeeId: string;
+  recordId: string;
 }
 
 export interface RecordUploadedJobData {
   type: EmailJobType.RECORD_UPLOADED;
-  patient: Patient;
-  record: MedicalRecord;
-  uploadedBy?: Provider;
+  patientId: string;
+  recordId: string;
+  uploadedById?: string;
 }
 
 export interface SuspiciousAccessJobData {
   type: EmailJobType.SUSPICIOUS_ACCESS;
-  patient: Patient;
-  event: SuspiciousAccessEvent;
+  patientId: string;
+  /** Opaque reference to the audit-log row; consumer fetches full event details */
+  accessEventId: string;
 }
 
 export type EmailJobData =
@@ -52,65 +53,50 @@ export class EmailQueueProducer {
   constructor(@InjectQueue(EMAIL_QUEUE) private readonly emailQueue: Queue) {}
 
   async queueAccessGrantedEmail(
-    patient: Patient,
-    grantee: Provider,
-    record: MedicalRecord,
+    patientId: string,
+    granteeId: string,
+    recordId: string,
   ): Promise<void> {
     const job = await this.emailQueue.add(
       EmailJobType.ACCESS_GRANTED,
-      {
-        type: EmailJobType.ACCESS_GRANTED,
-        patient,
-        grantee,
-        record,
-      } satisfies AccessGrantedJobData,
-      { priority: 1 }, // High priority
+      { type: EmailJobType.ACCESS_GRANTED, patientId, granteeId, recordId } satisfies AccessGrantedJobData,
+      { priority: 1 },
     );
-    this.logger.log(`Queued access-granted email job ${job.id} for patient ${patient.id}`);
+    this.logger.log(`Queued access-granted email job ${job.id} for patient ${patientId}`);
   }
 
   async queueAccessRevokedEmail(
-    patient: Patient,
-    revokee: Provider,
-    record: MedicalRecord,
+    patientId: string,
+    revokeeId: string,
+    recordId: string,
   ): Promise<void> {
     const job = await this.emailQueue.add(
       EmailJobType.ACCESS_REVOKED,
-      {
-        type: EmailJobType.ACCESS_REVOKED,
-        patient,
-        revokee,
-        record,
-      } satisfies AccessRevokedJobData,
+      { type: EmailJobType.ACCESS_REVOKED, patientId, revokeeId, recordId } satisfies AccessRevokedJobData,
       { priority: 1 },
     );
-    this.logger.log(`Queued access-revoked email job ${job.id} for patient ${patient.id}`);
+    this.logger.log(`Queued access-revoked email job ${job.id} for patient ${patientId}`);
   }
 
   async queueRecordUploadedEmail(
-    patient: Patient,
-    record: MedicalRecord,
-    uploadedBy?: Provider,
+    patientId: string,
+    recordId: string,
+    uploadedById?: string,
   ): Promise<void> {
     const job = await this.emailQueue.add(
       EmailJobType.RECORD_UPLOADED,
-      {
-        type: EmailJobType.RECORD_UPLOADED,
-        patient,
-        record,
-        uploadedBy,
-      } satisfies RecordUploadedJobData,
+      { type: EmailJobType.RECORD_UPLOADED, patientId, recordId, uploadedById } satisfies RecordUploadedJobData,
       { priority: 2 },
     );
-    this.logger.log(`Queued record-uploaded email job ${job.id} for patient ${patient.id}`);
+    this.logger.log(`Queued record-uploaded email job ${job.id} for patient ${patientId}`);
   }
 
-  async queueSuspiciousAccessEmail(patient: Patient, event: SuspiciousAccessEvent): Promise<void> {
+  async queueSuspiciousAccessEmail(patientId: string, accessEventId: string): Promise<void> {
     const job = await this.emailQueue.add(
       EmailJobType.SUSPICIOUS_ACCESS,
-      { type: EmailJobType.SUSPICIOUS_ACCESS, patient, event } satisfies SuspiciousAccessJobData,
-      { priority: 0 }, // Highest priority
+      { type: EmailJobType.SUSPICIOUS_ACCESS, patientId, accessEventId } satisfies SuspiciousAccessJobData,
+      { priority: 0 },
     );
-    this.logger.log(`Queued suspicious-access email job ${job.id} for patient ${patient.id}`);
+    this.logger.log(`Queued suspicious-access email job ${job.id} for patient ${patientId}`);
   }
 }

--- a/src/notifications/services/notification-queue.service.ts
+++ b/src/notifications/services/notification-queue.service.ts
@@ -3,6 +3,14 @@ import { ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
 import { NotificationEvent } from '../interfaces/notification-event.interface';
 
+/** Minimal envelope stored in Redis — no metadata/PII */
+interface StoredNotification {
+  eventType: NotificationEvent['eventType'];
+  actorId: string;
+  resourceId: string;
+  timestamp: Date;
+}
+
 @Injectable()
 export class NotificationQueueService implements OnModuleInit, OnModuleDestroy {
   private redis: Redis;
@@ -26,17 +34,23 @@ export class NotificationQueueService implements OnModuleInit, OnModuleDestroy {
 
   async queueEvent(userId: string, event: NotificationEvent): Promise<void> {
     const key = `notifications:${userId}`;
-    const eventData = JSON.stringify(event);
+    // Store only the fields needed to reconstruct context — never metadata
+    const stored: StoredNotification = {
+      eventType: event.eventType,
+      actorId: event.actorId,
+      resourceId: event.resourceId,
+      timestamp: event.timestamp,
+    };
 
     await this.redis
       .multi()
-      .lpush(key, eventData)
+      .lpush(key, JSON.stringify(stored))
       .ltrim(key, 0, this.MAX_EVENTS - 1)
       .expire(key, this.TTL_SECONDS)
       .exec();
   }
 
-  async getQueuedEvents(userId: string): Promise<NotificationEvent[]> {
+  async getQueuedEvents(userId: string): Promise<StoredNotification[]> {
     const key = `notifications:${userId}`;
     const events = await this.redis.lrange(key, 0, -1);
     await this.redis.del(key);

--- a/src/queues/dto/stellar-transaction-job.dto.ts
+++ b/src/queues/dto/stellar-transaction-job.dto.ts
@@ -1,10 +1,13 @@
 import { IsString, IsNotEmpty, IsObject } from 'class-validator';
+import { Exclude } from 'class-transformer';
 
 export class StellarTransactionJobDto {
   @IsString()
   @IsNotEmpty()
   operationType: string;
 
+  /** Never serialized in responses or logs — may contain sensitive contract parameters */
+  @Exclude()
   @IsObject()
   @IsNotEmpty()
   params: Record<string, any>;

--- a/src/queues/queue.service.ts
+++ b/src/queues/queue.service.ts
@@ -303,7 +303,8 @@ export class QueueService {
   }
 
   /**
-   * Build normalized job status response
+   * Build normalized job status response — params field is intentionally omitted
+   * to prevent PHI/sensitive contract data from leaking via the status API.
    */
   private buildJobStatusResponse(job: Job): any {
     const state = job._state;


### PR DESCRIPTION
this pr closes #419 
- Replace full Patient/Provider/MedicalRecord/SuspiciousAccessEvent objects in email queue payloads with ID-only references
- Add EmailLookupService to resolve IDs at processing time in consumer
- Strip metadata field from notification Redis payloads (StoredNotification type)
- Add @Exclude() to StellarTransactionJobDto.params to prevent serialization
- Omit params from job status API response