### PR TITLE
feat: resolve issue #520 (allowlist JSON array) and #521 (consolidate…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ backup_*.sql
 skills-lock.json
 
 issue.md
+vrickish.md

--- a/src/OAuth2/oidc-identity.entity.ts
+++ b/src/OAuth2/oidc-identity.entity.ts
@@ -7,7 +7,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import { User } from '../../users/entities/user.entity';
+import { User } from '../../auth/entities/user.entity';
 
 /**
  * Stores the binding between an external OIDC identity (provider + subject)

--- a/src/OAuth2/oidc.module.ts
+++ b/src/OAuth2/oidc.module.ts
@@ -9,7 +9,7 @@ import { OidcService } from './oidc.service';
 import { OidcController } from './oidc.controller';
 import { buildOidcConfig } from './oidc.config';
 import { UsersModule } from '../users/users.module';
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 
 /**
  * Self-contained OIDC / OAuth2 SSO module.

--- a/src/OAuth2/oidc.service.spec.ts
+++ b/src/OAuth2/oidc.service.spec.ts
@@ -11,7 +11,7 @@ import { DataSource, Repository } from 'typeorm';
 
 import { OidcService } from './oidc.service';
 import { OidcIdentity } from './entities/oidc-identity.entity';
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 import { OidcVerifiedProfile } from './oidc.strategy';
 import { LinkStellarAddressDto } from './dto/oidc.dto';
 

--- a/src/OAuth2/oidc.service.ts
+++ b/src/OAuth2/oidc.service.ts
@@ -12,7 +12,7 @@ import { DataSource, Repository } from 'typeorm';
 import * as StellarSdk from 'stellar-sdk';
 
 import { OidcIdentity } from './entities/oidc-identity.entity';
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 import { OidcVerifiedProfile } from './oidc.strategy';
 import {
   LinkStellarAddressDto,

--- a/src/analytics/admin-stats.service.spec.ts
+++ b/src/analytics/admin-stats.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { AnalyticsService } from './analytics.service';
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 import { MedicalRecord } from '../medical-records/entities/medical-record.entity';
 import { AccessGrant, GrantStatus } from '../access-control/entities/access-grant.entity';
 import { StellarTransaction } from './entities/stellar-transaction.entity';

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -4,7 +4,7 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import * as redisStore from 'cache-manager-ioredis';
 
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 import { MedicalRecord } from '../medical-records/entities/medical-record.entity';
 import { AccessGrant } from '../access-control/entities/access-grant.entity';
 import { StellarTransaction } from './entities/stellar-transaction.entity';

--- a/src/analytics/analytics.service.spec.ts
+++ b/src/analytics/analytics.service.spec.ts
@@ -3,7 +3,7 @@ import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { ForbiddenException } from '@nestjs/common';
 import { AnalyticsService } from './analytics.service';
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 import { MedicalRecord } from '../medical-records/entities/medical-record.entity';
 import { AccessGrant, GrantStatus } from '../access-control/entities/access-grant.entity';
 import { StellarTransaction } from './entities/stellar-transaction.entity';

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 import { MedicalRecord } from '../medical-records/entities/medical-record.entity';
 import { AccessGrant, GrantStatus } from '../access-control/entities/access-grant.entity';
 import { StellarTransaction } from './entities/stellar-transaction.entity';

--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -6,10 +6,12 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   OneToMany,
+  OneToOne,
 } from 'typeorm';
 import { MfaEntity } from './mfa.entity';
 import { SessionEntity } from './session.entity';
 import { AuditLogEntity } from '../../common/audit/audit-log.entity';
+import type { Patient } from '../../users/entities/patient.entity';
 
 export enum UserRole {
   ADMIN = 'admin',
@@ -19,6 +21,13 @@ export enum UserRole {
   BILLING_STAFF = 'billing_staff',
   MEDICAL_RECORDS = 'medical_records',
   SUPER_ADMIN = 'super_admin',
+}
+
+export enum UserStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  SUSPENDED = 'SUSPENDED',
+  PENDING_VERIFICATION = 'PENDING_VERIFICATION',
 }
 
 @Entity('users')
@@ -88,6 +97,7 @@ export class User {
 
   @Column({ default: true })
   emergencyAccessEnabled: boolean;
+
   @Column({ nullable: true, length: 255 })
   specialty: string;
 
@@ -107,6 +117,28 @@ export class User {
   @Column({ type: 'simple-array', nullable: true })
   permissions: string[];
 
+  /** User status (active, suspended, etc.) */
+  @Column({ type: 'enum', enum: UserStatus, default: UserStatus.ACTIVE })
+  status: UserStatus;
+
+  @Column({ type: 'date', nullable: true })
+  licenseExpiryDate: Date;
+
+  @Column({ nullable: true })
+  department: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  licenseVerifiedAt: Date;
+
+  @Column({ nullable: true })
+  verifiedBy: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastAccessRevocationAt: Date;
+
+  @Column({ nullable: true })
+  revocationReason: string;
+
   @CreateDateColumn()
   createdAt: Date;
 
