### PR TITLE
feat(#458): add Operator Runbook APIs for safe recovery actions

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -70,6 +70,7 @@ import { WebhooksModule } from './webhooks/webhooks.module';
 import { IdempotencyModule } from './idempotency/idempotency.module';
 import { IdempotencyInterceptor } from './idempotency/idempotency.interceptor';
 import { DlqModule } from './dlq/dlq.module';
+import { OperatorRunbookModule } from './operator-runbook/operator-runbook.module';
 
 @Module({
   imports: [
@@ -147,6 +148,7 @@ import { DlqModule } from './dlq/dlq.module';
     WebhooksModule,
     IdempotencyModule,
     DlqModule,
+    OperatorRunbookModule,
     EventEmitterModule.forRoot(),
  main
   ],

--- a/src/migrations/1775700000000-CreateOperatorRunbookTables.ts
+++ b/src/migrations/1775700000000-CreateOperatorRunbookTables.ts
@@ -1,0 +1,127 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateOperatorRunbookTables1775700000000 implements MigrationInterface {
+  name = 'CreateOperatorRunbookTables1775700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Enums
+    await queryRunner.query(`
+      CREATE TYPE "operator_runbooks_category_enum" AS ENUM (
+        'database_recovery',
+        'service_restart',
+        'data_correction',
+        'tenant_recovery',
+        'queue_drain',
+        'cache_flush',
+        'security_incident',
+        'general'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "operator_runbooks_status_enum" AS ENUM (
+        'draft',
+        'active',
+        'deprecated',
+        'archived'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "runbook_executions_status_enum" AS ENUM (
+        'pending_approval',
+        'approved',
+        'in_progress',
+        'completed',
+        'failed',
+        'rolled_back',
+        'cancelled'
+      )
+    `);
+
+    // operator_runbooks table
+    await queryRunner.query(`
+      CREATE TABLE "operator_runbooks" (
+        "id"                    UUID NOT NULL DEFAULT uuid_generate_v4(),
+        "name"                  VARCHAR(255) NOT NULL,
+        "description"           TEXT NOT NULL,
+        "category"              "operator_runbooks_category_enum" NOT NULL DEFAULT 'general',
+        "status"                "operator_runbooks_status_enum" NOT NULL DEFAULT 'draft',
+        "steps"                 JSONB NOT NULL,
+        "version"               VARCHAR(50) NOT NULL DEFAULT '1.0.0',
+        "createdBy"             UUID NOT NULL,
+        "updatedBy"             UUID,
+        "rollbackProcedure"     TEXT,
+        "requiredRoles"         JSONB,
+        "requiresDualApproval"  BOOLEAN NOT NULL DEFAULT false,
+        "tags"                  JSONB,
+        "metadata"              JSONB,
+        "createdAt"             TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt"             TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_operator_runbooks" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_operator_runbooks_category_status"
+        ON "operator_runbooks" ("category", "status")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_operator_runbooks_createdBy_createdAt"
+        ON "operator_runbooks" ("createdBy", "createdAt")
+    `);
+
+    // runbook_executions table
+    await queryRunner.query(`
+      CREATE TABLE "runbook_executions" (
+        "id"                UUID NOT NULL DEFAULT uuid_generate_v4(),
+        "runbookId"         UUID NOT NULL,
+        "status"            "runbook_executions_status_enum" NOT NULL DEFAULT 'pending_approval',
+        "initiatedBy"       UUID NOT NULL,
+        "executedBy"        UUID,
+        "approvedBy"        UUID,
+        "secondApprovalBy"  UUID,
+        "approvedAt"        TIMESTAMP,
+        "startedAt"         TIMESTAMP,
+        "completedAt"       TIMESTAMP,
+        "stepResults"       JSONB,
+        "reason"            TEXT,
+        "notes"             TEXT,
+        "context"           JSONB,
+        "errorMessage"      TEXT,
+        "dryRun"            BOOLEAN NOT NULL DEFAULT false,
+        "ipAddress"         VARCHAR(50),
+        "userAgent"         TEXT,
+        "createdAt"         TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt"         TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_runbook_executions" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_runbook_executions_runbook"
+          FOREIGN KEY ("runbookId") REFERENCES "operator_runbooks"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_runbook_executions_runbookId_createdAt"
+        ON "runbook_executions" ("runbookId", "createdAt")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_runbook_executions_status_createdAt"
+        ON "runbook_executions" ("status", "createdAt")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_runbook_executions_executedBy_createdAt"
+        ON "runbook_executions" ("executedBy", "createdAt")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "runbook_executions"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "operator_runbooks"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "runbook_executions_status_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "operator_runbooks_status_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "operator_runbooks_category_enum"`);
+  }
+}

--- a/src/operator-runbook/controllers/runbook.controller.ts
+++ b/src/operator-runbook/controllers/runbook.controller.ts
@@ -1,0 +1,243 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { RunbookService } from '../services/runbook.service';
+import {
+  ApproveExecutionDto,
+  CancelExecutionDto,
+  CompleteExecutionDto,
+  CreateRunbookDto,
+  InitiateExecutionDto,
+  RecordStepResultDto,
+  RunbookQueryDto,
+  UpdateRunbookDto,
+} from '../dto/runbook.dto';
+import { RunbookCategory, RunbookStatus } from '../entities/runbook.entity';
+import { RequireAdmin } from '../../rbac/decorators/policy.decorator';
+import { HipaaRoles } from '../../rbac/hipaa.decorators';
+
+@ApiTags('Operator Runbooks')
+@Controller('operator/runbooks')
+export class RunbookController {
+  constructor(private readonly runbookService: RunbookService) {}
+
+  // ─── Runbook management ───────────────────────────────────────────────────
+
+  @Post()
+  @RequireAdmin()
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Create a new operator runbook' })
+  @ApiResponse({ status: 201, description: 'Runbook created' })
+  async createRunbook(@Body() dto: CreateRunbookDto, @Req() req: Request) {
+    const operatorId = (req as any).user?.sub;
+    return this.runbookService.createRunbook(dto, operatorId);
+  }
+
+  @Get()
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'List runbooks with optional filters' })
+  @ApiQuery({ name: 'category', enum: RunbookCategory, required: false })
+  @ApiQuery({ name: 'status', enum: RunbookStatus, required: false })
+  @ApiQuery({ name: 'search', required: false })
+  async listRunbooks(@Query() query: RunbookQueryDto) {
+    return this.runbookService.listRunbooks(query);
+  }
+
+  @Get('executions/active')
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Get all active (in-flight) executions' })
+  async getActiveExecutions() {
+    return this.runbookService.getActiveExecutions();
+  }
+
+  @Get(':id')
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Get a runbook by ID' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async getRunbook(@Param('id', ParseUUIDPipe) id: string) {
+    return this.runbookService.getRunbook(id);
+  }
+
+  @Patch(':id')
+  @RequireAdmin()
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Update a runbook' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async updateRunbook(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateRunbookDto,
+    @Req() req: Request,
+  ) {
+    const operatorId = (req as any).user?.sub;
+    return this.runbookService.updateRunbook(id, dto, operatorId);
+  }
+
+  @Patch(':id/publish')
+  @RequireAdmin()
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Publish a draft runbook to make it executable' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async publishRunbook(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
+    const operatorId = (req as any).user?.sub;
+    return this.runbookService.publishRunbook(id, operatorId);
+  }
+
+  @Patch(':id/deprecate')
+  @RequireAdmin()
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Deprecate an active runbook' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  async deprecateRunbook(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
+    const operatorId = (req as any).user?.sub;
+    return this.runbookService.deprecateRunbook(id, operatorId);
+  }
+
+  // ─── Execution lifecycle ──────────────────────────────────────────────────
+
+  @Post(':id/executions')
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Initiate a new runbook execution' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiResponse({ status: 201, description: 'Execution initiated' })
+  async initiateExecution(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: InitiateExecutionDto,
+    @Req() req: Request,
+  ) {
+    const operatorId = (req as any).user?.sub;
+    const ipAddress = req.ip ?? req.socket?.remoteAddress ?? 'unknown';
+    const userAgent = req.get('User-Agent') ?? 'unknown';
+    return this.runbookService.initiateExecution(id, dto, operatorId, ipAddress, userAgent);
+  }
+
+  @Get(':id/executions')
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Get execution history for a runbook' })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  async getExecutionHistory(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('limit') limit?: number,
+  ) {
+    return this.runbookService.getExecutionHistory(id, limit ? Number(limit) : 20);
+  }
+
+  @Get(':runbookId/executions/:executionId')
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Get a specific execution' })
+  @ApiParam({ name: 'runbookId', type: 'string', format: 'uuid' })
+  @ApiParam({ name: 'executionId', type: 'string', format: 'uuid' })
+  async getExecution(@Param('executionId', ParseUUIDPipe) executionId: string) {
+    return this.runbookService.getExecution(executionId);
+  }
+
+  @Patch(':runbookId/executions/:executionId/approve')
+  @RequireAdmin()
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Approve a pending execution (supports dual-approval)' })
+  @ApiParam({ name: 'runbookId', type: 'string', format: 'uuid' })
+  @ApiParam({ name: 'executionId', type: 'string', format: 'uuid' })
+  async approveExecution(
+    @Param('executionId', ParseUUIDPipe) executionId: string,
+    @Body() dto: ApproveExecutionDto,
+    @Req() req: Request,
+  ) {
+    const approverId = (req as any).user?.sub;
+    return this.runbookService.approveExecution(executionId, dto, approverId);
+  }
+
+  @Patch(':runbookId/executions/:executionId/start')
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Start an approved execution' })
+  @ApiParam({ name: 'runbookId', type: 'string', format: 'uuid' })
+  @ApiParam({ name: 'executionId', type: 'string', format: 'uuid' })
+  async startExecution(
+    @Param('executionId', ParseUUIDPipe) executionId: string,
+    @Req() req: Request,
+  ) {
+    const operatorId = (req as any).user?.sub;
+    return this.runbookService.startExecution(executionId, operatorId);
+  }
+
+  @Post(':runbookId/executions/:executionId/steps')
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Record the result of a completed step' })
+  @ApiParam({ name: 'runbookId', type: 'string', format: 'uuid' })
+  @ApiParam({ name: 'executionId', type: 'string', format: 'uuid' })
+  async recordStepResult(
+    @Param('executionId', ParseUUIDPipe) executionId: string,
+    @Body() dto: RecordStepResultDto,
+    @Req() req: Request,
+  ) {
+    const operatorId = (req as any).user?.sub;
+    return this.runbookService.recordStepResult(executionId, dto, operatorId);
+  }
+
+  @Patch(':runbookId/executions/:executionId/complete')
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Mark an in-progress execution as completed' })
+  @ApiParam({ name: 'runbookId', type: 'string', format: 'uuid' })
+  @ApiParam({ name: 'executionId', type: 'string', format: 'uuid' })
+  async completeExecution(
+    @Param('executionId', ParseUUIDPipe) executionId: string,
+    @Body() dto: CompleteExecutionDto,
+    @Req() req: Request,
+  ) {
+    const operatorId = (req as any).user?.sub;
+    return this.runbookService.completeExecution(executionId, dto, operatorId);
+  }
+
+  @Patch(':runbookId/executions/:executionId/fail')
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Mark an in-progress execution as failed' })
+  @ApiParam({ name: 'runbookId', type: 'string', format: 'uuid' })
+  @ApiParam({ name: 'executionId', type: 'string', format: 'uuid' })
+  async failExecution(
+    @Param('executionId', ParseUUIDPipe) executionId: string,
+    @Body() body: { errorMessage: string },
+    @Req() req: Request,
+  ) {
+    const operatorId = (req as any).user?.sub;
+    return this.runbookService.failExecution(executionId, body.errorMessage, operatorId);
+  }
+
+  @Patch(':runbookId/executions/:executionId/rollback')
+  @RequireAdmin()
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Rollback an execution' })
+  @ApiParam({ name: 'runbookId', type: 'string', format: 'uuid' })
+  @ApiParam({ name: 'executionId', type: 'string', format: 'uuid' })
+  async rollbackExecution(
+    @Param('executionId', ParseUUIDPipe) executionId: string,
+    @Body() body: { notes?: string },
+    @Req() req: Request,
+  ) {
+    const operatorId = (req as any).user?.sub;
+    return this.runbookService.rollbackExecution(executionId, operatorId, body.notes);
+  }
+
+  @Patch(':runbookId/executions/:executionId/cancel')
+  @HipaaRoles('operator', 'admin')
+  @ApiOperation({ summary: 'Cancel a pending or approved execution' })
+  @ApiParam({ name: 'runbookId', type: 'string', format: 'uuid' })
+  @ApiParam({ name: 'executionId', type: 'string', format: 'uuid' })
+  async cancelExecution(
+    @Param('executionId', ParseUUIDPipe) executionId: string,
+    @Body() dto: CancelExecutionDto,
+    @Req() req: Request,
+  ) {
+    const operatorId = (req as any).user?.sub;
+    return this.runbookService.cancelExecution(executionId, dto, operatorId);
+  }
+}

