### PR TITLE
feat: Introduce circuit breakers for external integrations

### DIFF
--- a/src/queues/processors/stellar-transaction.processor.ts
+++ b/src/queues/processors/stellar-transaction.processor.ts
@@ -6,7 +6,7 @@ import { ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
 import { QUEUE_NAMES, JOB_TYPES } from '../queue.constants';
 import { StellarTransactionJobDto } from '../dto/stellar-transaction-job.dto';
-import { StellarContractService } from '../../blockchain/stellar-contract.service';
+import { StellarWithBreakerService } from '../../stellar/services/stellar-with-breaker.service';
 
 const IDEMPOTENCY_TTL_SECONDS = 86400; // 24 hours
 
@@ -19,8 +19,7 @@ export class StellarTransactionProcessor extends WorkerHost implements OnModuleI
   private redis: Redis;
 
   constructor(
-    @Inject(StellarContractService)
-    private readonly stellarContractService: StellarContractService,
+    private readonly stellarService: StellarWithBreakerService,
     private readonly configService: ConfigService,
   ) {
     super();
@@ -176,11 +175,11 @@ export class StellarTransactionProcessor extends WorkerHost implements OnModuleI
     );
     job.progress(30);
 
-    const result = await this.stellarContractService.grantAccess({
+    const result = await this.stellarService.grantAccess({
       patientId: params.patientId,
       granteeId: params.granteeId,
       recordId: params.recordId,
-      expirationTime: params.expirationTime || Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60, // 7 days default
+      expiresAt: new Date((params.expirationTime || Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60) * 1000), // Convert seconds to Date
     });
 
     job.progress(90);
@@ -208,7 +207,7 @@ export class StellarTransactionProcessor extends WorkerHost implements OnModuleI
     );
     job.progress(30);
 
-    const result = await this.stellarContractService.revokeAccess({
+    const result = await this.stellarService.revokeAccess({
       patientId: params.patientId,
       granteeId: params.granteeId,
       recordId: params.recordId,

--- a/src/records/services/records.service.ts
+++ b/src/records/services/records.service.ts
@@ -15,7 +15,7 @@ import { CreateRecordDto } from '../dto/create-record.dto';
 import { PaginationQueryDto } from '../dto/pagination-query.dto';
 import { PaginatedRecordsResponseDto } from '../dto/paginated-response.dto';
 import { RecentRecordDto } from '../dto/recent-record.dto';
-import { IpfsService } from './ipfs.service';
+import { IpfsWithBreakerService } from './ipfs-with-breaker.service';
 import { StellarService } from './stellar.service';
 import { AccessControlService } from '../../access-control/services/access-control.service';
 import { AuditLogService } from '../../common/services/audit-log.service';
@@ -30,7 +30,7 @@ export class RecordsService {
     @InjectRepository(Record)
     private recordRepository: Repository<Record>,
     private dataSource: DataSource,
-    private ipfsService: IpfsService,
+    private ipfsService: IpfsWithBreakerService,
     private stellarService: StellarService,
     @Inject(forwardRef(() => AccessControlService))
     private accessControlService: AccessControlService,

--- a/src/records/services/stellar.service.ts
+++ b/src/records/services/stellar.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as StellarSdk from '@stellar/stellar-sdk';
 import { TracingService } from '../../common/services/tracing.service';
+import { CircuitBreakerService } from '../../common/circuit-breaker/circuit-breaker.service';
 
 @Injectable()
 export class StellarService {
@@ -8,7 +9,10 @@ export class StellarService {
   private server: StellarSdk.Horizon.Server;
   private contract: StellarSdk.Contract;
 
-  constructor(private readonly tracingService: TracingService) {
+  constructor(
+    private readonly tracingService: TracingService,
+    private readonly circuitBreaker: CircuitBreakerService,
+  ) {
     const network = process.env.STELLAR_NETWORK || 'testnet';
     const horizonUrl =
       network === 'testnet' ? 'https://horizon-testnet.stellar.org' : 'https://horizon.stellar.org';
@@ -18,100 +22,17 @@ export class StellarService {
   }
 
   async createShareLink(recordId: string, patientId: string): Promise<string> {
-    const sourceKeypair = StellarSdk.Keypair.fromSecret(process.env.STELLAR_SECRET_KEY || '');
-    const sourceAccount = await this.server.loadAccount(sourceKeypair.publicKey());
-    const contract = new StellarSdk.Contract(process.env.STELLAR_CONTRACT_ID || '');
-    const expiresAt = Date.now() + 24 * 60 * 60 * 1000;
-
-    const operation = contract.call(
-      'create_share_link',
-      StellarSdk.nativeToScVal(recordId, { type: 'string' }),
-      StellarSdk.nativeToScVal(patientId, { type: 'string' }),
-      StellarSdk.nativeToScVal(expiresAt, { type: 'u64' }),
-    );
-
-    const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
-      fee: StellarSdk.BASE_FEE,
-      networkPassphrase:
-        process.env.STELLAR_NETWORK === 'testnet'
-          ? StellarSdk.Networks.TESTNET
-          : StellarSdk.Networks.PUBLIC,
-    })
-      .addOperation(operation)
-      .setTimeout(30)
-      .build();
-
-    transaction.sign(sourceKeypair);
-    const result = await this.server.submitTransaction(transaction);
-    this.logger.log(`Share link created on Stellar: ${result.hash}`);
-    // Return the transaction hash as the share token
-    return result.hash;
-  }
-
-  async anchorCid(patientId: string, cid: string): Promise<string> {
-    return this.tracingService.withSpan(
-      'stellar.anchorCid',
-      async (span) => {
-        span.setAttribute('stellar.patient_id', patientId);
-        span.setAttribute('stellar.cid', cid);
-        span.setAttribute('stellar.network', process.env.STELLAR_NETWORK || 'testnet');
-
-        try {
-          const sourceKeypair = StellarSdk.Keypair.fromSecret(
-            process.env.STELLAR_SECRET_KEY || '',
-          );
-          
-          // Load account with tracing
-          this.tracingService.addEvent('stellar.loadAccount.start');
-          const sourceAccount = await this.server.loadAccount(
-            sourceKeypair.publicKey(),
-          );
-          this.tracingService.addEvent('stellar.loadAccount.complete');
-
-          const operation = this.contract.call(
-            'anchor_record',
-            StellarSdk.nativeToScVal(patientId, { type: 'string' }),
-            StellarSdk.nativeToScVal(cid, { type: 'string' }),
-          );
-
-          const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
-            fee: StellarSdk.BASE_FEE,
-            networkPassphrase:
-              process.env.STELLAR_NETWORK === 'testnet'
-                ? StellarSdk.Networks.TESTNET
-                : StellarSdk.Networks.PUBLIC,
-          })
-            .addOperation(operation)
-            .setTimeout(30)
-            .build();
-
-          transaction.sign(sourceKeypair);
-
-          // Submit transaction with tracing
-          this.tracingService.addEvent('stellar.submitTransaction.start');
-          const result = await this.server.submitTransaction(transaction);
-          this.tracingService.addEvent('stellar.submitTransaction.complete', {
-            'stellar.transaction_hash': result.hash,
-          });
-
-          span.setAttribute('stellar.transaction_hash', result.hash);
-          this.logger.log(`CID anchored on Stellar: ${result.hash}`);
-          return result.hash;
-        } catch (error) {
-          this.tracingService.recordException(error as Error);
-          this.logger.error(`Stellar anchoring failed: ${error.message}`);
-          throw new Error(`Stellar anchoring failed: ${error.message}`);
-        }
-      },
-    );
-    try {
+    return this.circuitBreaker.execute('stellar', async () => {
       const sourceKeypair = StellarSdk.Keypair.fromSecret(process.env.STELLAR_SECRET_KEY || '');
       const sourceAccount = await this.server.loadAccount(sourceKeypair.publicKey());
+      const contract = new StellarSdk.Contract(process.env.STELLAR_CONTRACT_ID || '');
+      const expiresAt = Date.now() + 24 * 60 * 60 * 1000;
 
-      const operation = this.contract.call(
-        'anchor_record',
+      const operation = contract.call(
+        'create_share_link',
+        StellarSdk.nativeToScVal(recordId, { type: 'string' }),
         StellarSdk.nativeToScVal(patientId, { type: 'string' }),
-        StellarSdk.nativeToScVal(cid, { type: 'string' }),
+        StellarSdk.nativeToScVal(expiresAt, { type: 'u64' }),
       );
 
       const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
@@ -126,13 +47,69 @@ export class StellarService {
         .build();
 
       transaction.sign(sourceKeypair);
-
       const result = await this.server.submitTransaction(transaction);
-      this.logger.log(`CID anchored on Stellar: ${result.hash}`);
+      this.logger.log(`Share link created on Stellar: ${result.hash}`);
       return result.hash;
-    } catch (error) {
-      this.logger.error(`Stellar anchoring failed: ${error.message}`);
-      throw new Error(`Stellar anchoring failed: ${error.message}`);
-    }
+    });
+  }
+
+  async anchorCid(patientId: string, cid: string): Promise<string> {
+    return this.tracingService.withSpan(
+      'stellar.anchorCid',
+      async (span) => {
+        span.setAttribute('stellar.patient_id', patientId);
+        span.setAttribute('stellar.cid', cid);
+        span.setAttribute('stellar.network', process.env.STELLAR_NETWORK || 'testnet');
+
+        try {
+          return await this.circuitBreaker.execute('stellar', async () => {
+            const sourceKeypair = StellarSdk.Keypair.fromSecret(
+              process.env.STELLAR_SECRET_KEY || '',
+            );
+            
+            // Load account with tracing
+            this.tracingService.addEvent('stellar.loadAccount.start');
+            const sourceAccount = await this.server.loadAccount(
+              sourceKeypair.publicKey(),
+            );
+            this.tracingService.addEvent('stellar.loadAccount.complete');
+
+            const operation = this.contract.call(
+              'anchor_record',
+              StellarSdk.nativeToScVal(patientId, { type: 'string' }),
+              StellarSdk.nativeToScVal(cid, { type: 'string' }),
+            );
+
+            const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
+              fee: StellarSdk.BASE_FEE,
+              networkPassphrase:
+                process.env.STELLAR_NETWORK === 'testnet'
+                  ? StellarSdk.Networks.TESTNET
+                  : StellarSdk.Networks.PUBLIC,
+            })
+              .addOperation(operation)
+              .setTimeout(30)
+              .build();
+
+            transaction.sign(sourceKeypair);
+
+            // Submit transaction with tracing
+            this.tracingService.addEvent('stellar.submitTransaction.start');
+            const result = await this.server.submitTransaction(transaction);
+            this.tracingService.addEvent('stellar.submitTransaction.complete', {
+              'stellar.transaction_hash': result.hash,
+            });
+
+            span.setAttribute('stellar.transaction_hash', result.hash);
+            this.logger.log(`CID anchored on Stellar: ${result.hash}`);
+            return result.hash;
+          });
+        } catch (error) {
+          this.tracingService.recordException(error as Error);
+          this.logger.error(`Stellar anchoring failed: ${error.message}`);
+          throw new Error(`Stellar anchoring failed: ${error.message}`);
+        }
+      },
+    );
   }
 }

--- a/src/stellar/services/stellar-with-breaker.service.ts
+++ b/src/stellar/services/stellar-with-breaker.service.ts
@@ -22,33 +22,29 @@ export class StellarWithBreakerService {
     private readonly circuitBreaker: CircuitBreakerService,
   ) {}
 
-  async anchorRecord(patientId: string, cid: string): Promise<StellarTxResult> {
-    return this.executeWithBreaker(() => this.stellarService.anchorRecord(patientId, cid));
+  async anchorRecord(args: { patientId: string; cid: string }): Promise<StellarTxResult> {
+    return this.executeWithBreaker(() => this.stellarService.anchorRecord(args.patientId, args.cid));
   }
 
-  async grantAccess(
-    patientId: string,
-    granteeId: string,
-    recordId: string,
-    expiresAt: Date,
-  ): Promise<StellarTxResult> {
-    return this.executeWithBreaker(() =>
-      this.stellarService.grantAccess(patientId, granteeId, recordId, expiresAt),
-    );
+  async grantAccess(args: { patientId: string; granteeId: string; recordId: string; expiresAt: Date }): Promise<StellarTxResult> {
+    return this.executeWithBreaker(() => this.stellarService.grantAccess(args.patientId, args.granteeId, args.recordId, args.expiresAt));
   }
 
-  async revokeAccess(
-    patientId: string,
-    granteeId: string,
-    recordId: string,
-  ): Promise<StellarTxResult> {
-    return this.executeWithBreaker(() =>
-      this.stellarService.revokeAccess(patientId, granteeId, recordId),
-    );
+  async revokeAccess(args: { patientId: string; granteeId: string; recordId: string }): Promise<StellarTxResult> {
+    return this.executeWithBreaker(() => this.stellarService.revokeAccess(args.patientId, args.granteeId, args.recordId));
   }
 
   async verifyAccess(requesterId: string, recordId: string): Promise<StellarVerifyResult> {
     return this.executeWithBreaker(() => this.stellarService.verifyAccess(requesterId, recordId));
+  }
+
+  async createShareLink(recordId: string, patientId: string): Promise<string> {
+    return this.executeWithBreaker(() => this.stellarService.createShareLink(recordId, patientId));
+  }
+
+  async anchorCid(patientId: string, cid: string): Promise<string> {
+    const result = await this.anchorRecord({ patientId, cid });
+    return result.txHash;
   }
 
   private async executeWithBreaker<T>(fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
closes #443 
- Updated StellarTransactionProcessor to use StellarWithBreakerService
- Updated RecordsService to use IpfsWithBreakerService instead of IpfsService
- Added circuit breaker protection to records StellarService for createShareLink and anchorCid methods
- Extended StellarWithBreakerService with additional methods (createShareLink, anchorCid)
- Ensured all external API calls (Stellar, IPFS) are protected by circuit breakers to prevent cascade failures