### PR TITLE
feat: Add service health dependency degradation modes

### DIFF
--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, UseGuards, Version, VERSION_NEUTRAL } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
+import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator, HealthCheckResult } from '@nestjs/terminus';
 import { AdminGuard } from '../auth/guards/admin.guard';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CircuitBreakerService } from '../common/circuit-breaker/circuit-breaker.service';
@@ -13,11 +13,46 @@ import { IpfsHealthIndicator } from './indicators/ipfs.health';
 import { RedisHealthIndicator } from './indicators/redis.health';
 import { StellarHealthIndicator } from './indicators/stellar.health';
 
+enum DependencyLevel {
+  CRITICAL = 'critical', // Must be healthy for system to be ready
+  IMPORTANT = 'important', // Can be degraded, system still ready but with warnings
+  OPTIONAL = 'optional', // Can be down, system still ready
+}
+
+interface DependencyCheck {
+  name: string;
+  level: DependencyLevel;
+  check: () => Promise<HealthCheckResult>;
+}
+
 @ApiTags('health')
 @Version(VERSION_NEUTRAL)
 @Controller('health')
 @Public()
 export class HealthController {
+  private readonly dependencies: DependencyCheck[] = [
+    {
+      name: 'database',
+      level: DependencyLevel.CRITICAL,
+      check: () => this.db.pingCheck('database', { timeout: 3000 }),
+    },
+    {
+      name: 'redis',
+      level: DependencyLevel.CRITICAL,
+      check: () => this.redis.isHealthy('redis'),
+    },
+    {
+      name: 'stellar',
+      level: DependencyLevel.IMPORTANT,
+      check: () => this.stellar.isHealthy('stellar'),
+    },
+    {
+      name: 'ipfs',
+      level: DependencyLevel.IMPORTANT,
+      check: () => this.ipfs.isHealthy('ipfs'),
+    },
+  ];
+
   constructor(
     private health: HealthCheckService,
     private db: TypeOrmHealthIndicator,
@@ -41,19 +76,53 @@ export class HealthController {
 
   @Get('ready')
   @HealthCheck()
-  @ApiOperation({ summary: 'Readiness probe (all dependencies healthy)' })
-  @ApiResponse({ status: 200, description: 'System is ready' })
-  @ApiResponse({ status: 503, description: 'System is not ready' })
+  @ApiOperation({ summary: 'Readiness probe with dependency degradation modes' })
+  @ApiResponse({ status: 200, description: 'System is ready (critical dependencies healthy)' })
+  @ApiResponse({ status: 503, description: 'System is not ready (critical dependencies failed)' })
   async checkReadiness() {
-    const healthChecks = await this.health.check([
-      () => this.db.pingCheck('database', { timeout: 3000 }),
-      () => this.redis.isHealthy('redis'),
-      () => this.ipfs.isHealthy('ipfs'),
-      () => this.stellar.isHealthy('stellar'),
-    ]);
+    const results: Record<string, HealthCheckResult> = {};
+    const degradedServices: string[] = [];
+    let criticalFailure = false;
 
+    // Check all dependencies
+    for (const dep of this.dependencies) {
+      try {
+        const result = await dep.check();
+        results[dep.name] = result;
+
+        if (!result[dep.name]?.status || result[dep.name].status !== 'up') {
+          if (dep.level === DependencyLevel.CRITICAL) {
+            criticalFailure = true;
+          } else {
+            degradedServices.push(dep.name);
+          }
+        }
+      } catch (error) {
+        // Health check failed
+        if (dep.level === DependencyLevel.CRITICAL) {
+          criticalFailure = true;
+        } else {
+          degradedServices.push(dep.name);
+        }
+        results[dep.name] = {
+          [dep.name]: {
+            status: 'down',
+            error: error.message,
+          },
+        };
+      }
+    }
+
+    // If critical dependencies failed, return 503
+    if (criticalFailure) {
+      throw new Error('Critical dependencies are down');
+    }
+
+    // Return readiness status with degradation info
     return {
-      ...healthChecks,
+      status: 'up',
+      details: results,
+      degradedServices,
       circuitBreakers: this.circuitBreaker.getAllStates(),
     };
   }


### PR DESCRIPTION
closes #442
- Categorize dependencies into critical, important, and optional levels
- Critical dependencies (database, redis) must be healthy for readiness
- Important dependencies (stellar, ipfs) can be degraded without failing readiness
- Optional dependencies can be down without affecting readiness
- Return degradation information in readiness response