### PR TITLE
Fix CORS, feature flag auth, and KMS encryption

### DIFF
--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -1,6 +1,7 @@
 import {
   Entity,
   Column,
+  Index,
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,9 +1,12 @@
 import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { UserRole } from '../entities/user.entity';
 import { JwtPayload } from '../services/auth-token.service';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest();
     const user: JwtPayload = request.user;
@@ -12,8 +15,11 @@ export class RolesGuard implements CanActivate {
       throw new ForbiddenException('User not found in request');
     }
 
-    // Get required roles from route metadata or endpoint
-    const requiredRoles: UserRole[] = Reflect.getMetadata('roles', context.getHandler()) || [];
+    const requiredRoles =
+      this.reflector.getAllAndOverride<UserRole[]>('roles', [
+        context.getHandler(),
+        context.getClass(),
+      ]) || [];
 
     if (requiredRoles.length === 0) {
       // No specific roles required

--- a/src/common/services/kms-with-breaker.service.spec.ts
+++ b/src/common/services/kms-with-breaker.service.spec.ts
@@ -1,0 +1,100 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  DecryptCommand,
+  EncryptCommand,
+  GenerateDataKeyCommand,
+  KMSClient,
+} from '@aws-sdk/client-kms';
+import { CircuitBreakerService } from '../circuit-breaker/circuit-breaker.service';
+import { KmsWithBreakerService } from './kms-with-breaker.service';
+
+jest.mock('@aws-sdk/client-kms', () => ({
+  KMSClient: jest.fn(),
+  EncryptCommand: jest.fn(function EncryptCommand(input) {
+    this.input = input;
+  }),
+  DecryptCommand: jest.fn(function DecryptCommand(input) {
+    this.input = input;
+  }),
+  GenerateDataKeyCommand: jest.fn(function GenerateDataKeyCommand(input) {
+    this.input = input;
+  }),
+}));
+
+describe('KmsWithBreakerService', () => {
+  const send = jest.fn();
+  const circuitBreaker = {
+    execute: jest.fn(async (_serviceName: string, fn: () => Promise<unknown>) => fn()),
+  } as unknown as jest.Mocked<CircuitBreakerService>;
+  const configService = {
+    get: jest.fn((key: string, defaultValue?: string) => {
+      if (key === 'KMS_PROVIDER') return 'aws';
+      if (key === 'AWS_REGION') return 'us-east-1';
+      return defaultValue;
+    }),
+  } as unknown as jest.Mocked<ConfigService>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (KMSClient as jest.Mock).mockImplementation(() => ({ send }));
+  });
+
+  it('fails fast when AWS KMS region is not configured', () => {
+    const missingRegionConfig = {
+      get: jest.fn((key: string, defaultValue?: string) => {
+        if (key === 'KMS_PROVIDER') return 'aws';
+        if (key === 'AWS_REGION') return undefined;
+        return defaultValue;
+      }),
+    } as unknown as ConfigService;
+
+    expect(() => new KmsWithBreakerService(circuitBreaker, missingRegionConfig)).toThrow(
+      'AWS_REGION must be set for AWS KMS encryption',
+    );
+  });
+
+  it('encrypts by returning AWS KMS ciphertext, not plaintext', async () => {
+    const service = new KmsWithBreakerService(circuitBreaker, configService);
+    send.mockResolvedValue({ CiphertextBlob: Uint8Array.from([9, 8, 7]) });
+
+    const result = await service.encrypt(Buffer.from([1, 2, 3]), 'key-1');
+
+    expect(EncryptCommand).toHaveBeenCalledWith({
+      KeyId: 'key-1',
+      Plaintext: Buffer.from([1, 2, 3]),
+    });
+    expect(result).toEqual(Buffer.from([9, 8, 7]));
+  });
+
+  it('decrypts by returning AWS KMS plaintext, not ciphertext', async () => {
+    const service = new KmsWithBreakerService(circuitBreaker, configService);
+    send.mockResolvedValue({ Plaintext: Uint8Array.from([4, 5, 6]) });
+
+    const result = await service.decrypt(Buffer.from([9, 8, 7]), 'key-1');
+
+    expect(DecryptCommand).toHaveBeenCalledWith({
+      KeyId: 'key-1',
+      CiphertextBlob: Buffer.from([9, 8, 7]),
+    });
+    expect(result).toEqual(Buffer.from([4, 5, 6]));
+  });
+
+  it('generates a data key using AWS KMS ciphertext and plaintext', async () => {
+    const service = new KmsWithBreakerService(circuitBreaker, configService);
+    send.mockResolvedValue({
+      Plaintext: Uint8Array.from([1, 2, 3]),
+      CiphertextBlob: Uint8Array.from([7, 8, 9]),
+    });
+
+    const result = await service.generateDataKey('key-1');
+
+    expect(GenerateDataKeyCommand).toHaveBeenCalledWith({
+      KeyId: 'key-1',
+      KeySpec: 'AES_256',
+    });
+    expect(result).toEqual({
+      plaintext: Buffer.from([1, 2, 3]),
+      ciphertext: Buffer.from([7, 8, 9]),
+    });
+  });
+});

