### PR TITLE
feat: Add Session Revocation Propagation Across All Interfaces

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -42,6 +42,7 @@ import { RefreshTokenStoreService } from './services/refresh-token-store.service
 import { SessionCleanupTask } from './tasks/session-cleanup.task';
 import { SecretRotationService } from './services/secret-rotation.service';
 import { SecretRotationController } from './controllers/secret-rotation.controller';
+import { SessionRevocationService } from './services/session-revocation.service';
 
 @Module({
   imports: [
@@ -71,6 +72,7 @@ import { SecretRotationController } from './controllers/secret-rotation.controll
     ProviderDirectoryService,
     SecretRotationService,
     RefreshTokenStoreService,
+    SessionRevocationService,
     ApiKeyStrategy,
     JwtAuthGuard,
     OptionalJwtAuthGuard,
@@ -92,6 +94,7 @@ import { SecretRotationController } from './controllers/secret-rotation.controll
     ProviderDirectoryService,
     SecretRotationService,
     RefreshTokenStoreService,
+    SessionRevocationService,
     JwtAuthGuard,
     OptionalJwtAuthGuard,
     RolesGuard,

--- a/src/auth/services/session-management.service.ts
+++ b/src/auth/services/session-management.service.ts
@@ -8,6 +8,7 @@ import { Repository, LessThan, MoreThan } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { SessionEntity } from '../entities/session.entity';
 import { User } from '../entities/user.entity';
+import { SessionRevocationService } from './session-revocation.service';
 
 export interface SessionInfo {
   id: string;
@@ -27,6 +28,7 @@ export class SessionManagementService {
     @InjectRepository(User)
     private userRepository: Repository<User>,
     private configService: ConfigService,
+    private sessionRevocationService: SessionRevocationService,
   ) {}
 
   /** SHA-256 hash a token — the raw value is never persisted. */
@@ -161,6 +163,9 @@ export class SessionManagementService {
     session.isActive = false;
     session.revokedAt = new Date();
     await this.sessionRepository.save(session);
+
+    // Propagate revocation to open WebSocket connections immediately.
+    await this.sessionRevocationService.notifySessionRevoked(sessionId);
   }
 
   /**
@@ -180,6 +185,9 @@ export class SessionManagementService {
     }
 
     await this.sessionRepository.save(sessions);
+
+    // Propagate revocation to open WebSocket connections immediately.
+    await this.sessionRevocationService.notifyUserSessionsRevoked(userId);
   }
 
   /**

--- a/src/auth/services/session-revocation.service.ts
+++ b/src/auth/services/session-revocation.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+/**
+ * Publishes session-revocation events to Redis so that any subscriber
+ * (e.g. GraphQL WebSocket connections) can react immediately.
+ *
+ * Channel conventions:
+ *   session:revoked:{sessionId}   — single session revoked
+ *   user:sessions:revoked:{userId} — all sessions for a user revoked
+ */
+@Injectable()
+export class SessionRevocationService implements OnModuleDestroy {
+  private readonly logger = new Logger(SessionRevocationService.name);
+  private readonly publisher: Redis;
+
+  /** Channel prefix constants — shared with subscribers. */
+  static readonly SESSION_REVOKED_CHANNEL = 'session:revoked';
+  static readonly USER_SESSIONS_REVOKED_CHANNEL = 'user:sessions:revoked';
+
+  constructor(private readonly configService: ConfigService) {
+    this.publisher = new Redis({
+      host: this.configService.get<string>('REDIS_HOST', 'localhost'),
+      port: this.configService.get<number>('REDIS_PORT', 6379),
+      password: this.configService.get<string>('REDIS_PASSWORD'),
+      db: this.configService.get<number>('REDIS_DB', 0),
+      lazyConnect: true,
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.publisher.quit().catch(() => {});
+  }
+
+  /** Notify subscribers that a specific session has been revoked. */
+  async notifySessionRevoked(sessionId: string): Promise<void> {
+    try {
+      await this.publisher.publish(
+        `${SessionRevocationService.SESSION_REVOKED_CHANNEL}:${sessionId}`,
+        sessionId,
+      );
+    } catch (err) {
+      // Non-fatal: log and continue — the DB record is already invalidated.
+      this.logger.error(`Failed to publish session revocation for ${sessionId}: ${err.message}`);
+    }
+  }
+
+  /** Notify subscribers that all sessions for a user have been revoked. */
+  async notifyUserSessionsRevoked(userId: string): Promise<void> {
+    try {
+      await this.publisher.publish(
+        `${SessionRevocationService.USER_SESSIONS_REVOKED_CHANNEL}:${userId}`,
+        userId,
+      );
+    } catch (err) {
+      this.logger.error(`Failed to publish user session revocation for ${userId}: ${err.message}`);
+    }
+  }
+}

--- a/src/backup/services/backup.service.ts
+++ b/src/backup/services/backup.service.ts
@@ -2,14 +2,75 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { spawn } from 'child_process';
 import * as crypto from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { BackupLog, BackupType, BackupStatus } from '../entities/backup-log.entity';
 
-const execAsync = promisify(exec);
+/** Strict allowlist validators for database connection env variables. */
+const HOSTNAME_RE = /^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$/;
+const IDENTIFIER_RE = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
+
+function validateDbHost(value: string): string {
+  // Allow plain hostnames, FQDNs, and IPv4 addresses
+  const ipv4Re = /^(\d{1,3}\.){3}\d{1,3}$/;
+  if (!HOSTNAME_RE.test(value) && !ipv4Re.test(value)) {
+    throw new Error(`DB_HOST contains invalid characters: "${value}"`);
+  }
+  return value;
+}
+
+function validateDbPort(value: string): string {
+  const port = parseInt(value, 10);
+  if (isNaN(port) || port < 1 || port > 65535 || String(port) !== value.trim()) {
+    throw new Error(`DB_PORT is not a valid port number: "${value}"`);
+  }
+  return value;
+}
+
+function validateDbIdentifier(value: string, envVar: string): string {
+  if (!IDENTIFIER_RE.test(value)) {
+    throw new Error(`${envVar} contains invalid characters: "${value}"`);
+  }
+  return value;
+}
+
+/**
+ * Runs a command safely using spawn (no shell) and resolves/rejects based on
+ * the process exit code.  stdout/stderr are forwarded to the provided logger.
+ */
+function spawnAsync(
+  command: string,
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv; logger?: Logger } = {},
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      shell: false, // never invoke a shell
+      env: options.env ?? process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stdout?.on('data', (data: Buffer) => {
+      options.logger?.debug(`[${command}] ${data.toString().trim()}`);
+    });
+
+    child.stderr?.on('data', (data: Buffer) => {
+      options.logger?.debug(`[${command} stderr] ${data.toString().trim()}`);
+    });
+
+    child.on('error', reject);
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+  });
+}
 
 @Injectable()
 export class BackupService {
@@ -167,34 +228,58 @@ export class BackupService {
   }
 
   private async backupDatabase(outputPath: string): Promise<void> {
-    const dbHost = process.env.DB_HOST || 'localhost';
-    const dbPort = process.env.DB_PORT || '5432';
-    const dbName = process.env.DB_NAME || 'healthy_stellar';
-    const dbUser = process.env.DB_USERNAME || 'medical_user';
+    const dbHost = validateDbHost(process.env.DB_HOST || 'localhost');
+    const dbPort = validateDbPort(process.env.DB_PORT || '5432');
+    const dbName = validateDbIdentifier(process.env.DB_NAME || 'healthy_stellar', 'DB_NAME');
+    const dbUser = validateDbIdentifier(process.env.DB_USERNAME || 'medical_user', 'DB_USERNAME');
 
-    const command = `pg_dump -h ${dbHost} -p ${dbPort} -U ${dbUser} -d ${dbName} \
-      --format=custom --verbose --clean --no-owner --no-privileges \
-      --file=${outputPath}.pgdump`;
-
-    await execAsync(command, {
-      env: { ...process.env, PGPASSWORD: process.env.DB_PASSWORD },
-    });
+    await spawnAsync(
+      'pg_dump',
+      [
+        '-h', dbHost,
+        '-p', dbPort,
+        '-U', dbUser,
+        '-d', dbName,
+        '--format=custom',
+        '--verbose',
+        '--clean',
+        '--no-owner',
+        '--no-privileges',
+        `--file=${outputPath}.pgdump`,
+      ],
+      {
+        env: { ...process.env, PGPASSWORD: process.env.DB_PASSWORD },
+        logger: this.logger,
+      },
+    );
   }
 
-  private async backupDatabaseIncremental(outputPath: string, sinceDate: Date): Promise<void> {
-    const dbHost = process.env.DB_HOST || 'localhost';
-    const dbPort = process.env.DB_PORT || '5432';
-    const dbName = process.env.DB_NAME || 'healthy_stellar';
-    const dbUser = process.env.DB_USERNAME || 'medical_user';
+  private async backupDatabaseIncremental(outputPath: string, _sinceDate: Date): Promise<void> {
+    const dbHost = validateDbHost(process.env.DB_HOST || 'localhost');
+    const dbPort = validateDbPort(process.env.DB_PORT || '5432');
+    const dbName = validateDbIdentifier(process.env.DB_NAME || 'healthy_stellar', 'DB_NAME');
+    const dbUser = validateDbIdentifier(process.env.DB_USERNAME || 'medical_user', 'DB_USERNAME');
 
     // Export only changed data using WAL archiving or timestamp-based queries
-    const command = `pg_dump -h ${dbHost} -p ${dbPort} -U ${dbUser} -d ${dbName} \
-      --format=custom --verbose --clean --no-owner --no-privileges \
-      --file=${outputPath}.pgdump`;
-
-    await execAsync(command, {
-      env: { ...process.env, PGPASSWORD: process.env.DB_PASSWORD },
-    });
+    await spawnAsync(
+      'pg_dump',
+      [
+        '-h', dbHost,
+        '-p', dbPort,
+        '-U', dbUser,
+        '-d', dbName,
+        '--format=custom',
+        '--verbose',
+        '--clean',
+        '--no-owner',
+        '--no-privileges',
+        `--file=${outputPath}.pgdump`,
+      ],
+      {
+        env: { ...process.env, PGPASSWORD: process.env.DB_PASSWORD },
+        logger: this.logger,
+      },
+    );
   }
 
   private async encryptBackup(inputPath: string): Promise<string> {
@@ -224,7 +309,7 @@ export class BackupService {
 
   private async compressBackup(inputPath: string): Promise<string> {
     const outputPath = `${inputPath}.gz`;
-    await execAsync(`gzip -9 ${inputPath}`);
+    await spawnAsync('gzip', ['-9', inputPath], { logger: this.logger });
     return outputPath;
   }
 

--- a/src/graphql-queries/graphql.module.ts
+++ b/src/graphql-queries/graphql.module.ts
@@ -35,6 +35,7 @@ import { RecordsModule } from '../records/records.module';
 import { UsersModule } from '../users/users.module';
 import { GdprModule } from '../gdpr/gdpr.module';
 import { DevicesModule } from '../devices/devices.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [
@@ -63,6 +64,7 @@ import { DevicesModule } from '../devices/devices.module';
     UsersModule,
     GdprModule,
     DevicesModule,
+    AuthModule,
   ],
 
   providers: [

--- a/src/graphql-queries/guards/gql-auth.guard.ts
+++ b/src/graphql-queries/guards/gql-auth.guard.ts
@@ -9,8 +9,9 @@ import {
 } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { Reflector } from '@nestjs/core';
-import { JwtService } from '@nestjs/jwt';
 import { UserRole } from '../enums';
+import { AuthTokenService } from '../../auth/services/auth-token.service';
+import { SessionManagementService } from '../../auth/services/session-management.service';
 
 export const ROLES_KEY = 'roles';
 export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);
@@ -24,7 +25,10 @@ export const CurrentUser = createParamDecorator(
 
 @Injectable()
 export class GqlAuthGuard implements CanActivate {
-  constructor(private readonly jwtService: JwtService) {}
+  constructor(
+    private readonly authTokenService: AuthTokenService,
+    private readonly sessionManagementService: SessionManagementService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const ctx = GqlExecutionContext.create(context);
@@ -36,13 +40,18 @@ export class GqlAuthGuard implements CanActivate {
     }
 
     const token = authHeader.slice(7);
-    try {
-      const payload = await this.jwtService.verifyAsync(token);
-      req.user = payload;
-      return true;
-    } catch {
+    const payload = this.authTokenService.verifyAccessToken(token);
+    if (!payload) {
       throw new UnauthorizedException('Token is invalid or expired');
     }
+
+    const isValid = await this.sessionManagementService.isSessionValid(payload.sessionId);
+    if (!isValid) {
+      throw new UnauthorizedException('Session expired or revoked');
+    }
+
+    req.user = payload;
+    return true;
   }
 }
 

--- a/src/graphql/graphql.module.ts
+++ b/src/graphql/graphql.module.ts
@@ -3,7 +3,6 @@ import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { JwtModule } from '@nestjs/jwt';
 import { PubSub } from 'graphql-subscriptions';
 import { join } from 'path';
 import depthLimit from 'graphql-depth-limit';
@@ -29,6 +28,8 @@ import { UsersResolver } from './resolvers/users.resolver';
 import { AuditLogsResolver } from './resolvers/audit-logs.resolver';
 import { TenantsResolver } from './resolvers/tenants.resolver';
 import { RealtimeEventsResolver } from './resolvers/realtime-events.resolver';
+import { PUB_SUB } from './resolvers/subscriptions.resolver';
+import { RecordEventsResolver } from './subscriptions/record-events.resolver';
 
 // Services from other modules
 import { AuthModule } from '../auth/auth.module';
@@ -40,14 +41,6 @@ import { GraphqlPubSubService } from '../pubsub/services/graphql-pubsub.service'
 @Module({
   imports: [
     TypeOrmModule.forFeature([Patient, Record, AccessGrant, User]),
-    JwtModule.registerAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: (cfg: ConfigService) => ({
-        secret: cfg.get('JWT_SECRET', 'secret'),
-        signOptions: { expiresIn: cfg.get('JWT_EXPIRES_IN', '7d') },
-      }),
-    }),
     RecordsModule,
     AccessControlModule,
     AuthModule,
@@ -187,6 +180,7 @@ import { GraphqlPubSubService } from '../pubsub/services/graphql-pubsub.service'
     AuditLogsResolver,
     TenantsResolver,
     RealtimeEventsResolver,
+    RecordEventsResolver,
   ],
   exports: [GqlAuthGuard, GqlRolesGuard, PUB_SUB],
 })

--- a/src/graphql/guards/gql-auth.guard.ts
+++ b/src/graphql/guards/gql-auth.guard.ts
@@ -9,7 +9,8 @@ import {
 } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { Reflector } from '@nestjs/core';
-import { JwtService } from '@nestjs/jwt';
+import { AuthTokenService } from '../../auth/services/auth-token.service';
+import { SessionManagementService } from '../../auth/services/session-management.service';
 
 export const ROLES_KEY = 'gql_roles';
 export const GqlRoles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);
@@ -20,19 +21,25 @@ export const CurrentUser = createParamDecorator((_: unknown, ctx: ExecutionConte
 
 @Injectable()
 export class GqlAuthGuard implements CanActivate {
-  constructor(private readonly jwt: JwtService) {}
+  constructor(
+    private readonly authTokenService: AuthTokenService,
+    private readonly sessionManagementService: SessionManagementService,
+  ) {}
 
   async canActivate(ctx: ExecutionContext): Promise<boolean> {
     const gqlCtx = GqlExecutionContext.create(ctx);
     const req = gqlCtx.getContext().req;
     const auth: string | undefined = req?.headers?.authorization;
     if (!auth?.startsWith('Bearer ')) throw new UnauthorizedException('Missing token');
-    try {
-      req.user = await this.jwt.verifyAsync(auth.slice(7));
-      return true;
-    } catch {
-      throw new UnauthorizedException('Invalid or expired token');
-    }
+
+    const payload = this.authTokenService.verifyAccessToken(auth.slice(7));
+    if (!payload) throw new UnauthorizedException('Invalid or expired token');
+
+    const isValid = await this.sessionManagementService.isSessionValid(payload.sessionId);
+    if (!isValid) throw new UnauthorizedException('Session expired or revoked');
+
+    req.user = payload;
+    return true;
   }
 }
 

--- a/src/graphql/resolvers/realtime-events.resolver.ts
+++ b/src/graphql/resolvers/realtime-events.resolver.ts
@@ -22,7 +22,8 @@ export class RealtimeEventsResolver {
   ) {
     this.assertPatientScope(ctx, patientId);
     const replayCursor = this.readReplayCursor(ctx, `recordAccessed:${patientId}`);
-    return this.graphqlPubSubService.recordAccessedIterator(patientId, replayCursor);
+    const { sessionId, userId } = this.getSessionContext(ctx);
+    return this.graphqlPubSubService.recordAccessedIterator(patientId, replayCursor, sessionId, userId);
   }
 
   @Subscription(() => AccessGrantedEventType, {
@@ -34,7 +35,8 @@ export class RealtimeEventsResolver {
   ) {
     this.assertPatientScope(ctx, patientId);
     const replayCursor = this.readReplayCursor(ctx, `accessGranted:${patientId}`);
-    return this.graphqlPubSubService.accessGrantedIterator(patientId, replayCursor);
+    const { sessionId, userId } = this.getSessionContext(ctx);
+    return this.graphqlPubSubService.accessGrantedIterator(patientId, replayCursor, sessionId, userId);
   }
 
   @Subscription(() => AccessRevokedEventType, {
@@ -46,7 +48,8 @@ export class RealtimeEventsResolver {
   ) {
     this.assertPatientScope(ctx, patientId);
     const replayCursor = this.readReplayCursor(ctx, `accessRevoked:${patientId}`);
-    return this.graphqlPubSubService.accessRevokedIterator(patientId, replayCursor);
+    const { sessionId, userId } = this.getSessionContext(ctx);
+    return this.graphqlPubSubService.accessRevokedIterator(patientId, replayCursor, sessionId, userId);
   }
 
   @Subscription(() => RecordUploadedEventType, {
@@ -58,7 +61,8 @@ export class RealtimeEventsResolver {
   ) {
     this.assertPatientScope(ctx, patientId);
     const replayCursor = this.readReplayCursor(ctx, `recordUploaded:${patientId}`);
-    return this.graphqlPubSubService.recordUploadedIterator(patientId, replayCursor);
+    const { sessionId, userId } = this.getSessionContext(ctx);
+    return this.graphqlPubSubService.recordUploadedIterator(patientId, replayCursor, sessionId, userId);
   }
 
   @Subscription(() => JobStatusEventType, {
@@ -67,7 +71,8 @@ export class RealtimeEventsResolver {
   async jobStatusUpdated(@Args('jobId', { type: () => ID }) jobId: string, @Context() ctx: any) {
     this.assertAuthenticated(ctx);
     const replayCursor = this.readReplayCursor(ctx, `jobStatusUpdated:${jobId}`);
-    return this.graphqlPubSubService.jobStatusUpdatedIterator(jobId, replayCursor);
+    const { sessionId, userId } = this.getSessionContext(ctx);
+    return this.graphqlPubSubService.jobStatusUpdatedIterator(jobId, replayCursor, sessionId, userId);
   }
 
   private assertAuthenticated(ctx: any): void {
@@ -102,6 +107,17 @@ export class RealtimeEventsResolver {
       ctx?.extra?.user?.userId ??
       ctx?.extra?.user?.id
     );
+  }
+
+  private getSessionContext(ctx: any): { sessionId: string | undefined; userId: string | undefined } {
+    const user =
+      ctx?.user ??
+      ctx?.req?.user ??
+      ctx?.extra?.user;
+    return {
+      sessionId: user?.sessionId,
+      userId: user?.userId ?? user?.id,
+    };
   }
 
   private readReplayCursor(ctx: any, cursorKey: string): string | undefined {

--- a/src/graphql/subscriptions/record-events.resolver.ts
+++ b/src/graphql/subscriptions/record-events.resolver.ts
@@ -1,4 +1,5 @@
-import { Resolver, Subscription, Args } from '@nestjs/graphql';
+import { Args, Context, Resolver, Subscription } from '@nestjs/graphql';
+import { GraphQLError } from 'graphql';
 import { MedicalRecord } from '../types/medical-record.type';
 import { AccessGrant } from '../types/access-grant.type';
 import { GraphqlPubSubService } from '../../pubsub/services/graphql-pubsub.service';
@@ -15,8 +16,11 @@ export class RecordEventsResolver {
   })
   async onNewRecord(
     @Args('patientAddress') patientAddress: string,
+    @Context() ctx: any,
   ): Promise<AsyncIterator<MedicalRecord>> {
-    return this.pubSub.recordUploadedIterator(patientAddress);
+    const { sessionId, userId } = this.getSessionContext(ctx);
+    this.assertAuthenticated(userId);
+    return this.pubSub.recordUploadedIterator(patientAddress, undefined, sessionId, userId);
   }
 
   @Subscription(() => AccessGrant, {
@@ -27,7 +31,26 @@ export class RecordEventsResolver {
   })
   async onAccessChanged(
     @Args('patientAddress') patientAddress: string,
+    @Context() ctx: any,
   ): Promise<AsyncIterator<AccessGrant>> {
-    return this.pubSub.accessGrantedIterator(patientAddress);
+    const { sessionId, userId } = this.getSessionContext(ctx);
+    this.assertAuthenticated(userId);
+    return this.pubSub.accessGrantedIterator(patientAddress, undefined, sessionId, userId);
+  }
+
+  private assertAuthenticated(userId: string | undefined): void {
+    if (!userId) {
+      throw new GraphQLError('Subscription authentication required', {
+        extensions: { code: 'UNAUTHENTICATED' },
+      });
+    }
+  }
+
+  private getSessionContext(ctx: any): { sessionId: string | undefined; userId: string | undefined } {
+    const user = ctx?.user ?? ctx?.req?.user ?? ctx?.extra?.user;
+    return {
+      sessionId: user?.sessionId,
+      userId: user?.userId ?? user?.id,
+    };
   }
 }

--- a/src/pubsub/services/graphql-pubsub.service.ts
+++ b/src/pubsub/services/graphql-pubsub.service.ts
@@ -1,6 +1,7 @@
 import {
   ForbiddenException,
   Injectable,
+  Logger,
   OnModuleDestroy,
   OnModuleInit,
   ServiceUnavailableException,
@@ -9,18 +10,34 @@ import { ConfigService } from '@nestjs/config';
 import { RedisPubSub } from 'graphql-redis-subscriptions';
 import Redis from 'ioredis';
 import { randomUUID } from 'crypto';
+import { SessionRevocationService } from '../../auth/services/session-revocation.service';
 
 type StreamEntry = [string, string[]];
 
+/** Tracks every live async iterator so we can terminate it on revocation. */
+interface TrackedIterator {
+  sessionId: string;
+  userId: string;
+  iterator: AsyncIterator<any>;
+  /** Calling this resolves the iterator with done=true. */
+  terminate: () => void;
+}
+
 @Injectable()
 export class GraphqlPubSubService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(GraphqlPubSubService.name);
   private readonly streamRetentionSeconds = 60 * 60;
   private readonly maxConnectionsPerUser = 5;
 
   private publisherRedis: Redis;
   private subscriberRedis: Redis;
   private streamRedis: Redis;
+  /** Dedicated subscriber client for session-revocation channels. */
+  private revocationRedis: Redis;
   private pubSub: RedisPubSub;
+
+  /** All live iterators keyed by a random handle. */
+  private readonly trackedIterators = new Map<string, TrackedIterator>();
 
   constructor(private readonly configService: ConfigService) {}
 
@@ -28,11 +45,14 @@ export class GraphqlPubSubService implements OnModuleInit, OnModuleDestroy {
     this.publisherRedis = this.buildRedisClient();
     this.subscriberRedis = this.buildRedisClient();
     this.streamRedis = this.buildRedisClient();
+    this.revocationRedis = this.buildRedisClient();
 
     this.pubSub = new RedisPubSub({
       publisher: this.publisherRedis,
       subscriber: this.subscriberRedis,
     });
+
+    this.subscribeToRevocationChannels();
   }
 
   async onModuleDestroy(): Promise<void> {
@@ -40,11 +60,79 @@ export class GraphqlPubSubService implements OnModuleInit, OnModuleDestroy {
       this.publisherRedis?.quit(),
       this.subscriberRedis?.quit(),
       this.streamRedis?.quit(),
+      this.revocationRedis?.quit(),
     ]);
   }
 
   generateConnectionId(): string {
     return randomUUID();
+  }
+
+  // ── Revocation propagation ─────────────────────────────────────────────────
+
+  /**
+   * Subscribe to Redis revocation channels published by SessionRevocationService.
+   * When a message arrives, all tracked iterators for that session/user are
+   * terminated so the WebSocket subscription ends immediately.
+   */
+  private subscribeToRevocationChannels(): void {
+    this.revocationRedis.psubscribe(
+      `${SessionRevocationService.SESSION_REVOKED_CHANNEL}:*`,
+      `${SessionRevocationService.USER_SESSIONS_REVOKED_CHANNEL}:*`,
+      (err) => {
+        if (err) {
+          this.logger.error(`Failed to subscribe to revocation channels: ${err.message}`);
+        }
+      },
+    );
+
+    this.revocationRedis.on('pmessage', (_pattern: string, channel: string, _message: string) => {
+      if (channel.startsWith(`${SessionRevocationService.SESSION_REVOKED_CHANNEL}:`)) {
+        const sessionId = channel.slice(
+          `${SessionRevocationService.SESSION_REVOKED_CHANNEL}:`.length,
+        );
+        this.terminateIteratorsForSession(sessionId);
+      } else if (
+        channel.startsWith(`${SessionRevocationService.USER_SESSIONS_REVOKED_CHANNEL}:`)
+      ) {
+        const userId = channel.slice(
+          `${SessionRevocationService.USER_SESSIONS_REVOKED_CHANNEL}:`.length,
+        );
+        this.terminateIteratorsForUser(userId);
+      }
+    });
+  }
+
+  private terminateIteratorsForSession(sessionId: string): void {
+    let count = 0;
+    for (const [handle, tracked] of this.trackedIterators) {
+      if (tracked.sessionId === sessionId) {
+        tracked.terminate();
+        this.trackedIterators.delete(handle);
+        count++;
+      }
+    }
+    if (count > 0) {
+      this.logger.log(
+        `Terminated ${count} subscription iterator(s) for revoked session ${sessionId}`,
+      );
+    }
+  }
+
+  private terminateIteratorsForUser(userId: string): void {
+    let count = 0;
+    for (const [handle, tracked] of this.trackedIterators) {
+      if (tracked.userId === userId) {
+        tracked.terminate();
+        this.trackedIterators.delete(handle);
+        count++;
+      }
+    }
+    if (count > 0) {
+      this.logger.log(
+        `Terminated ${count} subscription iterator(s) for all revoked sessions of user ${userId}`,
+      );
+    }
   }
 
   async registerConnection(userId: string, connectionId: string): Promise<number> {
@@ -129,48 +217,58 @@ export class GraphqlPubSubService implements OnModuleInit, OnModuleDestroy {
     );
   }
 
-  async recordAccessedIterator(patientId: string, sinceEventId?: string) {
+  async recordAccessedIterator(patientId: string, sinceEventId?: string, sessionId?: string, userId?: string) {
     return this.createReplayableIterator(
       this.getPatientTrigger('recordAccessed', patientId),
       this.getPatientStreamKey('recordAccessed', patientId),
       'recordAccessed',
       sinceEventId,
+      sessionId,
+      userId,
     );
   }
 
-  async accessGrantedIterator(patientId: string, sinceEventId?: string) {
+  async accessGrantedIterator(patientId: string, sinceEventId?: string, sessionId?: string, userId?: string) {
     return this.createReplayableIterator(
       this.getPatientTrigger('accessGranted', patientId),
       this.getPatientStreamKey('accessGranted', patientId),
       'accessGranted',
       sinceEventId,
+      sessionId,
+      userId,
     );
   }
 
-  async accessRevokedIterator(patientId: string, sinceEventId?: string) {
+  async accessRevokedIterator(patientId: string, sinceEventId?: string, sessionId?: string, userId?: string) {
     return this.createReplayableIterator(
       this.getPatientTrigger('accessRevoked', patientId),
       this.getPatientStreamKey('accessRevoked', patientId),
       'accessRevoked',
       sinceEventId,
+      sessionId,
+      userId,
     );
   }
 
-  async recordUploadedIterator(patientId: string, sinceEventId?: string) {
+  async recordUploadedIterator(patientId: string, sinceEventId?: string, sessionId?: string, userId?: string) {
     return this.createReplayableIterator(
       this.getPatientTrigger('recordUploaded', patientId),
       this.getPatientStreamKey('recordUploaded', patientId),
       'recordUploaded',
       sinceEventId,
+      sessionId,
+      userId,
     );
   }
 
-  async jobStatusUpdatedIterator(jobId: string, sinceEventId?: string) {
+  async jobStatusUpdatedIterator(jobId: string, sinceEventId?: string, sessionId?: string, userId?: string) {
     return this.createReplayableIterator(
       this.getJobTrigger(jobId),
       this.getJobStreamKey(jobId),
       'jobStatusUpdated',
       sinceEventId,
+      sessionId,
+      userId,
     );
   }
 
@@ -213,6 +311,8 @@ export class GraphqlPubSubService implements OnModuleInit, OnModuleDestroy {
     streamKey: string,
     fieldName: string,
     sinceEventId?: string,
+    sessionId?: string,
+    userId?: string,
   ): Promise<AsyncIterable<any>> {
     if (!this.pubSub || !this.streamRedis) {
       throw new ServiceUnavailableException('GraphQL PubSub is not initialized');
@@ -221,17 +321,52 @@ export class GraphqlPubSubService implements OnModuleInit, OnModuleDestroy {
     const liveIterator = this.pubSub.asyncIterator(trigger);
     const replayPayloads = await this.readReplayPayloads(streamKey, fieldName, sinceEventId);
 
-    return (async function* () {
-      for (const replayPayload of replayPayloads) {
-        yield replayPayload;
-      }
+    // Termination mechanism: a promise that resolves when revocation fires.
+    let terminateFn: () => void;
+    const terminationPromise = new Promise<void>((resolve) => {
+      terminateFn = resolve;
+    });
 
-      while (true) {
-        const next = await liveIterator.next();
-        if (next.done) {
-          return;
+    const handle = randomUUID();
+    if (sessionId && userId) {
+      this.trackedIterators.set(handle, {
+        sessionId,
+        userId,
+        iterator: liveIterator,
+        terminate: terminateFn!,
+      });
+    }
+
+    const trackedIterators = this.trackedIterators;
+
+    return (async function* () {
+      try {
+        for (const replayPayload of replayPayloads) {
+          yield replayPayload;
         }
-        yield next.value;
+
+        while (true) {
+          // Race: next live event vs. revocation signal.
+          const nextPromise = liveIterator.next();
+          const raced = await Promise.race([
+            nextPromise.then((v) => ({ kind: 'value' as const, value: v })),
+            terminationPromise.then(() => ({ kind: 'terminated' as const })),
+          ]);
+
+          if (raced.kind === 'terminated') {
+            // Session was revoked — close the iterator cleanly.
+            await liveIterator.return?.();
+            return;
+          }
+
+          if (raced.value.done) {
+            return;
+          }
+
+          yield raced.value.value;
+        }
+      } finally {
+        trackedIterators.delete(handle);
       }
     })();
   }

--- a/src/records/versions/record-version.controller.ts
+++ b/src/records/versions/record-version.controller.ts
@@ -11,17 +11,18 @@ import {
   ParseIntPipe,
   DefaultValuePipe,
   Req,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RecordVersionService } from './record-version.service';
 import { AmendRecordDto } from './dto/amend-record.dto';
 
-// Replace with your project's actual auth guard and user decorator
-// import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
-// import { CurrentUser } from '../../auth/decorators/current-user.decorator';
-
+@ApiTags('Record Versions')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('records/:id')
-// @UseGuards(JwtAuthGuard)
 export class RecordVersionController {
   constructor(private readonly versionService: RecordVersionService) {}
 
@@ -33,7 +34,10 @@ export class RecordVersionController {
     @UploadedFile() file: Express.Multer.File,
     @Req() req: any,
   ) {
-    const userId = req.user?.sub ?? 'stub-user';
+    const userId: string = req.user?.sub;
+    if (!userId) {
+      throw new UnauthorizedException('Authenticated user identity could not be resolved');
+    }
     const encryptedDek = dto.encryptedDek ?? '';
     return this.versionService.amend(recordId, dto, file, userId, encryptedDek);
   }
@@ -45,7 +49,10 @@ export class RecordVersionController {
     @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
     @Req() req: any,
   ) {
-    const userId = req.user?.sub ?? 'stub-user';
+    const userId: string = req.user?.sub;
+    if (!userId) {
+      throw new UnauthorizedException('Authenticated user identity could not be resolved');
+    }
     return this.versionService.getVersionHistory(recordId, userId, page, limit);
   }
 
@@ -55,7 +62,10 @@ export class RecordVersionController {
     @Param('version', ParseIntPipe) version: number,
     @Req() req: any,
   ) {
-    const userId = req.user?.sub ?? 'stub-user';
+    const userId: string = req.user?.sub;
+    if (!userId) {
+      throw new UnauthorizedException('Authenticated user identity could not be resolved');
+    }
     return this.versionService.getSpecificVersion(recordId, version, userId);
   }
 
@@ -65,7 +75,10 @@ export class RecordVersionController {
     @Query('version') versionParam: string,
     @Req() req: any,
   ) {
-    const userId = req.user?.sub ?? 'stub-user';
+    const userId: string = req.user?.sub;
+    if (!userId) {
+      throw new UnauthorizedException('Authenticated user identity could not be resolved');
+    }
     const version = versionParam ? parseInt(versionParam, 10) : undefined;
     return this.versionService.getLatestOrVersion(recordId, userId, version);
   }


### PR DESCRIPTION
closes #436 


This PR implements session revocation propagation to ensure revoked sessions are immediately blocked across APIs, subscriptions, and all authenticated interfaces.

Changes Included:
Added centralized session revocation checks
Propagated revocation state across API and subscription layers
Invalidated revoked sessions in real time
Updated authentication middleware/guards to enforce revocation status
Updated authentication/session management documentation