--- a/src/operator-runbook/dto/runbook.dto.ts
+++ b/src/operator-runbook/dto/runbook.dto.ts
@@ -1,0 +1,247 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { RunbookCategory, RunbookStatus, RunbookStep } from '../entities/runbook.entity';
+
+export class RunbookStepDto implements Partial<RunbookStep> {
+  @ApiProperty()
+  @IsInt()
+  @Min(1)
+  stepNumber: number;
+
+  @ApiProperty()
+  @IsString()
+  title: string;
+
+  @ApiProperty()
+  @IsString()
+  description: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  command?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  expectedOutcome?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  rollbackCommand?: string;
+
+  @ApiProperty({ default: false })
+  @IsBoolean()
+  requiresConfirmation: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  timeoutSeconds?: number;
+}
+
+export class CreateRunbookDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty()
+  @IsString()
+  description: string;
+
+  @ApiProperty({ enum: RunbookCategory })
+  @IsEnum(RunbookCategory)
+  category: RunbookCategory;
+
+  @ApiProperty({ type: [RunbookStepDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => RunbookStepDto)
+  steps: RunbookStepDto[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  version?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  rollbackProcedure?: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  requiredRoles?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  requiresDualApproval?: boolean;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}
+
+export class UpdateRunbookDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ enum: RunbookCategory })
+  @IsOptional()
+  @IsEnum(RunbookCategory)
+  category?: RunbookCategory;
+
+  @ApiPropertyOptional({ enum: RunbookStatus })
+  @IsOptional()
+  @IsEnum(RunbookStatus)
+  status?: RunbookStatus;
+
+  @ApiPropertyOptional({ type: [RunbookStepDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => RunbookStepDto)
+  steps?: RunbookStepDto[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  version?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  rollbackProcedure?: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  requiredRoles?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  requiresDualApproval?: boolean;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}
+
+export class InitiateExecutionDto {
+  @ApiProperty({ description: 'Reason for executing this runbook' })
+  @IsString()
+  reason: string;
+
+  @ApiPropertyOptional({ description: 'Additional context or parameters for execution' })
+  @IsOptional()
+  @IsObject()
+  context?: Record<string, any>;
+
+  @ApiPropertyOptional({ description: 'Run in dry-run mode without applying changes', default: false })
+  @IsOptional()
+  @IsBoolean()
+  dryRun?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}
+
+export class ApproveExecutionDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}
+
+export class RecordStepResultDto {
+  @ApiProperty()
+  @IsInt()
+  @Min(1)
+  stepNumber: number;
+
+  @ApiProperty({ enum: ['success', 'failed', 'skipped'] })
+  @IsEnum(['success', 'failed', 'skipped'])
+  status: 'success' | 'failed' | 'skipped';
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  output?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  error?: string;
+}
+
+export class CompleteExecutionDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}
+
+export class CancelExecutionDto {
+  @ApiProperty()
+  @IsString()
+  reason: string;
+}
+
+export class RunbookQueryDto {
+  @ApiPropertyOptional({ enum: RunbookCategory })
+  @IsOptional()
+  @IsEnum(RunbookCategory)
+  category?: RunbookCategory;
+
+  @ApiPropertyOptional({ enum: RunbookStatus })
+  @IsOptional()
+  @IsEnum(RunbookStatus)
+  status?: RunbookStatus;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/src/operator-runbook/entities/runbook-execution.entity.ts
+++ b/src/operator-runbook/entities/runbook-execution.entity.ts
@@ -1,0 +1,101 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Runbook } from './runbook.entity';
+
+export enum ExecutionStatus {
+  PENDING_APPROVAL = 'pending_approval',
+  APPROVED = 'approved',
+  IN_PROGRESS = 'in_progress',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  ROLLED_BACK = 'rolled_back',
+  CANCELLED = 'cancelled',
+}
+
+export interface StepExecutionResult {
+  stepNumber: number;
+  status: 'success' | 'failed' | 'skipped';
+  output?: string;
+  error?: string;
+  startedAt: Date;
+  completedAt?: Date;
+  executedBy: string;
+}
+
+@Entity('runbook_executions')
+@Index(['runbookId', 'createdAt'])
+@Index(['status', 'createdAt'])
+@Index(['executedBy', 'createdAt'])
+export class RunbookExecution {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  runbookId: string;
+
+  @ManyToOne(() => Runbook, (runbook) => runbook.executions, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'runbookId' })
+  runbook: Runbook;
+
+  @Column({ type: 'enum', enum: ExecutionStatus, default: ExecutionStatus.PENDING_APPROVAL })
+  status: ExecutionStatus;
+
+  @Column({ type: 'uuid' })
+  initiatedBy: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  executedBy: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  approvedBy: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  secondApprovalBy: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  approvedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  startedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  completedAt: Date;
+
+  @Column({ type: 'jsonb', nullable: true })
+  stepResults: StepExecutionResult[];
+
+  @Column({ type: 'text', nullable: true })
+  reason: string;
+
+  @Column({ type: 'text', nullable: true })
+  notes: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  context: Record<string, any>;
+
+  @Column({ type: 'text', nullable: true })
+  errorMessage: string;
+
+  @Column({ type: 'boolean', default: false })
+  dryRun: boolean;
+
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  ipAddress: string;
+
+  @Column({ type: 'text', nullable: true })
+  userAgent: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/operator-runbook/entities/runbook.entity.ts
+++ b/src/operator-runbook/entities/runbook.entity.ts
@@ -1,0 +1,95 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { RunbookExecution } from './runbook-execution.entity';
+
+export enum RunbookStatus {
+  DRAFT = 'draft',
+  ACTIVE = 'active',
+  DEPRECATED = 'deprecated',
+  ARCHIVED = 'archived',
+}
+
+export enum RunbookCategory {
+  DATABASE_RECOVERY = 'database_recovery',
+  SERVICE_RESTART = 'service_restart',
+  DATA_CORRECTION = 'data_correction',
+  TENANT_RECOVERY = 'tenant_recovery',
+  QUEUE_DRAIN = 'queue_drain',
+  CACHE_FLUSH = 'cache_flush',
+  SECURITY_INCIDENT = 'security_incident',
+  GENERAL = 'general',
+}
+
+export interface RunbookStep {
+  stepNumber: number;
+  title: string;
+  description: string;
+  command?: string;
+  expectedOutcome?: string;
+  rollbackCommand?: string;
+  requiresConfirmation: boolean;
+  timeoutSeconds?: number;
+}
+
+@Entity('operator_runbooks')
+@Index(['category', 'status'])
+@Index(['createdBy', 'createdAt'])
+export class Runbook {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  name: string;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({ type: 'enum', enum: RunbookCategory, default: RunbookCategory.GENERAL })
+  category: RunbookCategory;
+
+  @Column({ type: 'enum', enum: RunbookStatus, default: RunbookStatus.DRAFT })
+  status: RunbookStatus;
+
+  @Column({ type: 'jsonb' })
+  steps: RunbookStep[];
+
+  @Column({ type: 'varchar', length: 50, default: '1.0.0' })
+  version: string;
+
+  @Column({ type: 'uuid' })
+  createdBy: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  updatedBy: string;
+
+  @Column({ type: 'text', nullable: true })
+  rollbackProcedure: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  requiredRoles: string[];
+
+  @Column({ type: 'boolean', default: false })
+  requiresDualApproval: boolean;
+
+  @Column({ type: 'jsonb', nullable: true })
+  tags: string[];
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, any>;
+
+  @OneToMany(() => RunbookExecution, (exec) => exec.runbook)
+  executions: RunbookExecution[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/operator-runbook/operator-runbook.module.ts
+++ b/src/operator-runbook/operator-runbook.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Runbook } from './entities/runbook.entity';
+import { RunbookExecution } from './entities/runbook-execution.entity';
+import { RunbookService } from './services/runbook.service';
+import { RunbookController } from './controllers/runbook.controller';
+import { AuditModule } from '../common/audit/audit.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Runbook, RunbookExecution]),
+    AuditModule,
+  ],
+  controllers: [RunbookController],
+  providers: [RunbookService],
+  exports: [RunbookService],
+})
+export class OperatorRunbookModule {}

