### PR TITLE
Add API Idempotency Keys for Mutating Endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -67,6 +67,9 @@ import { EventStoreModule } from './event-store/event-store.module';
 import { BullBoardAuthMiddleware } from './queues/middleware/bull-board-auth.middleware';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { WebhooksModule } from './webhooks/webhooks.module';
+import { IdempotencyModule } from './idempotency/idempotency.module';
+import { IdempotencyInterceptor } from './idempotency/idempotency.interceptor';
+import { DlqModule } from './dlq/dlq.module';
 
 @Module({
   imports: [
@@ -142,6 +145,8 @@ import { WebhooksModule } from './webhooks/webhooks.module';
     ConsistencyCheckerModule,
 
     WebhooksModule,
+    IdempotencyModule,
+    DlqModule,
     EventEmitterModule.forRoot(),
  main
   ],
@@ -168,6 +173,10 @@ import { WebhooksModule } from './webhooks/webhooks.module';
     {
       provide: APP_INTERCEPTOR,
       useClass: TenantInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: IdempotencyInterceptor,
     },
     {
       provide: APP_FILTER,

--- a/src/dlq/dlq-capture.listener.ts
+++ b/src/dlq/dlq-capture.listener.ts
@@ -1,0 +1,106 @@
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
+import { QueueEvents } from 'bullmq';
+import { ConfigService } from '@nestjs/config';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { DlqService } from './dlq.service';
+import { QUEUE_NAMES } from '../queues/queue.constants';
+import { createRedisRetryStrategy } from '../common/utils/connection-retry.util';
+
+/**
+ * Listens to BullMQ QueueEvents for every registered queue.
+ * When a job exhausts all retries (the 'failed' event fires with
+ * attemptsMade === opts.attempts), it is persisted to the dlq_jobs table
+ * via DlqService.capture().
+ */
+@Injectable()
+export class DlqCaptureListener implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(DlqCaptureListener.name);
+  private readonly queueEvents: QueueEvents[] = [];
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly dlqService: DlqService,
+
+    @InjectQueue(QUEUE_NAMES.STELLAR_TRANSACTIONS)
+    private readonly stellarQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.CONTRACT_WRITES)
+    private readonly contractWritesQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.IPFS_UPLOADS)
+    private readonly ipfsQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EVENT_INDEXING)
+    private readonly eventIndexingQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EMAIL_NOTIFICATIONS)
+    private readonly emailQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.REPORTS)
+    private readonly reportsQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EHR_IMPORT)
+    private readonly ehrImportQueue: Queue,
+  ) {}
+
+  private get queueMap(): Map<string, Queue> {
+    return new Map([
+      [QUEUE_NAMES.STELLAR_TRANSACTIONS, this.stellarQueue],
+      [QUEUE_NAMES.CONTRACT_WRITES, this.contractWritesQueue],
+      [QUEUE_NAMES.IPFS_UPLOADS, this.ipfsQueue],
+      [QUEUE_NAMES.EVENT_INDEXING, this.eventIndexingQueue],
+      [QUEUE_NAMES.EMAIL_NOTIFICATIONS, this.emailQueue],
+      [QUEUE_NAMES.REPORTS, this.reportsQueue],
+      [QUEUE_NAMES.EHR_IMPORT, this.ehrImportQueue],
+    ]);
+  }
+
+  onModuleInit(): void {
+    const connection = {
+      host: this.configService.get('REDIS_HOST', 'localhost'),
+      port: this.configService.get('REDIS_PORT', 6379),
+      password: this.configService.get('REDIS_PASSWORD'),
+      db: this.configService.get('REDIS_DB', 0),
+      retryStrategy: createRedisRetryStrategy(),
+    };
+
+    for (const [queueName, queue] of this.queueMap) {
+      const events = new QueueEvents(queueName, { connection });
+
+      events.on('failed', async ({ jobId, failedReason, prev }) => {
+        try {
+          const job = await queue.getJob(jobId);
+          if (!job) return;
+
+          const maxAttempts = job.opts?.attempts ?? 1;
+          // Only capture when all retries are exhausted
+          if (job.attemptsMade < maxAttempts) return;
+
+          await this.dlqService.capture({
+            jobId,
+            queueName,
+            jobName: job.name,
+            data: job.data as Record<string, any>,
+            opts: job.opts as Record<string, any>,
+            failedReason: failedReason ?? job.failedReason ?? 'Unknown error',
+            stackTrace: job.stacktrace?.join('\n') ?? undefined,
+            attemptsMade: job.attemptsMade,
+          });
+        } catch (err) {
+          this.logger.error(
+            `[DLQ] Error capturing failed job ${jobId} from ${queueName}: ${(err as Error).message}`,
+          );
+        }
+      });
+
+      events.on('error', (err) => {
+        this.logger.error(`[DLQ] QueueEvents error for ${queueName}`, err);
+      });
+
+      this.queueEvents.push(events);
+    }
+
+    this.logger.log(`[DLQ] Capture listener active for ${this.queueMap.size} queues`);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    for (const events of this.queueEvents) {
+      await events.close();
+    }
+  }
+}

