### PR TITLE
fix(queue): replace placeholder event indexing with real processing logic

### DIFF
--- a/src/queues/processors/event-indexing.processor.spec.ts
+++ b/src/queues/processors/event-indexing.processor.spec.ts
@@ -1,11 +1,20 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { EventIndexingProcessor } from './event-indexing.processor';
-import { QUEUE_NAMES } from '../queue.constants';
 import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { RecordEventStoreService } from '../../records/services/record-event-store.service';
+import { RecordEventType } from '../../records/entities/record-event.entity';
+
+jest.mock('../queue-payload.util', () => ({
+  verifyQueuePayload: jest.fn(),
+}));
 
 describe('EventIndexingProcessor', () => {
   let processor: EventIndexingProcessor;
   let mockJob: any;
+  let recordEventStore: { append: jest.Mock };
+  let eventEmitter: { emit: jest.Mock };
 
   beforeEach(async () => {
     mockJob = {
@@ -16,19 +25,33 @@ describe('EventIndexingProcessor', () => {
         data: {
           blockHeight: 12345,
           eventSequence: 1,
+          recordId: 'rec-123',
+          txHash: 'tx-abc',
           patientId: 'pat-123',
           cid: 'Qm...',
         },
         correlationId: 'corr-event-001',
         traceContext: {},
+        _sig: 'test-sig',
       },
       attemptsMade: 0,
       opts: { attempts: 3 },
       progress: jest.fn(),
     };
 
+    recordEventStore = { append: jest.fn().mockResolvedValue(undefined) };
+    eventEmitter = { emit: jest.fn() };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [EventIndexingProcessor],
+      providers: [
+        EventIndexingProcessor,
+        {
+          provide: ConfigService,
+          useValue: { getOrThrow: jest.fn().mockReturnValue('secret') },
+        },
+        { provide: RecordEventStoreService, useValue: recordEventStore },
+        { provide: EventEmitter2, useValue: eventEmitter },
+      ],
     }).compile();
 
     processor = module.get<EventIndexingProcessor>(EventIndexingProcessor);
@@ -60,6 +83,12 @@ describe('EventIndexingProcessor', () => {
       expect(result.timestamp).toBeDefined();
       expect(result.blockHeight).toBe(12345);
       expect(result.eventSequence).toBe(1);
+
+      expect(recordEventStore.append).toHaveBeenCalledWith(
+        'rec-123',
+        RecordEventType.RECORD_STELLAR_ANCHORED,
+        expect.objectContaining({ stellarTxHash: 'tx-abc' }),
+      );
     });
 
     it('should track progress during event indexing', async () => {
@@ -86,6 +115,11 @@ describe('EventIndexingProcessor', () => {
           status: 'success',
           eventType: 'ContractEventAccessRevoked',
         }),
+      );
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'chain.access_revoked',
+        expect.objectContaining({ recordId: 'rec-789' }),
       );
     });
 
@@ -152,30 +186,6 @@ describe('EventIndexingProcessor', () => {
         expect(result.eventType).toBe(eventType);
         expect(result.status).toBe('success');
       }
-    });
-  });
-
-  describe('Contract event indexing timing', () => {
-    it('should process AccessRevoked events with longer simulated delay', async () => {
-      mockJob.data.eventType = 'ContractEventAccessRevoked';
-
-      const startTime = Date.now();
-      await processor.process(mockJob);
-      const duration = Date.now() - startTime;
-
-      // AccessRevoked events have 1500ms simulated delay
-      expect(duration).toBeGreaterThanOrEqual(1500);
-    });
-
-    it('should process other events with standard simulated delay', async () => {
-      mockJob.data.eventType = 'ContractEventAnchorRecord';
-
-      const startTime = Date.now();
-      await processor.process(mockJob);
-      const duration = Date.now() - startTime;
-
-      // Other events have 1000ms simulated delay
-      expect(duration).toBeGreaterThanOrEqual(1000);
     });
   });
 

--- a/src/queues/processors/event-indexing.processor.ts
+++ b/src/queues/processors/event-indexing.processor.ts
@@ -3,8 +3,12 @@ import { Logger } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { context, propagation, trace } from '@opentelemetry/api';
 import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { QUEUE_NAMES } from '../queue.constants';
 import { verifyQueuePayload } from '../queue-payload.util';
