### PR TITLE
feat: add API version lifecycle enforcement

### DIFF
--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -68,6 +68,12 @@ Deprecated endpoints return the following response headers:
 | `Sunset`      | RFC 7231 date when the endpoint is removed |
 | `Link`        | Alternative route (`rel="alternate"`)      |
 
+After the sunset date, deprecated endpoints return:
+
+| Status Code | Meaning |
+|-------------|---------|
+| `410 Gone`  | Endpoint has reached end-of-life and is no longer served |
+
 Example:
 
 ```http
@@ -168,5 +174,6 @@ Add the new version to `src/versioning/api-versions.controller.ts`:
 ## Architecture Notes
 
 - `VERSION_NEUTRAL` is used for infrastructure endpoints: `GET /api`, `GET /health`, `GET /metrics`
-- The global `DeprecationInterceptor` automatically injects deprecation headers — no manual `res.setHeader()` needed
+- The global `DeprecationInterceptor` automatically injects deprecation headers and enforces `410 Gone` when route-level sunset dates are reached
+- The global `ApiVersionLifecycleInterceptor` enforces version lifecycle policy (current/deprecated/sunset) for URI-prefixed versions
 - `defaultVersion: ['1', VERSION_NEUTRAL]` ensures backward compatibility: clients not sending a version prefix still hit v1

--- a/src/common/interceptors/deprecation.interceptor.ts
+++ b/src/common/interceptors/deprecation.interceptor.ts
@@ -1,4 +1,10 @@
-import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  GoneException,
+} from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { Reflector } from '@nestjs/core';
 import { DEPRECATED_ROUTE_KEY, DeprecatedRouteOptions } from '../decorators/deprecated.decorator';
@@ -23,6 +29,17 @@ export class DeprecationInterceptor implements NestInterceptor {
       // Set Sunset header if provided
       if (isDeprecatedOptions.sunsetDate) {
         response.setHeader('Sunset', isDeprecatedOptions.sunsetDate);
+
+        const sunsetTime = Date.parse(isDeprecatedOptions.sunsetDate);
+        if (!Number.isNaN(sunsetTime) && Date.now() >= sunsetTime) {
+          const reason = isDeprecatedOptions.reason ? ` ${isDeprecatedOptions.reason}` : '';
+          const replacement = isDeprecatedOptions.alternativeRoute
+            ? ` Use ${isDeprecatedOptions.alternativeRoute} instead.`
+            : '';
+          throw new GoneException(
+            `This endpoint is no longer available. Sunset date: ${isDeprecatedOptions.sunsetDate}.${reason}${replacement}`,
+          );
+        }
       }
 
       // Add a link to the alternative route if provided

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { nonceMiddleware } from './common/middleware/nonce.middleware';
 import { DeprecationInterceptor } from './common/interceptors/deprecation.interceptor';
 import { Logger } from 'nestjs-pino';
 import { applySecurityHeaders } from './security/http-security.config';
+import { ApiVersionLifecycleInterceptor } from './versioning/api-version-lifecycle.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -92,7 +93,10 @@ async function bootstrap() {
     maxAge: 3600,
   });
 
-  app.useGlobalInterceptors(new DeprecationInterceptor(app.get(Reflector)));
+  app.useGlobalInterceptors(
+    new ApiVersionLifecycleInterceptor(),
+    new DeprecationInterceptor(app.get(Reflector)),
+  );
 
   app.useGlobalFilters(new GlobalExceptionFilter());
   app.useGlobalPipes(

--- a/src/versioning/api-version-lifecycle.interceptor.ts
+++ b/src/versioning/api-version-lifecycle.interceptor.ts
@@ -1,0 +1,67 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  GoneException,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import {
+  API_VERSION_LIFECYCLE_POLICIES,
+  ApiVersionLifecyclePolicy,
+} from './api-version-lifecycle.policy';
+
+@Injectable()
+export class ApiVersionLifecycleInterceptor implements NestInterceptor {
+  constructor(
+    private readonly policies: ApiVersionLifecyclePolicy[] = API_VERSION_LIFECYCLE_POLICIES,
+    private readonly nowProvider: () => Date = () => new Date(),
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const http = context.switchToHttp();
+    const request = http.getRequest();
+    const response = http.getResponse();
+
+    const version = this.extractUriVersion(request?.originalUrl ?? request?.url ?? '');
+    if (!version) return next.handle();
+
+    const policy = this.policies.find((p) => p.version === version);
+    if (!policy) return next.handle();
+
+    if (policy.status === 'deprecated') {
+      response.setHeader('Deprecation', 'true');
+      if (policy.sunsetDate) response.setHeader('Sunset', policy.sunsetDate);
+      if (policy.replacementVersion) {
+        response.setHeader('Link', `</v${policy.replacementVersion}>; rel="alternate"`);
+      }
+    }
+
+    if (this.isSunset(policy)) {
+      throw new GoneException(this.buildSunsetMessage(policy));
+    }
+
+    return next.handle();
+  }
+
+  private isSunset(policy: ApiVersionLifecyclePolicy): boolean {
+    if (policy.status === 'sunset') return true;
+    if (policy.status !== 'deprecated' || !policy.sunsetDate) return false;
+
+    const sunsetTime = Date.parse(policy.sunsetDate);
+    if (Number.isNaN(sunsetTime)) return false;
+
+    return this.nowProvider().getTime() >= sunsetTime;
+  }
+
+  private buildSunsetMessage(policy: ApiVersionLifecyclePolicy): string {
+    const replacement = policy.replacementVersion ? ` Use /v${policy.replacementVersion} instead.` : '';
+    const sunset = policy.sunsetDate ? ` Sunset date: ${policy.sunsetDate}.` : '';
+    return `API version v${policy.version} is no longer available.${sunset}${replacement}`.trim();
+  }
+
+  private extractUriVersion(urlPath: string): string | null {
+    const match = /^\/v(\d+)(?:\/|$)/i.exec(urlPath);
+    return match?.[1] ?? null;
+  }
+}

--- a/src/versioning/api-version-lifecycle.policy.ts
+++ b/src/versioning/api-version-lifecycle.policy.ts
@@ -1,0 +1,30 @@
+export type ApiVersionLifecycleStatus = 'current' | 'deprecated' | 'sunset';
+
+export interface ApiVersionLifecyclePolicy {
+  version: string;
+  status: ApiVersionLifecycleStatus;
+  releaseDate: string;
+  baseUrl: string;
+  changelog?: string;
+  sunsetDate?: string;
+  replacementVersion?: string;
+}
+
+export const API_VERSION_LIFECYCLE_POLICIES: ApiVersionLifecyclePolicy[] = [
+  {
+    version: '1',
+    status: 'current',
+    releaseDate: '2024-01-01',
+    baseUrl: '/v1',
+    changelog: 'https://github.com/joel-metal/Healthy-Stellar-backend/blob/main/docs/api-versioning.md#v1',
+  },
+  // Example for future rollout:
+  // {
+  //   version: '2',
+  //   status: 'deprecated',
+  //   releaseDate: '2025-01-01',
+  //   baseUrl: '/v2',
+  //   sunsetDate: 'Wed, 01 Jan 2027 00:00:00 GMT',
+  //   replacementVersion: '3',
+  // },
+];

--- a/src/versioning/api-versions.controller.ts
+++ b/src/versioning/api-versions.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, VERSION_NEUTRAL } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { API_VERSION_LIFECYCLE_POLICIES } from './api-version-lifecycle.policy';
 
 export interface ApiVersionInfo {
   version: string;
@@ -16,7 +17,6 @@ export interface ApiVersionInfo {
  * regardless of the URI version prefix.
  */
 @ApiTags('API Versioning')
-@Version(VERSION_NEUTRAL)
 @Controller('api')
 export class ApiVersionsController {
   @Get()
@@ -27,23 +27,7 @@ export class ApiVersionsController {
   })
   getVersions(): { versions: ApiVersionInfo[] } {
     return {
-      versions: [
-        {
-          version: '1',
-          status: 'current',
-          releaseDate: '2024-01-01',
-          baseUrl: '/v1',
-          changelog: 'https://github.com/joel-metal/Healthy-Stellar-backend/blob/main/docs/api-versioning.md#v1',
-        },
-        // v2 placeholder — uncomment when v2 controllers are ready
-        // {
-        //   version: '2',
-        //   status: 'current',
-        //   releaseDate: '2025-01-01',
-        //   baseUrl: '/v2',
-        //   changelog: '...',
-        // },
-      ],
+      versions: API_VERSION_LIFECYCLE_POLICIES,
     };
   }
 }

--- a/src/versioning/versioning-routing.spec.ts
+++ b/src/versioning/versioning-routing.spec.ts
@@ -4,6 +4,8 @@ import { Reflector } from '@nestjs/core';
 import * as request from 'supertest';
 import { DeprecationInterceptor } from '../common/interceptors/deprecation.interceptor';
 import { DeprecatedRoute } from '../common/decorators/deprecated.decorator';
+import { ApiVersionLifecycleInterceptor } from './api-version-lifecycle.interceptor';
+import { ApiVersionLifecyclePolicy } from './api-version-lifecycle.policy';
 
 // ── Minimal test controllers ──────────────────────────────────────────────────
 
@@ -18,10 +20,21 @@ class TestV1Controller {
   @Version('1')
   @Get('deprecated')
   @DeprecatedRoute({
-    sunsetDate: 'Wed, 01 Jan 2026 00:00:00 GMT',
+    sunsetDate: 'Wed, 01 Jan 2030 00:00:00 GMT',
     alternativeRoute: '/v2/test-v1/deprecated',
   })
   getDeprecated() {
+    return { version: 1, deprecated: true };
+  }
+
+  @Version('1')
+  @Get('deprecated-gone')
+  @DeprecatedRoute({
+    sunsetDate: 'Wed, 01 Jan 2020 00:00:00 GMT',
+    alternativeRoute: '/v2/test-v1/deprecated-gone',
+    reason: 'This endpoint has been removed.',
+  })
+  getDeprecatedGone() {
     return { version: 1, deprecated: true };
   }
 }
@@ -32,6 +45,15 @@ class TestV2Controller {
   @Get()
   getV2() {
     return { version: 2 };
+  }
+}
+
+@Controller('test-v1')
+class TestV3Controller {
+  @Version('3')
+  @Get()
+  getV3() {
+    return { version: 3 };
   }
 }
 
@@ -48,18 +70,46 @@ class TestNeutralController {
 
 describe('API Versioning (routing)', () => {
   let app: INestApplication;
+  let httpApp: any;
+  const now = () => new Date('2026-04-25T00:00:00.000Z');
+  const policies: ApiVersionLifecyclePolicy[] = [
+    {
+      version: '1',
+      status: 'current',
+      releaseDate: '2024-01-01',
+      baseUrl: '/v1',
+    },
+    {
+      version: '2',
+      status: 'deprecated',
+      releaseDate: '2025-01-01',
+      baseUrl: '/v2',
+      sunsetDate: 'Wed, 01 Jan 2030 00:00:00 GMT',
+      replacementVersion: '1',
+    },
+    {
+      version: '3',
+      status: 'sunset',
+      releaseDate: '2023-01-01',
+      baseUrl: '/v3',
+      sunsetDate: 'Wed, 01 Jan 2025 00:00:00 GMT',
+      replacementVersion: '1',
+    },
+  ];
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      controllers: [TestV1Controller, TestV2Controller, TestNeutralController],
+      controllers: [TestV1Controller, TestV2Controller, TestV3Controller, TestNeutralController],
     }).compile();
 
     app = module.createNestApplication();
 
     app.enableVersioning({ type: VersioningType.URI });
+    app.useGlobalInterceptors(new ApiVersionLifecycleInterceptor(policies, now));
     app.useGlobalInterceptors(new DeprecationInterceptor(app.get(Reflector)));
 
     await app.init();
+    httpApp = app.getHttpAdapter().getInstance();
   });
 
   afterAll(async () => {
@@ -67,37 +117,54 @@ describe('API Versioning (routing)', () => {
   });
 
   it('GET /v1/test-v1 routes to v1 controller', async () => {
-    const res = await request(app.getHttpServer()).get('/v1/test-v1').expect(200);
+    const res = await request(httpApp).get('/v1/test-v1').expect(200);
     expect(res.body.version).toBe(1);
   });
 
   it('GET /v2/test-v1 routes to v2 controller', async () => {
-    const res = await request(app.getHttpServer()).get('/v2/test-v1').expect(200);
+    const res = await request(httpApp).get('/v2/test-v1').expect(200);
     expect(res.body.version).toBe(2);
   });
 
+  it('deprecated version returns deprecation headers', async () => {
+    const res = await request(httpApp).get('/v2/test-v1').expect(200);
+    expect(res.headers['deprecation']).toBe('true');
+    expect(res.headers['sunset']).toBe('Wed, 01 Jan 2030 00:00:00 GMT');
+    expect(res.headers['link']).toContain('/v1');
+  });
+
+  it('sunset version returns 410 Gone', async () => {
+    const res = await request(httpApp).get('/v3/test-v1').expect(410);
+    expect(String(res.body.message)).toContain('API version v3 is no longer available');
+  });
+
   it('VERSION_NEUTRAL controller responds without version prefix', async () => {
-    const res = await request(app.getHttpServer()).get('/test-neutral').expect(200);
+    const res = await request(httpApp).get('/test-neutral').expect(200);
     expect(res.body.neutral).toBe(true);
   });
 
   it('deprecated endpoint returns Deprecation header', async () => {
-    const res = await request(app.getHttpServer()).get('/v1/test-v1/deprecated').expect(200);
+    const res = await request(httpApp).get('/v1/test-v1/deprecated').expect(200);
     expect(res.headers['deprecation']).toBe('true');
   });
 
   it('deprecated endpoint returns Sunset header', async () => {
-    const res = await request(app.getHttpServer()).get('/v1/test-v1/deprecated').expect(200);
-    expect(res.headers['sunset']).toBe('Wed, 01 Jan 2026 00:00:00 GMT');
+    const res = await request(httpApp).get('/v1/test-v1/deprecated').expect(200);
+    expect(res.headers['sunset']).toBe('Wed, 01 Jan 2030 00:00:00 GMT');
   });
 
   it('deprecated endpoint returns Link header pointing to alternative', async () => {
-    const res = await request(app.getHttpServer()).get('/v1/test-v1/deprecated').expect(200);
+    const res = await request(httpApp).get('/v1/test-v1/deprecated').expect(200);
     expect(res.headers['link']).toContain('/v2/test-v1/deprecated');
   });
 
+  it('route-level sunset endpoint returns 410 Gone', async () => {
+    const res = await request(httpApp).get('/v1/test-v1/deprecated-gone').expect(410);
+    expect(String(res.body.message)).toContain('This endpoint is no longer available');
+  });
+
   it('non-deprecated endpoint does NOT return Deprecation header', async () => {
-    const res = await request(app.getHttpServer()).get('/v1/test-v1').expect(200);
+    const res = await request(httpApp).get('/v1/test-v1').expect(200);
     expect(res.headers['deprecation']).toBeUndefined();
   });
 });


### PR DESCRIPTION
This pr closes issue #456 
summary- add centralized API version lifecycle policy registry
- enforce version-level lifecycle using a global interceptor (deprecated headers + 410 after sunset)
- n- enforce route-level @DeprecatedRoute sunset behavior with 410 Gone
- align /api version registry output with lifecycle policy
- update versioning routing tests and docs for lifecycle enforcement behavior Notes
-  targeted versioning specs were updated; full unit suite in this branch is currently failing due pre-existing unrelated repository issues