--- a/src/dlq/dlq-job.entity.ts
+++ b/src/dlq/dlq-job.entity.ts
@@ -1,0 +1,80 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum DlqJobStatus {
+  FAILED = 'failed',
+  REPLAYED = 'replayed',
+  DISCARDED = 'discarded',
+}
+
+/**
+ * Persistent record of every job that exhausted all BullMQ retries.
+ * Allows replay, inspection, and audit outside of Redis (which is volatile).
+ */
+@Entity('dlq_jobs')
+export class DlqJobEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** BullMQ job id */
+  @Index()
+  @Column({ type: 'varchar', length: 256 })
+  jobId: string;
+
+  /** Queue the job originally belonged to */
+  @Index()
+  @Column({ type: 'varchar', length: 128 })
+  queueName: string;
+
+  /** Job name / operation type */
+  @Column({ type: 'varchar', length: 256 })
+  jobName: string;
+
+  /** Full job data payload */
+  @Column({ type: 'jsonb' })
+  data: Record<string, any>;
+
+  /** BullMQ job options at time of failure */
+  @Column({ type: 'jsonb', default: '{}' })
+  opts: Record<string, any>;
+
+  /** Last error message */
+  @Column({ type: 'text', nullable: true })
+  failedReason: string | null;
+
+  /** Full stack trace of last failure */
+  @Column({ type: 'text', nullable: true })
+  stackTrace: string | null;
+
+  /** Number of attempts made before landing in DLQ */
+  @Column({ type: 'int', default: 0 })
+  attemptsMade: number;
+
+  @Index()
+  @Column({
+    type: 'enum',
+    enum: DlqJobStatus,
+    default: DlqJobStatus.FAILED,
+  })
+  status: DlqJobStatus;
+
+  /** How many times this DLQ entry has been replayed */
+  @Column({ type: 'int', default: 0 })
+  replayCount: number;
+
+  /** Who triggered the last replay */
+  @Column({ type: 'varchar', length: 256, nullable: true })
+  replayedBy: string | null;
+
+  @CreateDateColumn()
+  failedAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/dlq/dlq.controller.ts
+++ b/src/dlq/dlq.controller.ts
@@ -1,0 +1,100 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Query,
+  UseGuards,
+  Req,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery, ApiParam } from '@nestjs/swagger';
+import { Request } from 'express';
+import { DlqService, DlqListOptions } from './dlq.service';
+import { DlqJobStatus } from './dlq-job.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+
+@ApiTags('admin/dlq')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('admin/dlq')
+export class DlqController {
+  constructor(private readonly dlqService: DlqService) {}
+
+  // ── Stats ─────────────────────────────────────────────────────────────────
+
+  @Get('stats')
+  @ApiOperation({ summary: 'DLQ stats grouped by queue and status' })
+  stats() {
+    return this.dlqService.stats();
+  }
+
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  @Get()
+  @ApiOperation({ summary: 'List DLQ entries with optional filters' })
+  @ApiQuery({ name: 'queueName', required: false })
+  @ApiQuery({ name: 'status', required: false, enum: DlqJobStatus })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  list(
+    @Query('queueName') queueName?: string,
+    @Query('status') status?: DlqJobStatus,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    const opts: DlqListOptions = {
+      queueName,
+      status,
+      limit: limit ? parseInt(limit, 10) : undefined,
+      offset: offset ? parseInt(offset, 10) : undefined,
+    };
+    return this.dlqService.list(opts);
+  }
+
+  // ── Single entry ──────────────────────────────────────────────────────────
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single DLQ entry by UUID' })
+  @ApiParam({ name: 'id', type: String })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.dlqService.findOne(id);
+  }
+
+  // ── Replay single ─────────────────────────────────────────────────────────
+
+  @Post(':id/replay')
+  @ApiOperation({ summary: 'Replay a single DLQ entry back into its queue' })
+  @ApiParam({ name: 'id', type: String })
+  replay(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
+    const actor = (req as any).user?.email ?? (req as any).user?.id ?? 'unknown';
+    return this.dlqService.replay(id, actor);
+  }
+
+  // ── Replay all ────────────────────────────────────────────────────────────
+
+  @Post('replay-all')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Replay all failed DLQ entries (optionally filtered by queue)' })
+  @ApiQuery({ name: 'queueName', required: false })
+  replayAll(@Query('queueName') queueName?: string, @Req() req?: Request) {
+    const actor = (req as any)?.user?.email ?? 'system';
+    return this.dlqService.replayAll(queueName, actor);
+  }
+
+  // ── Discard ───────────────────────────────────────────────────────────────
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Discard a DLQ entry (marks as discarded, no replay)' })
+  @ApiParam({ name: 'id', type: String })
+  discard(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
+    const actor = (req as any).user?.email ?? (req as any).user?.id ?? 'unknown';
+    return this.dlqService.discard(id, actor);
+  }
+}