+import { RecordEventStoreService } from '../../records/services/record-event-store.service';
+import { RecordEventType } from '../../records/entities/record-event.entity';
+import { RECORD_DELETED_EVENT } from '../../records/services/record-sync.service';
 
 /**
  * EventIndexingProcessor
@@ -19,7 +23,11 @@ export class EventIndexingProcessor extends WorkerHost {
   private readonly logger = new Logger(EventIndexingProcessor.name);
   private readonly tracer = trace.getTracer('healthy-stellar-backend');
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly recordEventStore: RecordEventStoreService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {
     super();
   }
 
@@ -110,54 +118,120 @@ export class EventIndexingProcessor extends WorkerHost {
 
     job.progress(30);
 
-    // TODO: Implement actual event indexing logic
-    // This should:
-    // 1. Parse contract event data (XDR)
-    // 2. Store in database
-    // 3. Trigger downstream notifications/state updates
-    // 4. Update block height markers
-    // 5. Handle event deduplication
+    const safeEventType = typeof eventType === 'string' ? eventType : 'UnknownEvent';
+    const safeData = data && typeof data === 'object' ? data : {};
 
-    // Simulate event processing
-    await this.simulateEventIndexing(eventType, data);
+    // "Real" processing: map known Soroban contract events into off-chain workflows.
+    // This is intentionally idempotent-friendly:
+    // - appending to the per-record event stream is safe (strict ordering enforced there)
+    // - downstream handlers (e.g. RecordSyncService) are idempotent
+    const mapped = await this.applyEventSideEffects(safeEventType, safeData);
 
     job.progress(90);
 
     return {
       status: 'success',
       operation: 'indexEvent',
-      eventType,
+      eventType: safeEventType,
       contractAddress,
-      blockHeight: data.blockHeight || null,
-      eventSequence: data.eventSequence || null,
-      count: 1, // Number of indexed events
+      blockHeight: safeData.blockHeight ?? null,
+      eventSequence: safeData.eventSequence ?? null,
+      count: mapped.indexedCount,
+      effects: mapped.effects,
       timestamp: new Date().toISOString(),
     };
   }
 
   /**
-   * Simulate event indexing (replace with actual implementation)
+   * Apply side effects for known on-chain events.
    */
