### PR TITLE
fix: tamper-evident audit hash chain and atomic record writes

### DIFF
--- a/src/medical-records/services/medical-records.service.ts
+++ b/src/medical-records/services/medical-records.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException, BadRequestException, ConflictException, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Like, Between, DataSource } from 'typeorm';
+import { Repository, Like, Between, DataSource, EntityManager } from 'typeorm';
 import { MedicalRecord, MedicalRecordStatus } from '../entities/medical-record.entity';
 import { MedicalRecordVersion } from '../entities/medical-record-version.entity';
 import { MedicalHistory, HistoryEventType } from '../entities/medical-history.entity';
@@ -79,6 +79,7 @@ export class MedicalRecordsService {
           userId,
           userName,
           'Initial record creation',
+          manager,
         );
       } catch (error) {
         this.logger.error(`Failed to create initial version: ${error.message}`, error.stack);
@@ -93,6 +94,10 @@ export class MedicalRecordsService {
         'Medical record created',
         userId,
         userName,
+        undefined,
+        undefined,
+        undefined,
+        manager,
       );
 
       this.logger.log(`Medical record created: ${savedRecord.id} by user ${userId}`);
@@ -139,55 +144,57 @@ export class MedicalRecordsService {
       );
     }
 
-    // Store previous content for versioning
-    const previousContent = JSON.stringify({
-      title: record.title,
-      description: record.description,
-      recordType: record.recordType,
-      status: record.status,
-      metadata: record.metadata,
+    return this.dataSource.transaction(async (manager) => {
+      const previousContent = JSON.stringify({
+        title: record.title,
+        description: record.description,
+        recordType: record.recordType,
+        status: record.status,
+        metadata: record.metadata,
+      });
+
+      Object.assign(record, {
+        ...updateDto,
+        updatedBy: userId,
+        recordDate: updateDto.recordDate ? new Date(updateDto.recordDate) : record.recordDate,
+      });
+
+      const updatedRecord = await manager.save(MedicalRecord, record);
+
+      const currentContent = JSON.stringify({
+        title: updatedRecord.title,
+        description: updatedRecord.description,
+        recordType: updatedRecord.recordType,
+        status: updatedRecord.status,
+        metadata: updatedRecord.metadata,
+      });
+
+      await this.createVersion(
+        updatedRecord,
+        previousContent,
+        currentContent,
+        userId,
+        userName,
+        changeReason || 'Record updated',
+        manager,
+      );
+
+      await this.createHistoryEntry(
+        updatedRecord.id,
+        updatedRecord.patientId,
+        HistoryEventType.UPDATED,
+        'Medical record updated',
+        userId,
+        userName,
+        { changes: updateDto },
+        undefined,
+        undefined,
+        manager,
+      );
+
+      this.logger.log(`Medical record updated: ${id} by user ${userId}`);
+      return updatedRecord;
     });
-
-    // Update record
-    Object.assign(record, {
-      ...updateDto,
-      updatedBy: userId,
-      recordDate: updateDto.recordDate ? new Date(updateDto.recordDate) : record.recordDate,
-    });
-
-    const updatedRecord = await this.medicalRecordRepository.save(record);
-
-    // Create version
-    const currentContent = JSON.stringify({
-      title: updatedRecord.title,
-      description: updatedRecord.description,
-      recordType: updatedRecord.recordType,
-      status: updatedRecord.status,
-      metadata: updatedRecord.metadata,
-    });
-
-    await this.createVersion(
-      updatedRecord,
-      previousContent,
-      currentContent,
-      userId,
-      userName,
-      changeReason || 'Record updated',
-    );
-
-    // Create history entry
-    await this.createHistoryEntry(
-      updatedRecord.id,
-      updatedRecord.patientId,
-      HistoryEventType.UPDATED,
-      'Medical record updated',
-      userId,
-      userName,
-      { changes: updateDto },
-    );
-
-    this.logger.log(`Medical record updated: ${id} by user ${userId}`);
-    return updatedRecord;
   }
 
   async search(searchDto: SearchMedicalRecordsDto, organizationId?: string): Promise<{
@@ -278,21 +285,28 @@ export class MedicalRecordsService {
 
   async archive(id: string, userId: string, userName?: string): Promise<MedicalRecord> {
     const record = await this.findOne(id);
-    record.status = MedicalRecordStatus.ARCHIVED;
-    record.updatedBy = userId;
 
-    const archived = await this.medicalRecordRepository.save(record);
+    return this.dataSource.transaction(async (manager) => {
+      record.status = MedicalRecordStatus.ARCHIVED;
+      record.updatedBy = userId;
 
-    await this.createHistoryEntry(
-      archived.id,
-      archived.patientId,
-      HistoryEventType.ARCHIVED,
-      'Medical record archived',
-      userId,
-      userName,
-    );
+      const archived = await manager.save(MedicalRecord, record);
 
-    return archived;
+      await this.createHistoryEntry(
+        archived.id,
+        archived.patientId,
+        HistoryEventType.ARCHIVED,
+        'Medical record archived',
+        userId,
+        userName,
+        undefined,
+        undefined,
+        undefined,
+        manager,
+      );
+
+      return archived;
+    });
   }
 
   async restore(id: string, userId: string, userName?: string): Promise<MedicalRecord> {
@@ -302,38 +316,51 @@ export class MedicalRecordsService {
       throw new BadRequestException('Only archived records can be restored');
     }
 
-    record.status = MedicalRecordStatus.ACTIVE;
-    record.updatedBy = userId;
+    return this.dataSource.transaction(async (manager) => {
+      record.status = MedicalRecordStatus.ACTIVE;
+      record.updatedBy = userId;
 
-    const restored = await this.medicalRecordRepository.save(record);
+      const restored = await manager.save(MedicalRecord, record);
 
-    await this.createHistoryEntry(
-      restored.id,
-      restored.patientId,
-      HistoryEventType.RESTORED,
-      'Medical record restored',
-      userId,
-      userName,
-    );
+      await this.createHistoryEntry(
+        restored.id,
+        restored.patientId,
+        HistoryEventType.RESTORED,
+        'Medical record restored',
+        userId,
+        userName,
+        undefined,
+        undefined,
+        undefined,
+        manager,
+      );
 
-    return restored;
+      return restored;
+    });
   }
 
   async delete(id: string, userId: string, userName?: string): Promise<void> {
     const record = await this.findOne(id);
-    record.status = MedicalRecordStatus.DELETED;
-    record.updatedBy = userId;
 
-    await this.medicalRecordRepository.save(record);
+    await this.dataSource.transaction(async (manager) => {
+      record.status = MedicalRecordStatus.DELETED;
+      record.updatedBy = userId;
 
-    await this.createHistoryEntry(
-      record.id,
-      record.patientId,
-      HistoryEventType.DELETED,
-      'Medical record deleted',
-      userId,
-      userName,
-    );
+      await manager.save(MedicalRecord, record);
+
+      await this.createHistoryEntry(
+        record.id,
+        record.patientId,
+        HistoryEventType.DELETED,
+        'Medical record deleted',
+        userId,
+        userName,
+        undefined,
+        undefined,
+        undefined,
+        manager,
+      );
+    });
 
     this.logger.log(`Medical record deleted: ${id} by user ${userId}`);
   }
@@ -345,13 +372,14 @@ export class MedicalRecordsService {
     userId: string,
     userName?: string,
     changeReason?: string,
+    manager?: EntityManager,
   ): Promise<MedicalRecordVersion> {
-    // Get the current version number (default to 1 if not set)
+    const repo = manager ? manager.getRepository(MedicalRecordVersion) : this.versionRepository;
     const versionNumber = record.version || 1;
 
-    const version = this.versionRepository.create({
+    const version = repo.create({
       medicalRecordId: record.id,
-      versionNumber: versionNumber,
+      versionNumber,
       previousContent,
       currentContent,
       changedBy: userId,
@@ -360,7 +388,7 @@ export class MedicalRecordsService {
       changes: previousContent ? this.calculateChanges(previousContent, currentContent) : null,
     });
 
-    return this.versionRepository.save(version);
+    return repo.save(version);
   }
 
   private async createHistoryEntry(
@@ -373,8 +401,11 @@ export class MedicalRecordsService {
     eventData?: Record<string, any>,
     ipAddress?: string,
     userAgent?: string,
+    manager?: EntityManager,
   ): Promise<MedicalHistory> {
-    const history = this.historyRepository.create({
+    const repo = manager ? manager.getRepository(MedicalHistory) : this.historyRepository;
+
+    const history = repo.create({
       medicalRecordId: recordId,
       patientId,
       eventType,
@@ -386,7 +417,7 @@ export class MedicalRecordsService {
       userAgent,
     });
 
-    return this.historyRepository.save(history);
+    return repo.save(history);
   }
 
   private calculateChanges(previousContent: string, currentContent: string): Record<string, any> {

--- a/src/migrations/1775300000000-AddPreviousHashToAuditLogs.ts
+++ b/src/migrations/1775300000000-AddPreviousHashToAuditLogs.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `previousHash` to `audit_logs` to form a tamper-evident hash chain.
+ * Each row stores the SHA-256 of the previous row's `integrityHash`, so any
+ * insertion, deletion, or modification of a historical row breaks the chain
+ * and is detectable by a sequential scan.
+ */
+export class AddPreviousHashToAuditLogs1775300000000 implements MigrationInterface {
+  name = 'AddPreviousHashToAuditLogs1775300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE audit_logs
+      ADD COLUMN IF NOT EXISTS "previousHash" varchar(128) NULL;
+    `);
+
+    // Index to support efficient chain-verification queries (walk by createdAt order)
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at
+      ON audit_logs ("createdAt" ASC);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_audit_logs_created_at`);
+    await queryRunner.query(`ALTER TABLE audit_logs DROP COLUMN IF EXISTS "previousHash"`);
+  }
+}

--- a/src/rbac/audit-log.entity.ts
+++ b/src/rbac/audit-log.entity.ts
@@ -108,6 +108,13 @@ export class AuditLog {
   @Column({ type: 'varchar', length: 128 })
   integrityHash: string;
 
+  /**
+   * SHA-256 of the previous row's integrityHash, forming a tamper-evident chain.
+   * NULL only for the very first row in the table.
+   */
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  previousHash: string | null;
+
   @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date;
 }

--- a/src/rbac/audit.service.ts
+++ b/src/rbac/audit.service.ts
@@ -110,7 +110,7 @@ export class AuditService implements OnModuleInit, OnApplicationShutdown {
    *   for crash-safe durability, then flushed to PostgreSQL by the background worker.
    */
   async log(options: AuditLogOptions): Promise<void> {
-    const entry = this.buildAuditEntry(options);
+    const entry = await this.buildAuditEntry(options);
 
     this.eventEmitter.emit('audit.logged', entry);
 
@@ -293,12 +293,36 @@ export class AuditService implements OnModuleInit, OnApplicationShutdown {
     }
   }
 
-  private buildAuditEntry(options: AuditLogOptions): Partial<AuditLog> {
+  /**
+   * Fetch the integrityHash of the most-recently inserted audit row.
+   * Used to chain each new entry to its predecessor.
+   */
+  private async getLatestIntegrityHash(): Promise<string | null> {
+    const latest = await this.auditLogRepository.findOne({
+      where: {},
+      order: { createdAt: 'DESC' },
+      select: ['integrityHash'],
+    });
+    return latest?.integrityHash ?? null;
+  }
+
+  /**
+   * Build a tamper-evident audit entry.
+   *
+   * The integrityHash covers: userId, action, resource, timestamp, AND the
+   * previousHash of the preceding row.  Any deletion or modification of a
+   * historical row breaks the chain and is detectable by a sequential scan.
+   */
+  private async buildAuditEntry(options: AuditLogOptions): Promise<Partial<AuditLog>> {
+    const previousHash = await this.getLatestIntegrityHash();
+    const timestamp = new Date().toISOString();
+
     const dataString = JSON.stringify({
       userId: options.userId,
       action: options.action,
       resource: options.resource,
-      timestamp: new Date().toISOString(),
+      timestamp,
+      previousHash,
     });
 
     return {
@@ -320,6 +344,7 @@ export class AuditService implements OnModuleInit, OnApplicationShutdown {
       deviceId: options.deviceId || null,
       correlationId: options.correlationId || null,
       isAnomaly: false,
+      previousHash,
       integrityHash: this.encryptionService.createIntegritySignature(dataString),
     };
   }


### PR DESCRIPTION
this pr closes #428 
this pr closes #437 

- Add previousHash column to audit_logs for hash chaining
- buildAuditEntry now includes previousHash in integrity signature
- update/archive/restore/delete wrapped in dataSource.transaction()
- createVersion/createHistoryEntry accept optional EntityManager
- Migration 1775300000000-AddPreviousHashToAuditLogs