--- a/src/dlq/dlq.module.ts
+++ b/src/dlq/dlq.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bullmq';
+import { DlqJobEntity } from './dlq-job.entity';
+import { DlqService } from './dlq.service';
+import { DlqController } from './dlq.controller';
+import { DlqCaptureListener } from './dlq-capture.listener';
+import { QUEUE_NAMES } from '../queues/queue.constants';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([DlqJobEntity]),
+    // Inject all queues so DlqService and DlqCaptureListener can re-enqueue jobs
+    BullModule.registerQueue(
+      { name: QUEUE_NAMES.STELLAR_TRANSACTIONS },
+      { name: QUEUE_NAMES.CONTRACT_WRITES },
+      { name: QUEUE_NAMES.IPFS_UPLOADS },
+      { name: QUEUE_NAMES.EVENT_INDEXING },
+      { name: QUEUE_NAMES.EMAIL_NOTIFICATIONS },
+      { name: QUEUE_NAMES.REPORTS },
+      { name: QUEUE_NAMES.EHR_IMPORT },
+    ),
+  ],
+  controllers: [DlqController],
+  providers: [DlqService, DlqCaptureListener],
+  exports: [DlqService],
+})
+export class DlqModule {}

--- a/src/dlq/dlq.service.ts
+++ b/src/dlq/dlq.service.ts
@@ -1,0 +1,214 @@
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, FindManyOptions } from 'typeorm';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { DlqJobEntity, DlqJobStatus } from './dlq-job.entity';
+import { QUEUE_NAMES } from '../queues/queue.constants';
+
+export interface DlqListOptions {
+  queueName?: string;
+  status?: DlqJobStatus;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ReplayResult {
+  dlqId: string;
+  jobId: string;
+  queueName: string;
+  newBullJobId: string | undefined;
+}
+
+@Injectable()
+export class DlqService {
+  private readonly logger = new Logger(DlqService.name);
+
+  /** Map queue name → injected BullMQ Queue instance */
+  private readonly queues: Map<string, Queue>;
+
+  constructor(
+    @InjectRepository(DlqJobEntity)
+    private readonly repo: Repository<DlqJobEntity>,
+
+    @InjectQueue(QUEUE_NAMES.STELLAR_TRANSACTIONS)
+    private readonly stellarQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.CONTRACT_WRITES)
+    private readonly contractWritesQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.IPFS_UPLOADS)
+    private readonly ipfsQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EVENT_INDEXING)
+    private readonly eventIndexingQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EMAIL_NOTIFICATIONS)
+    private readonly emailQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.REPORTS)
+    private readonly reportsQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EHR_IMPORT)
+    private readonly ehrImportQueue: Queue,
+  ) {
+    this.queues = new Map([
+      [QUEUE_NAMES.STELLAR_TRANSACTIONS, this.stellarQueue],
+      [QUEUE_NAMES.CONTRACT_WRITES, this.contractWritesQueue],
+      [QUEUE_NAMES.IPFS_UPLOADS, this.ipfsQueue],
+      [QUEUE_NAMES.EVENT_INDEXING, this.eventIndexingQueue],
+      [QUEUE_NAMES.EMAIL_NOTIFICATIONS, this.emailQueue],
+      [QUEUE_NAMES.REPORTS, this.reportsQueue],
+      [QUEUE_NAMES.EHR_IMPORT, this.ehrImportQueue],
+    ]);
+  }
+
+  // ── Capture ──────────────────────────────────────────────────────────────
+
+  /**
+   * Called by the QueueEventsListener when a job exhausts all retries.
+   * Persists the failed job to the dlq_jobs table.
+   */
+  async capture(params: {
+    jobId: string;
+    queueName: string;
+    jobName: string;
+    data: Record<string, any>;
+    opts: Record<string, any>;
+    failedReason: string;
+    stackTrace?: string;
+    attemptsMade: number;
+  }): Promise<DlqJobEntity> {
+    const entity = this.repo.create({
+      jobId: params.jobId,
+      queueName: params.queueName,
+      jobName: params.jobName,
+      data: params.data,
+      opts: params.opts,
+      failedReason: params.failedReason,
+      stackTrace: params.stackTrace ?? null,
+      attemptsMade: params.attemptsMade,
+      status: DlqJobStatus.FAILED,
+    });
+
+    const saved = await this.repo.save(entity);
+    this.logger.warn(`[DLQ] Captured failed job ${params.jobId} from queue=${params.queueName}`);
+    return saved;
+  }
+
+  // ── Query ─────────────────────────────────────────────────────────────────
+
+  async list(opts: DlqListOptions = {}): Promise<{ items: DlqJobEntity[]; total: number }> {
+    const where: FindManyOptions<DlqJobEntity>['where'] = {};
+    if (opts.queueName) (where as any).queueName = opts.queueName;
+    if (opts.status) (where as any).status = opts.status;
+
+    const [items, total] = await this.repo.findAndCount({
+      where,
+      order: { failedAt: 'DESC' },
+      take: opts.limit ?? 50,
+      skip: opts.offset ?? 0,
+    });
+
+    return { items, total };
+  }
+
+  async findOne(id: string): Promise<DlqJobEntity> {
+    const entity = await this.repo.findOne({ where: { id } });
+    if (!entity) throw new NotFoundException(`DLQ job ${id} not found`);
+    return entity;
+  }
+
+  // ── Replay ────────────────────────────────────────────────────────────────
+
+  /**
+   * Re-enqueue a single DLQ entry back into its original queue.
+   */
+  async replay(id: string, replayedBy: string): Promise<ReplayResult> {
+    const entity = await this.findOne(id);
+
+    if (entity.status === DlqJobStatus.DISCARDED) {
+      throw new BadRequestException(`DLQ job ${id} has been discarded and cannot be replayed`);
+    }
+
+    const queue = this.queues.get(entity.queueName);
+    if (!queue) {
+      throw new BadRequestException(`No queue registered for '${entity.queueName}'`);
+    }
+
+    const newJob = await queue.add(entity.jobName, entity.data, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 2000 },
+      removeOnComplete: true,
+      removeOnFail: false,
+    });
+
+    await this.repo.update(id, {
+      status: DlqJobStatus.REPLAYED,
+      replayCount: entity.replayCount + 1,
+      replayedBy,
+    });
+
+    this.logger.log(
+      `[DLQ] Replayed job ${entity.jobId} → new BullMQ job ${newJob.id} (queue=${entity.queueName}, by=${replayedBy})`,
+    );
+
+    return {
+      dlqId: id,
+      jobId: entity.jobId,
+      queueName: entity.queueName,
+      newBullJobId: newJob.id,
+    };
+  }
+
+  /**
+   * Replay all failed entries for a given queue (or all queues if omitted).
+   */
+  async replayAll(queueName?: string, replayedBy = 'system'): Promise<ReplayResult[]> {
+    const { items } = await this.list({
+      queueName,
+      status: DlqJobStatus.FAILED,
+      limit: 500,
+    });
+
+    const results: ReplayResult[] = [];
+    for (const item of items) {
+      try {
+        const result = await this.replay(item.id, replayedBy);
+        results.push(result);
+      } catch (err) {
+        this.logger.error(`[DLQ] Failed to replay ${item.id}: ${(err as Error).message}`);
+      }
+    }
+
+    return results;
+  }
+
+  // ── Discard ───────────────────────────────────────────────────────────────
+
+  async discard(id: string, discardedBy: string): Promise<DlqJobEntity> {
+    const entity = await this.findOne(id);
+    await this.repo.update(id, {
+      status: DlqJobStatus.DISCARDED,
+      replayedBy: discardedBy,
+    });
+    this.logger.log(`[DLQ] Discarded job ${entity.jobId} by ${discardedBy}`);
+    return { ...entity, status: DlqJobStatus.DISCARDED };
+  }
+
+  // ── Stats ─────────────────────────────────────────────────────────────────
+
+  async stats(): Promise<Record<string, { failed: number; replayed: number; discarded: number }>> {
+    const rows = await this.repo
+      .createQueryBuilder('d')
+      .select('d.queueName', 'queueName')
+      .addSelect('d.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('d.queueName')
+      .addGroupBy('d.status')
+      .getRawMany<{ queueName: string; status: DlqJobStatus; count: string }>();
+
+    const result: Record<string, { failed: number; replayed: number; discarded: number }> = {};
+    for (const row of rows) {
+      if (!result[row.queueName]) {
+        result[row.queueName] = { failed: 0, replayed: 0, discarded: 0 };
+      }
+      result[row.queueName][row.status] = parseInt(row.count, 10);
+    }
+    return result;
+  }
+}