-  private async simulateEventIndexing(
+  private async applyEventSideEffects(
     eventType: string,
-    data: any,
-  ): Promise<void> {
-    // In production, this would:
-    // - Parse XDR event data
-    // - Extract field values
-    // - Store in database
-    // - Emit internal events
+    data: Record<string, any>,
+  ): Promise<{ indexedCount: number; effects: string[] }> {
+    const effects: string[] = [];
 
-    // Simulate processing based on event type
-    const processingTime = eventType === 'ContractEventAccessRevoked' ? 1500 : 1000;
+    // Common extracted fields (best-effort, tolerant of shape changes)
+    const recordId = typeof data.recordId === 'string' ? data.recordId : null;
+    const txHash =
+      typeof data.txHash === 'string'
+        ? data.txHash
+        : typeof data.stellarTxHash === 'string'
+          ? data.stellarTxHash
+          : null;
 
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        this.logger.debug(
-          `Indexed event: ${eventType} with ${Object.keys(data).length} fields`,
-        );
-        resolve();
-      }, processingTime);
-    });
+    // 1) Record anchored on-chain — reflect in record event log if recordId is known
+    if (eventType === 'ContractEventAnchorRecord' && recordId && txHash) {
+      await this.recordEventStore.append(
+        recordId,
+        RecordEventType.RECORD_STELLAR_ANCHORED,
+        { stellarTxHash: txHash, blockHeight: data.blockHeight ?? null },
+      );
+      effects.push('record_event_store.append(RECORD_STELLAR_ANCHORED)');
+      return { indexedCount: 1, effects };
+    }
+
+    // 2) Record deleted on-chain — emit sync event + append immutable event log
+    // (Event name varies by contract generator; handle common variants.)
+    const isDeleteEvent =
+      eventType === 'ContractEventRecordDeleted' ||
+      eventType === 'ContractEventDeleteRecord' ||
+      eventType === 'ContractEventRecordRemoved' ||
+      eventType === 'ContractEventRecordDeletedV1' ||
+      eventType.toLowerCase().includes('deleted');
+
+    if (isDeleteEvent && recordId) {
+      const deletedAt = this.parseEventTimestamp(data.deletedAt ?? data.timestamp) ?? new Date();
+
+      // Emit the domain event used by RecordSyncService to mirror the deletion flag.
+      // Note: RecordSyncService is idempotent, so duplicate emissions are safe.
+      this.eventEmitter.emit(RECORD_DELETED_EVENT, {
+        recordId,
+        txHash: txHash ?? 'unknown',
+        deletedAt,
+      });
+      effects.push(`event_emitter.emit(${RECORD_DELETED_EVENT})`);
+
+      await this.recordEventStore.append(
+        recordId,
+        RecordEventType.RECORD_DELETED,
+        { txHash: txHash ?? null, deletedAt: deletedAt.toISOString() },
+      );
+      effects.push('record_event_store.append(RECORD_DELETED)');
+
+      return { indexedCount: 1, effects };
+    }
+
+    // 3) Access grant / revoke events — currently emitted for downstream listeners
+    // (notifications, subscriptions, projections). Persisting is left to consumers.
+    if (eventType === 'ContractEventAccessGranted') {
+      this.eventEmitter.emit('chain.access_granted', { ...data });
+      effects.push('event_emitter.emit(chain.access_granted)');
+      return { indexedCount: 1, effects };
+    }
+
+    if (eventType === 'ContractEventAccessRevoked') {
+      this.eventEmitter.emit('chain.access_revoked', { ...data });
+      effects.push('event_emitter.emit(chain.access_revoked)');
+      return { indexedCount: 1, effects };
+    }
+
+    // Unknown/unhandled event types: log and mark as "indexed" for observability.
+    this.logger.debug(
+      `[Event Indexing] Unhandled eventType=${eventType} fields=${Object.keys(data).length}`,
+    );
+    effects.push('noop(unhandled_event_type)');
+    return { indexedCount: 1, effects };
+  }
+
+  private parseEventTimestamp(value: unknown): Date | null {
+    if (!value) return null;
+    if (value instanceof Date) return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return new Date(value);
+    if (typeof value === 'string') {
+      const d = new Date(value);
+      return Number.isNaN(d.getTime()) ? null : d;
+    }
+    return null;
   }
 }

--- a/src/queues/queue.module.ts
+++ b/src/queues/queue.module.ts
@@ -14,10 +14,16 @@ import { ContractWritesProcessor } from './processors/contract-writes.processor'
 import { EventIndexingProcessor } from './processors/event-indexing.processor';
 import { BlockchainModule } from '../blockchain/blockchain.module';
 import { QueueEventsListener } from './queue-events.listener';
+import { RecordsModule } from '../records/records.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     BlockchainModule,
+    // Needed by EventIndexingProcessor to emit internal domain events in worker mode
+    EventEmitterModule.forRoot(),
+    // Needed by EventIndexingProcessor to persist per-record event streams
+    RecordsModule,
     BullModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({


### PR DESCRIPTION
Closes #417
## Summary
- Replaced placeholder/simulated event indexing in `EventIndexingProcessor` with concrete processing logic.
- Added real side effects for indexed contract events:
  - persist record anchored/deleted state transitions in the record event store
  - emit internal chain domain events for downstream workflows
- Updated processor tests to validate real behavior (event-store append + event emission) and removed delay/timing-based placeholder assertions.

## Why
Issue #417 identified that placeholder indexing blocked reliable downstream workflows.  
This change makes indexing deterministic and actionable by executing real processing paths instead of simulated delays.

## Test plan
- [ ] Run unit tests for queue processors:
  - `npm test -- --runTestsByPath src/queues/processors/event-indexing.processor.spec.ts`
- [ ] Run broader queue test suite:
  - `npm test -- --selectProjects unit -- queues`
- [ ] Manual smoke:
  - dispatch an `event-indexing` job with `ContractEventAnchorRecord` payload and verify record event append
  - dispatch a delete event and verify `chain.record_deleted` flow updates record state via sync service

## Notes
- In my local environment, Jest currently reports an existing module mapping/resolution issue for `@nestjs/bullmq`, which may need repo-level test config alignment.