--- a/src/common/services/kms-with-breaker.service.ts
+++ b/src/common/services/kms-with-breaker.service.ts
@@ -1,4 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  DecryptCommand,
+  EncryptCommand,
+  GenerateDataKeyCommand,
+  KMSClient,
+} from '@aws-sdk/client-kms';
+import type { KeySpec } from '@aws-sdk/client-kms';
 import { CircuitBreakerService } from '../circuit-breaker/circuit-breaker.service';
 import { BrokenCircuitError } from 'cockatiel';
 import { CircuitOpenException } from '../circuit-breaker/exceptions/circuit-open.exception';
@@ -6,33 +14,49 @@ import { CIRCUIT_BREAKER_CONFIGS } from '../circuit-breaker/circuit-breaker.conf
 
 /**
  * Key Management Service with circuit breaker protection
- * 
- * This is a placeholder implementation. Replace with actual KMS integration
- * (AWS KMS, HashiCorp Vault, etc.) when available.
  */
 @Injectable()
 export class KmsWithBreakerService {
   private readonly logger = new Logger(KmsWithBreakerService.name);
   private readonly serviceName = 'kms';
+  private readonly kmsClient: KMSClient;
 
-  constructor(private readonly circuitBreaker: CircuitBreakerService) {}
+  constructor(
+    private readonly circuitBreaker: CircuitBreakerService,
+    private readonly configService: ConfigService,
+  ) {
+    const provider = this.configService.get<string>('KMS_PROVIDER', 'aws');
+    const region = this.configService.get<string>('AWS_REGION');
+
+    if (provider !== 'aws') {
+      throw new Error(`Unsupported KMS_PROVIDER '${provider}'. Configure AWS KMS before starting.`);
+    }
+
+    if (!region) {
+      throw new Error('AWS_REGION must be set for AWS KMS encryption');
+    }
+
+    this.kmsClient = new KMSClient({ region });
+  }
 
   /**
    * Encrypt data using KMS
    */
   async encrypt(plaintext: Buffer, keyId: string): Promise<Buffer> {
     return this.executeWithBreaker(async () => {
-      // TODO: Implement actual KMS encryption
-      // Example: AWS KMS
-      // const result = await this.kmsClient.encrypt({
-      //   KeyId: keyId,
-      //   Plaintext: plaintext,
-      // }).promise();
-      // return Buffer.from(result.CiphertextBlob);
-
       this.logger.debug(`[KMS] Encrypting data with key: ${keyId}`);
-      // Placeholder implementation
-      return plaintext;
+      const result = await this.kmsClient.send(
+        new EncryptCommand({
+          KeyId: keyId,
+          Plaintext: plaintext,
+        }),
+      );
+
+      if (!result.CiphertextBlob) {
+        throw new Error('AWS KMS encrypt response did not include CiphertextBlob');
+      }
+
+      return Buffer.from(result.CiphertextBlob);
     });
   }
 
@@ -41,16 +65,19 @@ export class KmsWithBreakerService {
    */
   async decrypt(ciphertext: Buffer, keyId: string): Promise<Buffer> {
     return this.executeWithBreaker(async () => {
-      // TODO: Implement actual KMS decryption
-      // Example: AWS KMS
-      // const result = await this.kmsClient.decrypt({
-      //   CiphertextBlob: ciphertext,
-      // }).promise();
-      // return Buffer.from(result.Plaintext);
-
       this.logger.debug(`[KMS] Decrypting data with key: ${keyId}`);
-      // Placeholder implementation
-      return ciphertext;
+      const result = await this.kmsClient.send(
+        new DecryptCommand({
+          KeyId: keyId,
+          CiphertextBlob: ciphertext,
+        }),
+      );
+
+      if (!result.Plaintext) {
+        throw new Error('AWS KMS decrypt response did not include Plaintext');
+      }
+
+      return Buffer.from(result.Plaintext);
     });
   }
 
@@ -62,23 +89,21 @@ export class KmsWithBreakerService {
     ciphertext: Buffer;
   }> {
     return this.executeWithBreaker(async () => {
-      // TODO: Implement actual KMS data key generation
-      // Example: AWS KMS
-      // const result = await this.kmsClient.generateDataKey({
-      //   KeyId: keyId,
-      //   KeySpec: keySpec,
-      // }).promise();
-      // return {
-      //   plaintext: Buffer.from(result.Plaintext),
-      //   ciphertext: Buffer.from(result.CiphertextBlob),
-      // };
-
       this.logger.debug(`[KMS] Generating data key with spec: ${keySpec}`);
-      // Placeholder implementation
-      const mockKey = Buffer.alloc(32);
+      const result = await this.kmsClient.send(
+        new GenerateDataKeyCommand({
+          KeyId: keyId,
+          KeySpec: keySpec as KeySpec,
+        }),
+      );
+
+      if (!result.Plaintext || !result.CiphertextBlob) {
+        throw new Error('AWS KMS generateDataKey response was missing key material');
+      }
+
       return {
-        plaintext: mockKey,
-        ciphertext: mockKey,
+        plaintext: Buffer.from(result.Plaintext),
+        ciphertext: Buffer.from(result.CiphertextBlob),
       };
     });
   }

--- a/src/feature-flags/feature-flag.controller.auth.spec.ts
+++ b/src/feature-flags/feature-flag.controller.auth.spec.ts
@@ -1,0 +1,69 @@
+import { INestApplication } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AuthTokenService } from '../auth/services/auth-token.service';
+import { SessionManagementService } from '../auth/services/session-management.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { FeatureFlagController } from './feature-flag.controller';
+import { FeatureFlagService } from './feature-flag.service';
+
+describe('FeatureFlagController auth', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [FeatureFlagController],
+      providers: [
+        JwtAuthGuard,
+        RolesGuard,
+        Reflector,
+        {
+          provide: AuthTokenService,
+          useValue: {
+            verifyAccessToken: jest.fn(),
+          },
+        },
+        {
+          provide: SessionManagementService,
+          useValue: {
+            isSessionValid: jest.fn(),
+            updateSessionActivity: jest.fn(),
+          },
+        },
+        {
+          provide: FeatureFlagService,
+          useValue: {
+            findAll: jest.fn(),
+            upsert: jest.fn(),
+            rollback: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it.each([
+    ['GET', '/admin/feature-flags'],
+    ['POST', '/admin/feature-flags'],
+    ['PATCH', '/admin/feature-flags/test-flag/rollback'],
+  ])('returns 401 for unauthenticated %s %s', async (method, path) => {
+    const agent = request(app.getHttpServer());
+    const response =
+      method === 'GET'
+        ? agent.get(path)
+        : method === 'POST'
+          ? agent.post(path).send({ key: 'test-flag', enabled: true })
+          : agent.patch(path);
+
+    await response.expect(401);
+  });
+});

--- a/src/feature-flags/feature-flag.controller.ts
+++ b/src/feature-flags/feature-flag.controller.ts
@@ -1,10 +1,16 @@
 import { Body, Controller, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../auth/entities/user.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
 import { FeatureFlagService, UpsertFeatureFlagDto } from './feature-flag.service';
 
 @ApiTags('feature-flags')
 @ApiBearerAuth()
 @Controller('admin/feature-flags')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
 export class FeatureFlagController {
   constructor(private readonly service: FeatureFlagService) {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,10 +82,6 @@ async function bootstrap() {
 
   app.enableCors({
     origin: allowedOrigins,
-    methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Authorization', 'Content-Type'],
-    maxAge: 86400,
-    origin: corsOrigins,
     credentials: process.env.CORS_CREDENTIALS === 'true',
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With', 'X-Trace-ID'],


### PR DESCRIPTION
This PR closes
  Closes #493
  Closes #495
  Closes #496

Summary:
- Removes the duplicate CORS options that referenced undefined corsOrigins.
- Protects admin feature flag routes with JWT and admin role guards, and fixes class-level role metadata enforcement.
- Replaces KmsWithBreakerService no-op placeholders with AWS KMS encrypt/decrypt/data-key operations and startup config validation.

Tests:
- npx jest --selectProjects unit --runTestsByPath src/common/services/kms-with-breaker.service.spec.ts src/feature-flags/feature-flag.controller.auth.spec.ts --runInBand

Note:
- npm run build is currently blocked by existing repo-wide TypeScript/module issues outside this change set, including conflict text in src/app.module.ts and missing modules/imports.