--- a/src/idempotency/idempotency.entity.ts
+++ b/src/idempotency/idempotency.entity.ts
@@ -1,0 +1,36 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * Stores HTTP idempotency key → response mappings for mutating endpoints.
+ * Keyed by `<tenantId>:<userId>:<Idempotency-Key header>` to prevent
+ * cross-tenant/cross-user collisions.
+ */
+@Entity('http_idempotency_keys')
+export class HttpIdempotencyEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Composite key: tenantId:userId:clientKey */
+  @Index({ unique: true })
+  @Column({ type: 'varchar', length: 512 })
+  key: string;
+
+  /** HTTP status code of the original response */
+  @Column({ type: 'int' })
+  statusCode: number;
+
+  /** Serialised response body */
+  @Column({ type: 'jsonb' })
+  body: Record<string, any>;
+
+  /** Response headers to replay (content-type, location, etc.) */
+  @Column({ type: 'jsonb', default: '{}' })
+  headers: Record<string, string>;
+
+  /** Request fingerprint (method + path) for mismatch detection */
+  @Column({ type: 'varchar', length: 512 })
+  requestFingerprint: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/idempotency/idempotency.interceptor.ts
+++ b/src/idempotency/idempotency.interceptor.ts
@@ -1,0 +1,116 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  ConflictException,
+  UnprocessableEntityException,
+  Logger,
+} from '@nestjs/common';
+import { Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { HttpIdempotencyEntity } from './idempotency.entity';
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const IDEMPOTENCY_HEADER = 'idempotency-key';
+/** Keys expire after 24 hours */
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(IdempotencyInterceptor.name);
+
+  constructor(
+    @InjectRepository(HttpIdempotencyEntity)
+    private readonly repo: Repository<HttpIdempotencyEntity>,
+  ) {}
+
+  async intercept(ctx: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
+    const req = ctx.switchToHttp().getRequest();
+    const res = ctx.switchToHttp().getResponse();
+
+    // Only apply to mutating HTTP methods
+    if (!MUTATING_METHODS.has(req.method)) {
+      return next.handle();
+    }
+
+    const clientKey = req.headers[IDEMPOTENCY_HEADER] as string | undefined;
+    if (!clientKey) {
+      return next.handle();
+    }
+
+    if (clientKey.length > 256) {
+      throw new UnprocessableEntityException('Idempotency-Key must be 256 characters or fewer');
+    }
+
+    const tenantId: string = req.headers['x-tenant-id'] ?? 'global';
+    const userId: string = (req as any).user?.id ?? 'anonymous';
+    const compositeKey = `${tenantId}:${userId}:${clientKey}`;
+    const fingerprint = `${req.method}:${req.path}`;
+
+    // Look up existing record (within TTL)
+    const cutoff = new Date(Date.now() - TTL_MS);
+    const existing = await this.repo.findOne({
+      where: { key: compositeKey },
+    });
+
+    if (existing) {
+      // Expired — treat as new
+      if (existing.createdAt < cutoff) {
+        await this.repo.delete({ key: compositeKey });
+      } else {
+        // Fingerprint mismatch — different endpoint reusing the same key
+        if (existing.requestFingerprint !== fingerprint) {
+          throw new UnprocessableEntityException(
+            `Idempotency-Key '${clientKey}' was already used for ${existing.requestFingerprint}`,
+          );
+        }
+
+        this.logger.debug(`[Idempotency] Replaying cached response for key=${clientKey}`);
+
+        // Replay stored headers
+        for (const [name, value] of Object.entries(existing.headers)) {
+          res.setHeader(name, value);
+        }
+        res.setHeader('Idempotent-Replayed', 'true');
+        res.status(existing.statusCode);
+
+        return of(existing.body);
+      }
+    }
+
+    // Process the request and cache the response
+    return next.handle().pipe(
+      tap(async (body) => {
+        const statusCode: number = res.statusCode ?? 200;
+
+        // Capture a safe subset of response headers
+        const headers: Record<string, string> = {};
+        for (const name of ['content-type', 'location', 'x-resource-id']) {
+          const val = res.getHeader(name);
+          if (val) headers[name] = String(val);
+        }
+
+        try {
+          await this.repo.upsert(
+            {
+              key: compositeKey,
+              statusCode,
+              body: body ?? {},
+              headers,
+              requestFingerprint: fingerprint,
+            },
+            ['key'],
+          );
+        } catch (err) {
+          // Non-fatal — log and continue; the response has already been sent
+          this.logger.error(
+            `[Idempotency] Failed to persist key=${clientKey}: ${(err as Error).message}`,
+          );
+        }
+      }),
+    );
+  }
+}

