### PR TITLE
feat: add backup verification and restore drill automation

### DIFF
--- a/src/backup/controllers/backup.controller.ts
+++ b/src/backup/controllers/backup.controller.ts
@@ -100,4 +100,10 @@ export class BackupController {
   async getStatistics(@Query('days') days?: number) {
     return this.monitoringService.getBackupStatistics(days ? parseInt(days as any, 10) : 30);
   }
+
+  @Post('recovery/drill/trigger')
+  @Roles('admin', 'system_admin')
+  async triggerRestoreDrill() {
+    return this.recoveryService.scheduledRestoreDrill();
+  }
 }

--- a/src/backup/services/backup-verification.service.ts
+++ b/src/backup/services/backup-verification.service.ts
@@ -25,7 +25,6 @@ export class BackupVerificationService {
     const unverifiedBackups = await this.backupLogRepository.find({
       where: { status: BackupStatus.COMPLETED },
       order: { completedAt: 'DESC' },
-      take: 10,
     });
 
     for (const backup of unverifiedBackups) {

--- a/src/backup/services/disaster-recovery.service.spec.ts
+++ b/src/backup/services/disaster-recovery.service.spec.ts
@@ -1,0 +1,93 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DisasterRecoveryService } from './disaster-recovery.service';
+import { BackupLog, BackupStatus, BackupType } from '../entities/backup-log.entity';
+import { RecoveryTest, RecoveryTestStatus } from '../entities/recovery-test.entity';
+import { Repository } from 'typeorm';
+
+describe('DisasterRecoveryService', () => {
+  let service: DisasterRecoveryService;
+  let backupLogRepository: Repository<BackupLog>;
+  let recoveryTestRepository: Repository<RecoveryTest>;
+
+  const mockBackupLogRepository = {
+    findOne: jest.fn(),
+    save: jest.fn(),
+    create: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const mockRecoveryTestRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DisasterRecoveryService,
+        {
+          provide: getRepositoryToken(BackupLog),
+          useValue: mockBackupLogRepository,
+        },
+        {
+          provide: getRepositoryToken(RecoveryTest),
+          useValue: mockRecoveryTestRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DisasterRecoveryService>(DisasterRecoveryService);
+    backupLogRepository = module.get<Repository<BackupLog>>(getRepositoryToken(BackupLog));
+    recoveryTestRepository = module.get<Repository<RecoveryTest>>(getRepositoryToken(RecoveryTest));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('scheduledRestoreDrill', () => {
+    it('should skip if no verified full backup is found', async () => {
+      mockBackupLogRepository.findOne.mockResolvedValue(null);
+      const loggerSpy = jest.spyOn((service as any).logger, 'warn');
+
+      await service.scheduledRestoreDrill();
+
+      expect(mockBackupLogRepository.findOne).toHaveBeenCalledWith({
+        where: { status: BackupStatus.VERIFIED, backupType: BackupType.FULL },
+        order: { completedAt: 'DESC' },
+      });
+      expect(loggerSpy).toHaveBeenCalledWith('No verified full backup found for automated restore drill');
+    });
+
+    it('should perform recovery if verified full backup is found', async () => {
+      const mockBackup = { id: 'backup-123', status: BackupStatus.VERIFIED, backupPath: 'path/to/backup' };
+      mockBackupLogRepository.findOne.mockResolvedValue(mockBackup);
+      
+      const performRecoverySpy = jest.spyOn(service, 'performRecovery').mockResolvedValue({} as any);
+
+      await service.scheduledRestoreDrill();
+
+      expect(performRecoverySpy).toHaveBeenCalledWith(
+        { backupId: 'backup-123', validateOnly: true },
+        'automated-drill',
+      );
+    });
+
+    it('should log error if recovery fails', async () => {
+      const mockBackup = { id: 'backup-123', status: BackupStatus.VERIFIED, backupPath: 'path/to/backup' };
+      mockBackupLogRepository.findOne.mockResolvedValue(mockBackup);
+      
+      const error = new Error('Restore failed');
+      jest.spyOn(service, 'performRecovery').mockRejectedValue(error);
+      const loggerSpy = jest.spyOn((service as any).logger, 'error');
+
+      await service.scheduledRestoreDrill();
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        `Automated restore drill for backup backup-123 failed: ${error.message}`,
+      );
+    });
+  });
+});

--- a/src/backup/services/disaster-recovery.service.ts
+++ b/src/backup/services/disaster-recovery.service.ts
@@ -5,7 +5,8 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import * as crypto from 'crypto';
 import * as fs from 'fs/promises';
-import { BackupLog, BackupStatus } from '../entities/backup-log.entity';
+import { Cron } from '@nestjs/schedule';
+import { BackupLog, BackupStatus, BackupType } from '../entities/backup-log.entity';
 import { RecoveryTest, RecoveryTestStatus } from '../entities/recovery-test.entity';
 
 const execAsync = promisify(exec);
@@ -314,5 +315,34 @@ export class DisasterRecoveryService {
 
   async scheduleRecoveryTest(backupId: string, testedBy: string): Promise<RecoveryTest> {
     return this.performRecovery({ backupId, validateOnly: true }, testedBy);
+  }
+
+  @Cron('0 5 * * 0') // Weekly on Sunday at 5 AM
+  async scheduledRestoreDrill() {
+    this.logger.log('Starting scheduled automated restore drill');
+
+    const latestVerifiedBackup = await this.backupLogRepository.findOne({
+      where: { status: BackupStatus.VERIFIED, backupType: BackupType.FULL },
+      order: { completedAt: 'DESC' },
+    });
+
+    if (!latestVerifiedBackup) {
+      this.logger.warn('No verified full backup found for automated restore drill');
+      return;
+    }
+
+    try {
+      await this.performRecovery(
+        { backupId: latestVerifiedBackup.id, validateOnly: true },
+        'automated-drill',
+      );
+      this.logger.log(
+        `Automated restore drill for backup ${latestVerifiedBackup.id} completed successfully`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Automated restore drill for backup ${latestVerifiedBackup.id} failed: ${error.message}`,
+      );
+    }
   }
 }


### PR DESCRIPTION
Closes #438

---

Closes Issue #438 
This PR implements automated restore drills and enhances backup verification robustness for the Healthy-Stellar backend (Issue #438). The goal is to ensure that backups are not only created and verified for integrity but are also proven to be restorable through regular, automated drills.

Key Changes
1. Automated Restore Drill Automation
Added a weekly scheduled task (@Cron) in DisasterRecoveryService that runs every Sunday at 5 AM.
The task automatically identifies the latest VERIFIED full backup and performs a validateOnly restoration to a temporary database.
This process validates decryption, decompression, and database schema integrity without affecting the production database.
Results are logged and stored in the recovery_tests table for compliance auditing.
2. Manual Drill Trigger
Introduced a new administrative endpoint: POST /backup/recovery/drill/trigger.
Allows authorized users (admin, system_admin) to initiate an automated restore drill on-demand for immediate validation.
3. Verification Robustness
Enhanced BackupVerificationService to process all pending COMPLETED backups in each verification cycle.
Removed the previous limit of 10 backups per cycle to prevent verification lag during high-frequency backup periods.
4. Improved Test Coverage
Created a new unit test suite: src/backup/services/disaster-recovery.service.spec.ts.
Verified the logic for identifying eligible backups, handling successful drills, and logging failures.