@@ -115,6 +147,9 @@ export class User {
 
   @Column({ nullable: true })
   deletedAt: Date;
+
+  @OneToOne(() => Patient, (patient) => patient.user, { nullable: true })
+  patientProfile: Patient;
 
   @OneToMany(() => MfaEntity, (mfa) => mfa.user, { cascade: true })
   mfaDevices: MfaEntity[];

--- a/src/consistency-checker/consistency-checker.module.ts
+++ b/src/consistency-checker/consistency-checker.module.ts
@@ -3,7 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { MedicalRecord } from '../medical-records/entities/medical-record.entity';
 import { MedicalRecordVersion } from '../medical-records/entities/medical-record-version.entity';
 import { AccessGrant } from '../access-control/entities/access-grant.entity';
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 import { Patient } from '../patients/entities/patient.entity';
 import { StellarTransaction } from '../analytics/entities/stellar-transaction.entity';
 import { CommonModule } from '../common/common.module';

--- a/src/consistency-checker/consistency-checker.service.spec.ts
+++ b/src/consistency-checker/consistency-checker.service.spec.ts
@@ -5,7 +5,7 @@ import { ConsistencyCheckerService } from './consistency-checker.service';
 import { MedicalRecord } from '../medical-records/entities/medical-record.entity';
 import { MedicalRecordVersion } from '../medical-records/entities/medical-record-version.entity';
 import { AccessGrant } from '../access-control/entities/access-grant.entity';
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 import { Patient } from '../patients/entities/patient.entity';
 import { StellarTransaction } from '../analytics/entities/stellar-transaction.entity';
 

--- a/src/consistency-checker/consistency-checker.service.ts
+++ b/src/consistency-checker/consistency-checker.service.ts
@@ -4,7 +4,7 @@ import { Repository, DataSource } from 'typeorm';
 import { MedicalRecord } from '../medical-records/entities/medical-record.entity';
 import { MedicalRecordVersion } from '../medical-records/entities/medical-record-version.entity';
 import { AccessGrant } from '../access-control/entities/access-grant.entity';
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 import { Patient } from '../patients/entities/patient.entity';
 import { StellarTransaction } from '../analytics/entities/stellar-transaction.entity';
 

--- a/src/feature-flags/feature-flag.entity.ts
+++ b/src/feature-flags/feature-flag.entity.ts
@@ -32,9 +32,9 @@ export class FeatureFlag {
   @Column({ type: 'int', default: 0 })
   rolloutPercentage: number;
 
-  /** Comma-separated user/tenant IDs for ALLOWLIST strategy */
-  @Column({ type: 'text', nullable: true })
-  allowlist: string;
+  /** User/tenant IDs for ALLOWLIST strategy */
+  @Column({ type: 'simple-array', nullable: true })
+  allowlist: string[];
 
   @Column({ type: 'text', nullable: true })
   description: string;

--- a/src/feature-flags/feature-flag.service.ts
+++ b/src/feature-flags/feature-flag.service.ts
@@ -8,7 +8,7 @@ export interface UpsertFeatureFlagDto {
   enabled: boolean;
   strategy?: RolloutStrategy;
   rolloutPercentage?: number;
-  allowlist?: string;
+  allowlist?: string[];
   description?: string;
 }
 
@@ -33,8 +33,8 @@ export class FeatureFlagService {
         return (hash % 100) < flag.rolloutPercentage;
       }
       case RolloutStrategy.ALLOWLIST: {
-        if (!actorId || !flag.allowlist) return false;
-        return flag.allowlist.split(',').map((s) => s.trim()).includes(actorId);
+        if (!actorId || !flag.allowlist || flag.allowlist.length === 0) return false;
+        return flag.allowlist.includes(actorId);
       }
       default:
         return true;

--- a/src/fhir/mappers/patient.mapper.ts
+++ b/src/fhir/mappers/patient.mapper.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { User } from '../../users/entities/user.entity';
+import { User } from '../../auth/entities/user.entity';
 import { FhirMappingException } from '../exceptions/fhir-mapping.exception';
 
 @Injectable()

--- a/src/graphql-queries/dataloaders/user.dataloader.ts
+++ b/src/graphql-queries/dataloaders/user.dataloader.ts
@@ -2,7 +2,7 @@ import { Injectable, Scope } from '@nestjs/common';
 import * as DataLoader from 'dataloader';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';
-import { UserEntity } from '../../users/entities/user.entity';
+import { User as UserEntity } from '../../auth/entities/user.entity';
 
 /**
  * UserDataLoader is REQUEST-scoped so each GraphQL operation

--- a/src/graphql/dataloaders/dataloader.service.ts
+++ b/src/graphql/dataloaders/dataloader.service.ts
@@ -5,7 +5,7 @@ import * as DataLoader from 'dataloader';
 import { Patient } from '../../patients/entities/patient.entity';
 import { Record } from '../../records/entities/record.entity';
 import { AccessGrant } from '../../access-control/entities/access-grant.entity';
-import { User } from '../../users/entities/user.entity';
+import { User } from '../../auth/entities/user.entity';
 
 @Injectable({ scope: Scope.REQUEST })
 export class DataLoaderService {

--- a/src/graphql/graphql.module.ts
+++ b/src/graphql/graphql.module.ts
@@ -12,7 +12,7 @@ import { GraphQLError } from 'graphql';
 import { Patient } from '../patients/entities/patient.entity';
 import { Record } from '../records/entities/record.entity';
 import { AccessGrant } from '../access-control/entities/access-grant.entity';
-import { User } from '../users/entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 
 import { RecordsModule } from '../records/records.module';
 import { AccessControlModule } from '../access-control/access-control.module';

--- a/src/migrations/1773100000000-AddFeatureFlagsAndMigrationSafety.ts
+++ b/src/migrations/1773100000000-AddFeatureFlagsAndMigrationSafety.ts
@@ -25,7 +25,7 @@ export class AddFeatureFlagsAndMigrationSafety1773100000000 implements Migration
               default: "'ALL'",
             },
             { name: 'rolloutPercentage', type: 'int', default: 0 },
-            { name: 'allowlist', type: 'text', isNullable: true },
+            { name: 'allowlist', type: 'simple-array', isNullable: true },
             { name: 'description', type: 'text', isNullable: true },
             { name: 'updatedBy', type: 'uuid', isNullable: true },
             { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,7 +1,7 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateUserDto } from './create-user.dto';
 import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
-import { UserStatus } from '../enums/medical-role.enum';
+import { UserStatus } from '../../auth/entities/user.entity';
 
 export class UpdateUserDto extends PartialType(CreateUserDto) {
   @IsEnum(UserStatus)

--- a/src/users/entities/patient.entity.ts
+++ b/src/users/entities/patient.entity.ts
@@ -7,7 +7,7 @@ import {
   OneToOne,
   JoinColumn,
 } from 'typeorm';
-import { User } from './user.entity';
+import { User } from '../../auth/entities/user.entity';
 
 @Entity('patients')
 export class Patient {

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,70 +1,7 @@
-import {
-  Entity,
-  PrimaryGeneratedColumn,
-  Column,
-  CreateDateColumn,
-  UpdateDateColumn,
-  OneToOne,
-} from 'typeorm';
-import { MedicalRole, UserStatus } from '../enums/medical-role.enum';
-import { Patient } from './patient.entity';
+/**
+ * @deprecated Import User from '../../auth/entities/user.entity' instead.
+ * This file is kept as a re-export bridge for backward compatibility.
+ * Both User entities have been consolidated into auth/entities/user.entity.
+ */
+export { User, UserRole, UserStatus } from '../../auth/entities/user.entity';
 
-@Entity('users')
-export class User {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
-  @Column({ unique: true })
-  email: string;
-
-  @Column()
-  password: string;
-
-  @Column()
-  firstName: string;
-
-  @Column()
-  lastName: string;
-
-  @Column({ type: 'enum', enum: MedicalRole })
-  role: MedicalRole;
-
-  @Column({ type: 'enum', enum: UserStatus, default: UserStatus.PENDING_VERIFICATION })
-  status: UserStatus;
-
-  @Column({ nullable: true })
-  medicalLicenseNumber: string;
-
-  @Column({ type: 'date', nullable: true })
-  licenseExpiryDate: Date;
-
-  @Column({ nullable: true })
-  specialization: string;
-
-  @Column({ nullable: true })
-  department: string;
-
-  @Column({ default: false })
-  isLicenseVerified: boolean;
-
-  @Column({ type: 'timestamp', nullable: true })
-  licenseVerifiedAt: Date;
-
-  @Column({ nullable: true })
-  verifiedBy: string;
-
-  @Column({ type: 'timestamp', nullable: true })
-  lastAccessRevocationAt: Date;
-
-  @Column({ nullable: true })
-  revocationReason: string;
-
-  @OneToOne(() => Patient, (patient) => patient.user, { nullable: true })
-  patientProfile: Patient;
-
-  @CreateDateColumn()
-  createdAt: Date;
-
-  @UpdateDateColumn()
-  updatedAt: Date;
-}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
-import { User } from './entities/user.entity';
+import { User } from '../auth/entities/user.entity';
 import { Patient } from './entities/patient.entity';
 
 @Module({

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -7,12 +7,12 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
-import { User } from './entities/user.entity';
+import { User, UserStatus } from '../auth/entities/user.entity';
 import { Patient } from './entities/patient.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { MedicalRole, UserStatus } from './enums/medical-role.enum';
+import { MedicalRole } from './enums/medical-role.enum';
 
 @Injectable()
 export class UsersService {
@@ -36,7 +36,7 @@ export class UsersService {
     const hashedPassword = await bcrypt.hash(createUserDto.password, 10);
     const user = this.usersRepository.create({
       ...createUserDto,
-      password: hashedPassword,
+      passwordHash: hashedPassword,
       status: UserStatus.PENDING_VERIFICATION,
     });
 
@@ -52,7 +52,7 @@ export class UsersService {
     const hashedPassword = await bcrypt.hash(createPatientDto.password, 10);
     const user = this.usersRepository.create({
       email: createPatientDto.email,
-      password: hashedPassword,
+      passwordHash: hashedPassword,
       firstName: createPatientDto.firstName,
       lastName: createPatientDto.lastName,
       role: MedicalRole.PATIENT,


### PR DESCRIPTION
##Closes #520
##Closes #521 
---

#This PR Closes:

Issue #520: Changed feature_flags allowlist column from comma-separated text to simple-array (JSON array). Updated entity, DTO, service logic, and migration.

Issue #521: Consolidated two separate User entities (auth/entities/user.entity.ts and users/entities/user.entity.ts) into a single canonical entity at auth/entities/user.entity.ts with all fields from both. Added UserStatus enum, licenseExpiryDate, department, licenseVerifiedAt, verifiedBy, lastAccessRevocationAt, revocationReason, status, and patientProfile relationship. Made users/entities/user.entity.ts a re-export bridge. Updated all imports across the codebase to use the canonical path. Also added patientProfile OneToOne relationship.