--- a/src/idempotency/idempotency.module.ts
+++ b/src/idempotency/idempotency.module.ts
@@ -1,0 +1,12 @@
+import { Module, Global } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpIdempotencyEntity } from './idempotency.entity';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+
+@Global()
+@Module({
+  imports: [TypeOrmModule.forFeature([HttpIdempotencyEntity])],
+  providers: [IdempotencyInterceptor],
+  exports: [IdempotencyInterceptor],
+})
+export class IdempotencyModule {}

--- a/src/migrations/1775500000000-CreateHttpIdempotencyKeys.ts
+++ b/src/migrations/1775500000000-CreateHttpIdempotencyKeys.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateHttpIdempotencyKeys1775500000000 implements MigrationInterface {
+  name = 'CreateHttpIdempotencyKeys1775500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "http_idempotency_keys" (
+        "id"                   UUID         NOT NULL DEFAULT uuid_generate_v4(),
+        "key"                  VARCHAR(512) NOT NULL,
+        "status_code"          INTEGER      NOT NULL,
+        "body"                 JSONB        NOT NULL,
+        "headers"              JSONB        NOT NULL DEFAULT '{}',
+        "request_fingerprint"  VARCHAR(512) NOT NULL,
+        "created_at"           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+        CONSTRAINT "PK_http_idempotency_keys" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_http_idempotency_keys_key" UNIQUE ("key")
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_http_idempotency_keys_created_at"
+        ON "http_idempotency_keys" ("created_at");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "http_idempotency_keys";`);
+  }
+}

--- a/src/migrations/1775600000000-CreateDlqJobsTable.ts
+++ b/src/migrations/1775600000000-CreateDlqJobsTable.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateDlqJobsTable1775600000000 implements MigrationInterface {
+  name = 'CreateDlqJobsTable1775600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "dlq_jobs_status_enum" AS ENUM ('failed', 'replayed', 'discarded');
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "dlq_jobs" (
+        "id"             UUID         NOT NULL DEFAULT uuid_generate_v4(),
+        "job_id"         VARCHAR(256) NOT NULL,
+        "queue_name"     VARCHAR(128) NOT NULL,
+        "job_name"       VARCHAR(256) NOT NULL,
+        "data"           JSONB        NOT NULL,
+        "opts"           JSONB        NOT NULL DEFAULT '{}',
+        "failed_reason"  TEXT,
+        "stack_trace"    TEXT,
+        "attempts_made"  INTEGER      NOT NULL DEFAULT 0,
+        "status"         "dlq_jobs_status_enum" NOT NULL DEFAULT 'failed',
+        "replay_count"   INTEGER      NOT NULL DEFAULT 0,
+        "replayed_by"    VARCHAR(256),
+        "failed_at"      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+        "updated_at"     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+        CONSTRAINT "PK_dlq_jobs" PRIMARY KEY ("id")
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_dlq_jobs_queue_name"
+        ON "dlq_jobs" ("queue_name");
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_dlq_jobs_status"
+        ON "dlq_jobs" ("status");
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_dlq_jobs_job_id"
+        ON "dlq_jobs" ("job_id");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "dlq_jobs";`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "dlq_jobs_status_enum";`);
+  }
+}


### PR DESCRIPTION
Adds two reliability primitives to the backend: safe replay of mutating HTTP endpoints via idempotency keys, and a persistent dead letter queue with a full replay/discard workflow for failed background jobs.

Idempotency Keys for Mutating Endpoints

Introduces a global IdempotencyInterceptor that intercepts all POST, PUT, PATCH, and DELETE requests. When a client sends an Idempotency-Key header, the first response is stored in a new http_idempotency_keys table and replayed verbatim on any duplicate request within a 24-hour window. Keys are namespaced as tenantId:userId:clientKey to prevent cross-tenant and cross-user collisions. Requests that reuse a key against a different endpoint are rejected with 422. The interceptor is registered globally so all mutating routes get coverage with zero per-controller changes.

New files: 
idempotency.entity.ts
, idempotency.interceptor.ts, idempotency.module.ts Migration: 1775500000000-CreateHttpIdempotencyKeys

Dead Letter Queue & Replay Workflow

Adds a persistent DLQ layer on top of BullMQ. A DlqCaptureListener subscribes to QueueEvents for all 7 registered queues and automatically writes any job that exhausts all retries to a dlq_jobs Postgres table — surviving Redis flushes and restarts. Each entry tracks the original payload, failure reason, stack trace, attempt count, replay history, and the actor who triggered replays or discards.

A new DlqController under admin/dlq (JWT + admin role) exposes:

GET /stats — per-queue breakdown by status
GET / — paginated list with queue and status filters
GET /:id — single entry detail
POST /:id/replay — re-enqueues one job with fresh retry budget
POST /replay-all — bulk replay, optionally scoped to one queue
DELETE /:id — marks a job as discarded
New files: 
dlq-job.entity.ts
, dlq.service.ts, dlq.controller.ts, dlq-capture.listener.ts, dlq.module.ts Migration: 1775600000000-CreateDlqJobsTable

What changed in existing files

app.module.ts — imports IdempotencyModule and DlqModule, registers IdempotencyInterceptor as a global APP_INTERCEPTOR.

How to test manually

Run both new migrations.
Send a POST with Idempotency-Key: test-123 — second identical request returns the cached response with Idempotent-Replayed: true.
Trigger a job that fails all retries — confirm a row appears in dlq_jobs.
POST /admin/dlq/:id/replay — confirm the job re-enters its queue





closes #411

closes #413