--- a/src/operator-runbook/services/runbook.service.ts
+++ b/src/operator-runbook/services/runbook.service.ts
@@ -1,0 +1,461 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Like } from 'typeorm';
+import { Runbook, RunbookStatus } from '../entities/runbook.entity';
+import {
+  RunbookExecution,
+  ExecutionStatus,
+  StepExecutionResult,
+} from '../entities/runbook-execution.entity';
+import {
+  ApproveExecutionDto,
+  CancelExecutionDto,
+  CompleteExecutionDto,
+  CreateRunbookDto,
+  InitiateExecutionDto,
+  RecordStepResultDto,
+  RunbookQueryDto,
+  UpdateRunbookDto,
+} from '../dto/runbook.dto';
+import { AuditService } from '../../common/audit/audit.service';
+import { AuditEventDto } from '../../common/audit/dto/audit-event.dto';
+
+/** Extend AuditEventDto locally to carry runbook-specific metadata */
+type RunbookAuditEvent = AuditEventDto & { metadata?: Record<string, any> };
+
+@Injectable()
+export class RunbookService {
+  private readonly logger = new Logger(RunbookService.name);
+
+  constructor(
+    @InjectRepository(Runbook)
+    private readonly runbookRepo: Repository<Runbook>,
+    @InjectRepository(RunbookExecution)
+    private readonly executionRepo: Repository<RunbookExecution>,
+    private readonly auditService: AuditService,
+  ) {}
+
+  // ─── Runbook CRUD ────────────────────────────────────────────────────────────
+
+  async createRunbook(dto: CreateRunbookDto, operatorId: string): Promise<Runbook> {
+    const runbook = this.runbookRepo.create({
+      ...dto,
+      createdBy: operatorId,
+      status: RunbookStatus.DRAFT,
+    });
+    const saved = await this.runbookRepo.save(runbook);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_CREATED',
+      resourceId: saved.id,
+      resourceType: 'Runbook',
+    });
+
+    this.logger.log(`Runbook created: ${saved.id} by operator ${operatorId}`);
+    return saved;
+  }
+
+  async listRunbooks(query: RunbookQueryDto): Promise<Runbook[]> {
+    const where: Record<string, any> = {};
+    if (query.category) where.category = query.category;
+    if (query.status) where.status = query.status;
+    if (query.search) where.name = Like(`%${query.search}%`);
+
+    return this.runbookRepo.find({
+      where,
+      order: { updatedAt: 'DESC' },
+    });
+  }
+
+  async getRunbook(id: string): Promise<Runbook> {
+    const runbook = await this.runbookRepo.findOne({ where: { id } });
+    if (!runbook) throw new NotFoundException(`Runbook ${id} not found`);
+    return runbook;
+  }
+
+  async updateRunbook(id: string, dto: UpdateRunbookDto, operatorId: string): Promise<Runbook> {
+    const runbook = await this.getRunbook(id);
+
+    if (runbook.status === RunbookStatus.ARCHIVED) {
+      throw new BadRequestException('Cannot update an archived runbook');
+    }
+
+    Object.assign(runbook, { ...dto, updatedBy: operatorId });
+    const saved = await this.runbookRepo.save(runbook);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_UPDATED',
+      resourceId: saved.id,
+      resourceType: 'Runbook',
+    });
+
+    return saved;
+  }
+
+  async publishRunbook(id: string, operatorId: string): Promise<Runbook> {
+    const runbook = await this.getRunbook(id);
+
+    if (runbook.status !== RunbookStatus.DRAFT) {
+      throw new BadRequestException(`Only draft runbooks can be published (current: ${runbook.status})`);
+    }
+    if (!runbook.steps?.length) {
+      throw new BadRequestException('Runbook must have at least one step before publishing');
+    }
+
+    runbook.status = RunbookStatus.ACTIVE;
+    runbook.updatedBy = operatorId;
+    const saved = await this.runbookRepo.save(runbook);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_PUBLISHED',
+      resourceId: saved.id,
+      resourceType: 'Runbook',
+    });
+
+    return saved;
+  }
+
+  async deprecateRunbook(id: string, operatorId: string): Promise<Runbook> {
+    const runbook = await this.getRunbook(id);
+    runbook.status = RunbookStatus.DEPRECATED;
+    runbook.updatedBy = operatorId;
+    const saved = await this.runbookRepo.save(runbook);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_DEPRECATED',
+      resourceId: saved.id,
+      resourceType: 'Runbook',
+    });
+
+    return saved;
+  }
+
+  // ─── Execution lifecycle ─────────────────────────────────────────────────────
+
+  async initiateExecution(
+    runbookId: string,
+    dto: InitiateExecutionDto,
+    operatorId: string,
+    ipAddress: string,
+    userAgent: string,
+  ): Promise<RunbookExecution> {
+    const runbook = await this.getRunbook(runbookId);
+
+    if (runbook.status !== RunbookStatus.ACTIVE) {
+      throw new BadRequestException(`Runbook is not active (status: ${runbook.status})`);
+    }
+
+    const execution = this.executionRepo.create({
+      runbookId,
+      initiatedBy: operatorId,
+      reason: dto.reason,
+      context: dto.context,
+      dryRun: dto.dryRun ?? false,
+      notes: dto.notes,
+      ipAddress,
+      userAgent,
+      status: runbook.requiresDualApproval
+        ? ExecutionStatus.PENDING_APPROVAL
+        : ExecutionStatus.APPROVED,
+      // Self-approve if no dual approval required
+      approvedBy: runbook.requiresDualApproval ? undefined : operatorId,
+      approvedAt: runbook.requiresDualApproval ? undefined : new Date(),
+    });
+
+    const saved = await this.executionRepo.save(execution);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_EXECUTION_INITIATED',
+      resourceId: saved.id,
+      resourceType: 'RunbookExecution',
+      metadata: { runbookId, dryRun: dto.dryRun, reason: dto.reason },
+    } as RunbookAuditEvent);
+
+    this.logger.log(
+      `Execution ${saved.id} initiated for runbook ${runbookId} by ${operatorId} (dryRun=${dto.dryRun})`,
+    );
+    return saved;
+  }
+
+  async approveExecution(
+    executionId: string,
+    dto: ApproveExecutionDto,
+    approverId: string,
+  ): Promise<RunbookExecution> {
+    const execution = await this.findExecution(executionId);
+
+    if (execution.status !== ExecutionStatus.PENDING_APPROVAL) {
+      throw new BadRequestException(`Execution is not pending approval (status: ${execution.status})`);
+    }
+    if (execution.initiatedBy === approverId) {
+      throw new ForbiddenException('Initiator cannot approve their own execution request');
+    }
+
+    const runbook = await this.getRunbook(execution.runbookId);
+
+    // Handle dual approval: first approval sets approvedBy, second sets secondApprovalBy
+    if (!execution.approvedBy) {
+      execution.approvedBy = approverId;
+      execution.approvedAt = new Date();
+
+      // If dual approval required, check if we need a second approver
+      if (runbook.requiresDualApproval) {
+        execution.status = ExecutionStatus.PENDING_APPROVAL; // still needs second
+      } else {
+        execution.status = ExecutionStatus.APPROVED;
+      }
+    } else if (runbook.requiresDualApproval && !execution.secondApprovalBy) {
+      if (execution.approvedBy === approverId) {
+        throw new ForbiddenException('Same operator cannot provide both approvals');
+      }
+      execution.secondApprovalBy = approverId;
+      execution.status = ExecutionStatus.APPROVED;
+    } else {
+      throw new BadRequestException('Execution already has all required approvals');
+    }
+
+    if (dto.notes) execution.notes = execution.notes ? `${execution.notes}\n${dto.notes}` : dto.notes;
+
+    const saved = await this.executionRepo.save(execution);
+
+    await this.auditService.log({
+      actorId: approverId,
+      action: 'RUNBOOK_EXECUTION_APPROVED',
+      resourceId: executionId,
+      resourceType: 'RunbookExecution',
+    });
+
+    return saved;
+  }
+
+  async startExecution(executionId: string, operatorId: string): Promise<RunbookExecution> {
+    const execution = await this.findExecution(executionId);
+
+    if (execution.status !== ExecutionStatus.APPROVED) {
+      throw new BadRequestException(`Execution must be approved before starting (status: ${execution.status})`);
+    }
+
+    execution.status = ExecutionStatus.IN_PROGRESS;
+    execution.executedBy = operatorId;
+    execution.startedAt = new Date();
+    execution.stepResults = [];
+
+    const saved = await this.executionRepo.save(execution);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_EXECUTION_STARTED',
+      resourceId: executionId,
+      resourceType: 'RunbookExecution',
+    });
+
+    this.logger.log(`Execution ${executionId} started by ${operatorId}`);
+    return saved;
+  }
+
+  async recordStepResult(
+    executionId: string,
+    dto: RecordStepResultDto,
+    operatorId: string,
+  ): Promise<RunbookExecution> {
+    const execution = await this.findExecution(executionId);
+
+    if (execution.status !== ExecutionStatus.IN_PROGRESS) {
+      throw new BadRequestException(`Execution is not in progress (status: ${execution.status})`);
+    }
+
+    const runbook = await this.getRunbook(execution.runbookId);
+    const step = runbook.steps.find((s) => s.stepNumber === dto.stepNumber);
+    if (!step) {
+      throw new NotFoundException(`Step ${dto.stepNumber} not found in runbook`);
+    }
+
+    const result: StepExecutionResult = {
+      stepNumber: dto.stepNumber,
+      status: dto.status,
+      output: dto.output,
+      error: dto.error,
+      startedAt: new Date(),
+      completedAt: new Date(),
+      executedBy: operatorId,
+    };
+
+    execution.stepResults = [...(execution.stepResults ?? []), result];
+    const saved = await this.executionRepo.save(execution);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_STEP_RECORDED',
+      resourceId: executionId,
+      resourceType: 'RunbookExecution',
+      metadata: { stepNumber: dto.stepNumber, status: dto.status },
+    } as RunbookAuditEvent);
+
+    return saved;
+  }
+
+  async completeExecution(
+    executionId: string,
+    dto: CompleteExecutionDto,
+    operatorId: string,
+  ): Promise<RunbookExecution> {
+    const execution = await this.findExecution(executionId);
+
+    if (execution.status !== ExecutionStatus.IN_PROGRESS) {
+      throw new BadRequestException(`Execution is not in progress (status: ${execution.status})`);
+    }
+
+    execution.status = ExecutionStatus.COMPLETED;
+    execution.completedAt = new Date();
+    if (dto.notes) execution.notes = execution.notes ? `${execution.notes}\n${dto.notes}` : dto.notes;
+
+    const saved = await this.executionRepo.save(execution);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_EXECUTION_COMPLETED',
+      resourceId: executionId,
+      resourceType: 'RunbookExecution',
+    });
+
+    this.logger.log(`Execution ${executionId} completed by ${operatorId}`);
+    return saved;
+  }
+
+  async failExecution(
+    executionId: string,
+    errorMessage: string,
+    operatorId: string,
+  ): Promise<RunbookExecution> {
+    const execution = await this.findExecution(executionId);
+
+    if (execution.status !== ExecutionStatus.IN_PROGRESS) {
+      throw new BadRequestException(`Execution is not in progress (status: ${execution.status})`);
+    }
+
+    execution.status = ExecutionStatus.FAILED;
+    execution.errorMessage = errorMessage;
+    execution.completedAt = new Date();
+
+    const saved = await this.executionRepo.save(execution);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_EXECUTION_FAILED',
+      resourceId: executionId,
+      resourceType: 'RunbookExecution',
+      metadata: { errorMessage },
+    } as RunbookAuditEvent);
+
+    this.logger.warn(`Execution ${executionId} failed: ${errorMessage}`);
+    return saved;
+  }
+
+  async rollbackExecution(
+    executionId: string,
+    operatorId: string,
+    notes?: string,
+  ): Promise<RunbookExecution> {
+    const execution = await this.findExecution(executionId);
+
+    const rollbackableStatuses = [ExecutionStatus.IN_PROGRESS, ExecutionStatus.FAILED, ExecutionStatus.COMPLETED];
+    if (!rollbackableStatuses.includes(execution.status)) {
+      throw new BadRequestException(`Cannot rollback execution in status: ${execution.status}`);
+    }
+
+    execution.status = ExecutionStatus.ROLLED_BACK;
+    if (notes) execution.notes = execution.notes ? `${execution.notes}\nROLLBACK: ${notes}` : `ROLLBACK: ${notes}`;
+
+    const saved = await this.executionRepo.save(execution);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_EXECUTION_ROLLED_BACK',
+      resourceId: executionId,
+      resourceType: 'RunbookExecution',
+      metadata: { notes },
+    } as RunbookAuditEvent);
+
+    this.logger.warn(`Execution ${executionId} rolled back by ${operatorId}`);
+    return saved;
+  }
+
+  async cancelExecution(
+    executionId: string,
+    dto: CancelExecutionDto,
+    operatorId: string,
+  ): Promise<RunbookExecution> {
+    const execution = await this.findExecution(executionId);
+
+    const cancellableStatuses = [ExecutionStatus.PENDING_APPROVAL, ExecutionStatus.APPROVED];
+    if (!cancellableStatuses.includes(execution.status)) {
+      throw new BadRequestException(`Cannot cancel execution in status: ${execution.status}`);
+    }
+
+    execution.status = ExecutionStatus.CANCELLED;
+    execution.notes = execution.notes
+      ? `${execution.notes}\nCANCELLED: ${dto.reason}`
+      : `CANCELLED: ${dto.reason}`;
+
+    const saved = await this.executionRepo.save(execution);
+
+    await this.auditService.log({
+      actorId: operatorId,
+      action: 'RUNBOOK_EXECUTION_CANCELLED',
+      resourceId: executionId,
+      resourceType: 'RunbookExecution',
+      metadata: { reason: dto.reason },
+    } as RunbookAuditEvent);
+
+    return saved;
+  }
+
+  // ─── Query helpers ───────────────────────────────────────────────────────────
+
+  async getExecutionHistory(
+    runbookId: string,
+    limit = 20,
+  ): Promise<RunbookExecution[]> {
+    await this.getRunbook(runbookId); // ensure runbook exists
+    return this.executionRepo.find({
+      where: { runbookId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+  }
+
+  async getExecution(executionId: string): Promise<RunbookExecution> {
+    return this.findExecution(executionId);
+  }
+
+  async getActiveExecutions(): Promise<RunbookExecution[]> {
+    return this.executionRepo.find({
+      where: [
+        { status: ExecutionStatus.PENDING_APPROVAL },
+        { status: ExecutionStatus.APPROVED },
+        { status: ExecutionStatus.IN_PROGRESS },
+      ],
+      relations: ['runbook'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  // ─── Private helpers ─────────────────────────────────────────────────────────
+
+  private async findExecution(id: string): Promise<RunbookExecution> {
+    const execution = await this.executionRepo.findOne({ where: { id } });
+    if (!execution) throw new NotFoundException(`Execution ${id} not found`);
+    return execution;
+  }
+}


### PR DESCRIPTION
closes #458

- Add Runbook entity with categories (db_recovery, service_restart, data_correction, tenant_recovery, queue_drain, cache_flush, security_incident, general), status lifecycle (draft → active → deprecated/archived), versioned steps with rollback commands, and optional dual-approval flag
- Add RunbookExecution entity tracking full lifecycle: pending_approval → approved → in_progress → completed/failed/rolled_back/cancelled with per-step results, dry-run support, and IP/user-agent capture
- Add RunbookService with create/update/publish/deprecate runbook ops and initiate/approve/start/record-step/complete/fail/rollback/cancel execution ops; enforces dual-approval (initiator ≠ approver, two distinct approvers required)
- Add RunbookController under /operator/runbooks with full CRUD and execution lifecycle endpoints; protected by RequireAdmin + HipaaRoles
- Add migration 1775700000000-CreateOperatorRunbookTables with enums, tables, and indexes
- Register OperatorRunbookModule in AppModule
- All state transitions are fully audited via AuditService