### PR TITLE
feat: replace in-memory retry state with Redis persistence

### DIFF
--- a/src/stellar/services/stellar-retry-store.service.ts
+++ b/src/stellar/services/stellar-retry-store.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { TransactionPriority, TransactionStatus } from './stellar-transaction-queue.service';
+import { TransactionContext } from './stellar-transaction-retry.service';
+
+export interface PersistedQueueEntry {
+  id: string;
+  xdr: string;
+  context: TransactionContext;
+  sourcePublicKey: string;
+  attempts: number;
+  maxAttempts: number;
+  nextRetryAt: string;
+  createdAt: string;
+  lastAttemptAt?: string;
+  lastError?: string;
+  priority: TransactionPriority;
+  status: TransactionStatus;
+}
+
+const INDEX_KEY = 'stellar:retry:index';
+const entryKey = (id: string) => `stellar:retry:${id}`;
+
+@Injectable()
+export class StellarRetryStoreService {
+  private readonly logger = new Logger(StellarRetryStoreService.name);
+  private redis: any;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  private async getClient(): Promise<any> {
+    if (!this.redis) {
+      const Redis = require('ioredis');
+      this.redis = new Redis({
+        host: this.configService.get<string>('REDIS_HOST', 'localhost'),
+        port: this.configService.get<number>('REDIS_PORT', 6379),
+        password: this.configService.get<string>('REDIS_PASSWORD'),
+        db: this.configService.get<number>('REDIS_DB', 0),
+        lazyConnect: true,
+      });
+      await this.redis.connect().catch((err: Error) => {
+        this.logger.warn(`Redis connect warning: ${err.message}`);
+      });
+    }
+    return this.redis;
+  }
+
+  async save(entry: PersistedQueueEntry): Promise<void> {
+    try {
+      const client = await this.getClient();
+      await client.set(entryKey(entry.id), JSON.stringify(entry));
+      await client.sadd(INDEX_KEY, entry.id);
+    } catch (err: any) {
+      this.logger.error(`Failed to persist queue entry ${entry.id}: ${err.message}`);
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    try {
+      const client = await this.getClient();
+      await client.del(entryKey(id));
+      await client.srem(INDEX_KEY, id);
+    } catch (err: any) {
+      this.logger.error(`Failed to remove queue entry ${id}: ${err.message}`);
+    }
+  }
+
+  async loadAll(): Promise<PersistedQueueEntry[]> {
+    try {
+      const client = await this.getClient();
+      const ids: string[] = await client.smembers(INDEX_KEY);
+      if (!ids.length) return [];
+
+      const pipeline = client.pipeline();
+      for (const id of ids) pipeline.get(entryKey(id));
+      const results: [Error | null, string | null][] = await pipeline.exec();
+
+      const entries: PersistedQueueEntry[] = [];
+      for (let i = 0; i < results.length; i++) {
+        const [err, raw] = results[i];
+        if (err || !raw) {
+          // Stale index entry — clean up
+          await client.srem(INDEX_KEY, ids[i]);
+          continue;
+        }
+        try {
+          entries.push(JSON.parse(raw) as PersistedQueueEntry);
+        } catch {
+          await client.srem(INDEX_KEY, ids[i]);
+        }
+      }
+      return entries;
+    } catch (err: any) {
+      this.logger.error(`Failed to load queue entries: ${err.message}`);
+      return [];
+    }
+  }
+}

--- a/src/stellar/services/stellar-transaction-queue.service.ts
+++ b/src/stellar/services/stellar-transaction-queue.service.ts
@@ -5,6 +5,7 @@ import {
   StellarTransactionRetryService,
   TransactionContext,
 } from './stellar-transaction-retry.service';
+import { StellarRetryStoreService } from './stellar-retry-store.service';
 
 /**
  * Stellar Transaction Queue Service
@@ -64,6 +65,7 @@ export class StellarTransactionQueueService implements OnModuleInit {
   constructor(
     private readonly configService: ConfigService,
     private readonly retryService: StellarTransactionRetryService,
+    private readonly retryStore: StellarRetryStoreService,
   ) {
     this.maxQueueSize = parseInt(
       this.configService.get<string>('STELLAR_QUEUE_MAX_SIZE', '1000'),
@@ -83,8 +85,21 @@ export class StellarTransactionQueueService implements OnModuleInit {
     );
   }
 
-  onModuleInit() {
+  async onModuleInit() {
+    await this.loadPersistedQueue();
     this.startRetryScheduler();
+  }
+
+  private async loadPersistedQueue(): Promise<void> {
+    const networkPassphrase = this.configService.get<string>(
+      'STELLAR_NETWORK_PASSPHRASE',
+      StellarSdk.Networks.TESTNET,
+    );
+    const entries = await this.retryStore.loadAll();
+    if (!entries.length) return;
+
+    const imported = this.importQueue(entries, networkPassphrase);
+    this.logger.log(`Restored ${imported} queued transactions from Redis`);
   }
 
   /**
@@ -121,6 +136,9 @@ export class StellarTransactionQueueService implements OnModuleInit {
 
     this.queue.set(id, queuedTx);
 
+    // Persist to Redis so state survives restarts
+    await this.retryStore.save(this.toPersistedEntry(queuedTx));
+
     this.logger.log(
       `[${context.operation}] Transaction enqueued: ${id} (priority: ${priority}, queue size: ${this.queue.size})`,
     );
@@ -134,6 +152,7 @@ export class StellarTransactionQueueService implements OnModuleInit {
   dequeue(id: string): boolean {
     const removed = this.queue.delete(id);
     if (removed) {
+      this.retryStore.remove(id).catch(() => {});
       this.logger.log(`Transaction dequeued: ${id}`);
     }
     return removed;
@@ -185,6 +204,7 @@ export class StellarTransactionQueueService implements OnModuleInit {
 
       if (shouldRemove) {
         this.queue.delete(id);
+        this.retryStore.remove(id).catch(() => {});
       }
     }
 
@@ -267,6 +287,7 @@ export class StellarTransactionQueueService implements OnModuleInit {
     const age = Date.now() - queuedTx.createdAt.getTime();
     if (age > this.transactionTTLMs) {
       queuedTx.status = TransactionStatus.EXPIRED;
+      await this.retryStore.save(this.toPersistedEntry(queuedTx));
       this.logger.warn(`[${context.operation}] Transaction ${id} expired (age: ${age}ms)`);
       return;
     }
@@ -311,6 +332,9 @@ export class StellarTransactionQueueService implements OnModuleInit {
         `[${context.operation}] Transaction ${id} retry failed: ${err.message}. Next retry at ${queuedTx.nextRetryAt.toISOString()}`,
       );
     }
+
+    // Persist updated state
+    await this.retryStore.save(this.toPersistedEntry(queuedTx));
   }
 
   /**
@@ -330,6 +354,26 @@ export class StellarTransactionQueueService implements OnModuleInit {
     const hash = transaction.hash().toString('hex');
     const timestamp = Date.now();
     return `${hash.substring(0, 16)}-${timestamp}`;
+  }
+
+  /**
+   * Map an in-memory QueuedTransaction to the serializable shape used by the store
+   */
+  private toPersistedEntry(tx: QueuedTransaction) {
+    return {
+      id: tx.id,
+      xdr: tx.transaction.toXDR(),
+      context: tx.context,
+      sourcePublicKey: tx.sourcePublicKey,
+      attempts: tx.attempts,
+      maxAttempts: tx.maxAttempts,
+      nextRetryAt: tx.nextRetryAt.toISOString(),
+      createdAt: tx.createdAt.toISOString(),
+      lastAttemptAt: tx.lastAttemptAt?.toISOString(),
+      lastError: tx.lastError,
+      priority: tx.priority,
+      status: tx.status,
+    };
   }
 
   /**

--- a/src/stellar/stellar.module.ts
+++ b/src/stellar/stellar.module.ts
@@ -9,6 +9,7 @@ import { StellarWithBreakerService } from './services/stellar-with-breaker.servi
 import { StellarTransactionRetryService } from './services/stellar-transaction-retry.service';
 import { StellarTransactionQueueService } from './services/stellar-transaction-queue.service';
 import { StellarRecoveryManagerService } from './services/stellar-recovery-manager.service';
+import { StellarRetryStoreService } from './services/stellar-retry-store.service';
 import { CircuitBreakerModule } from '../common/circuit-breaker/circuit-breaker.module';
 
 @Module({
@@ -27,6 +28,7 @@ import { CircuitBreakerModule } from '../common/circuit-breaker/circuit-breaker.
     StellarService,
     StellarWithBreakerService,
     StellarTransactionRetryService,
+    StellarRetryStoreService,
     StellarTransactionQueueService,
     StellarRecoveryManagerService,
   ],


### PR DESCRIPTION
Closes #412

---

## Summary

Retry state in `StellarTransactionQueueService` was held in a plain `Map`, which is lost on process restart and not shared across horizontal replicas.

## Changes

- **`stellar-retry-store.service.ts`** (new): Redis persistence layer using `ioredis` (same pattern as `RefreshTokenStoreService`). Each entry stored as JSON at `stellar:retry:<id>`; a Redis set `stellar:retry:index` tracks all live IDs for bulk load on startup.
- **`stellar-transaction-queue.service.ts`**: Injected `StellarRetryStoreService`; `onModuleInit` now rehydrates the in-memory map from Redis before starting the retry scheduler; all mutations (`enqueue`, `dequeue`, `cleanup`, `retryTransaction`) write-through to Redis.
- **`stellar.module.ts`**: Registered `StellarRetryStoreService` as a provider.

## Behaviour

- Redis errors are caught and logged — never thrown. The in-memory map remains the source of truth for the running process; Redis is the durable backing store.
- On startup, any transactions queued before a restart are restored and retried normally.