### PR TITLE
feat: throttle report jobs and add structured incident evidence capture

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -72,6 +72,7 @@ import { IdempotencyModule } from './idempotency/idempotency.module';
 import { IdempotencyInterceptor } from './idempotency/idempotency.interceptor';
 import { DlqModule } from './dlq/dlq.module';
 import { OperatorRunbookModule } from './operator-runbook/operator-runbook.module';
+import { IncidentModule } from './incident/incident.module';
 
 @Module({
   imports: [
@@ -151,6 +152,7 @@ import { OperatorRunbookModule } from './operator-runbook/operator-runbook.modul
     IdempotencyModule,
     DlqModule,
     OperatorRunbookModule,
+    IncidentModule,
     EventEmitterModule.forRoot(),
  main
   ],

--- a/src/common/logger/custom-logger.service.ts
+++ b/src/common/logger/custom-logger.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Scope, LoggerService } from '@nestjs/common';
 import { PinoLogger } from 'nestjs-pino';
 import { getRequestContext } from '../middleware/request-context.middleware';
+import { pushLogEntry } from '../../incident/incident-log.buffer';
 
 @Injectable({ scope: Scope.TRANSIENT })
 export class CustomLoggerService implements LoggerService {
@@ -22,6 +23,7 @@ export class CustomLoggerService implements LoggerService {
 
   log(message: any, context?: string) {
     this.logger.info(this.enrichLogData(message, context));
+    pushLogEntry({ level: 'info', message: String(message), timestamp: new Date().toISOString(), context });
   }
 
   error(message: any, trace?: string, context?: string) {
@@ -32,10 +34,12 @@ export class CustomLoggerService implements LoggerService {
       },
       message,
     );
+    pushLogEntry({ level: 'error', message: String(message), timestamp: new Date().toISOString(), context });
   }
 
   warn(message: any, context?: string) {
     this.logger.warn(this.enrichLogData(message, context));
+    pushLogEntry({ level: 'warn', message: String(message), timestamp: new Date().toISOString(), context });
   }
 
   debug(message: any, context?: string) {

--- a/src/incident/dto/incident.dto.ts
+++ b/src/incident/dto/incident.dto.ts
@@ -1,0 +1,58 @@
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IncidentSeverity, IncidentStatus } from '../entities/incident-evidence.entity';
+
+export class CaptureIncidentDto {
+  @ApiProperty({ example: 'High RSS on worker-2 during report burst' })
+  @IsString()
+  @MaxLength(255)
+  title: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ enum: IncidentSeverity, default: IncidentSeverity.HIGH })
+  @IsOptional()
+  @IsEnum(IncidentSeverity)
+  severity?: IncidentSeverity;
+
+  @ApiPropertyOptional({ description: 'Operator ID or automated rule name' })
+  @IsOptional()
+  @IsString()
+  triggeredBy?: string;
+
+  @ApiPropertyOptional({ description: 'Arbitrary key/value context (job IDs, queue names, etc.)' })
+  @IsOptional()
+  metadata?: Record<string, any>;
+}
+
+export class ResolveIncidentDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}
+
+export class UpdateIncidentNotesDto {
+  @ApiProperty()
+  @IsString()
+  notes: string;
+}
+
+export class IncidentQueryDto {
+  @ApiPropertyOptional({ enum: IncidentSeverity })
+  @IsOptional()
+  @IsEnum(IncidentSeverity)
+  severity?: IncidentSeverity;
+
+  @ApiPropertyOptional({ enum: IncidentStatus })
+  @IsOptional()
+  @IsEnum(IncidentStatus)
+  status?: IncidentStatus;
+
+  @ApiPropertyOptional({ default: 20 })
+  @IsOptional()
+  limit?: number;
+}

--- a/src/incident/entities/incident-evidence.entity.ts
+++ b/src/incident/entities/incident-evidence.entity.ts
@@ -1,0 +1,102 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum IncidentSeverity {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+  CRITICAL = 'critical',
+}
+
+export enum IncidentStatus {
+  OPEN = 'open',
+  INVESTIGATING = 'investigating',
+  RESOLVED = 'resolved',
+}
+
+/**
+ * Persisted evidence bundle for a severe incident.
+ * Captures a point-in-time snapshot of system state so on-call engineers
+ * have structured, reproducible evidence without needing to reconstruct it
+ * from scattered logs after the fact.
+ */
+@Entity('incident_evidence')
+@Index(['severity', 'status'])
+@Index(['capturedAt'])
+export class IncidentEvidenceEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Human-readable title, e.g. "High memory on worker-2" */
+  @Column({ type: 'varchar', length: 255 })
+  title: string;
+
+  /** Free-text description of what triggered the capture */
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ type: 'enum', enum: IncidentSeverity, default: IncidentSeverity.HIGH })
+  severity: IncidentSeverity;
+
+  @Column({ type: 'enum', enum: IncidentStatus, default: IncidentStatus.OPEN })
+  status: IncidentStatus;
+
+  /** Who or what triggered the capture (operator ID, automated rule name, etc.) */
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  triggeredBy: string;
+
+  /** Active OTel trace ID at capture time, for correlation with Jaeger/Tempo */
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  traceId: string;
+
+  /** Node.js process memory snapshot */
+  @Column({ type: 'jsonb', nullable: true })
+  memorySnapshot: {
+    rss: number;
+    heapUsed: number;
+    heapTotal: number;
+    external: number;
+    arrayBuffers: number;
+  };
+
+  /** process.cpuUsage() delta since process start */
+  @Column({ type: 'jsonb', nullable: true })
+  cpuSnapshot: {
+    user: number;
+    system: number;
+  };
+
+  /** BullMQ queue depths at capture time */
+  @Column({ type: 'jsonb', nullable: true })
+  queueSnapshot: Record<string, { waiting: number; active: number; failed: number; delayed: number }>;
+
+  /** Recent structured log lines (last N entries from in-memory ring buffer) */
+  @Column({ type: 'jsonb', nullable: true })
+  recentLogs: Array<{ level: string; message: string; timestamp: string; context?: string }>;
+
+  /** Active OTel span context for correlation */
+  @Column({ type: 'jsonb', nullable: true })
+  traceContext: { traceId?: string; spanId?: string; traceFlags?: number };
+
+  /** Arbitrary key/value metadata (e.g. triggering job ID, patient ID, queue name) */
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, any>;
+
+  /** Operator notes added during investigation */
+  @Column({ type: 'text', nullable: true })
+  notes: string;
+
+  @CreateDateColumn()
+  capturedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  resolvedAt: Date;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  resolvedBy: string;
+}

--- a/src/incident/incident-evidence.controller.ts
+++ b/src/incident/incident-evidence.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { IncidentEvidenceService } from './incident-evidence.service';
+import {
+  CaptureIncidentDto,
+  IncidentQueryDto,
+  ResolveIncidentDto,
+  UpdateIncidentNotesDto,
+} from './dto/incident.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@ApiTags('incidents')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('incidents')
+export class IncidentEvidenceController {
+  constructor(private readonly service: IncidentEvidenceService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Capture a structured incident evidence bundle' })
+  @ApiResponse({ status: 201, description: 'Evidence bundle persisted' })
+  capture(@Body() dto: CaptureIncidentDto, @Req() req: Request) {
+    const triggeredBy = dto.triggeredBy ?? (req.user as any)?.id ?? 'unknown';
+    return this.service.capture({ ...dto, triggeredBy });
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List incident evidence bundles' })
+  list(@Query() query: IncidentQueryDto) {
+    return this.service.list(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single incident evidence bundle' })
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Patch(':id/resolve')
+  @ApiOperation({ summary: 'Mark an incident as resolved' })
+  resolve(
+    @Param('id') id: string,
+    @Body() dto: ResolveIncidentDto,
+    @Req() req: Request,
+  ) {
+    const resolvedBy = (req.user as any)?.id ?? 'unknown';
+    return this.service.resolve(id, dto, resolvedBy);
+  }
+
+  @Patch(':id/notes')
+  @ApiOperation({ summary: 'Append investigation notes to an incident' })
+  addNotes(@Param('id') id: string, @Body() dto: UpdateIncidentNotesDto) {
+    return this.service.addNotes(id, dto);
+  }
+}

--- a/src/incident/incident-evidence.service.ts
+++ b/src/incident/incident-evidence.service.ts
@@ -1,0 +1,195 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import {
+  IncidentEvidenceEntity,
+  IncidentSeverity,
+  IncidentStatus,
+} from './entities/incident-evidence.entity';
+import {
+  CaptureIncidentDto,
+  IncidentQueryDto,
+  ResolveIncidentDto,
+  UpdateIncidentNotesDto,
+} from './dto/incident.dto';
+import { TracingService } from '../common/services/tracing.service';
+import { QUEUE_NAMES } from '../queues/queue.constants';
+import { getRecentLogs } from './incident-log.buffer';
+
+/**
+ * IncidentEvidenceService
+ *
+ * Captures a structured evidence bundle at the moment a severe incident is
+ * declared. The bundle includes:
+ *
+ *  - Process memory & CPU snapshot (RSS, heap, CPU user/sys)
+ *  - BullMQ queue depths for every registered queue
+ *  - Last 50 structured log entries from the in-memory ring buffer
+ *  - Active OTel trace context for correlation with Jaeger/Tempo
+ *  - Caller-supplied metadata (job IDs, patient IDs, queue names, etc.)
+ *
+ * All evidence is persisted to `incident_evidence` so it survives restarts
+ * and can be queried by operators via the REST API.
+ */
+@Injectable()
+export class IncidentEvidenceService {
+  private readonly logger = new Logger(IncidentEvidenceService.name);
+
+  /** Map of queue name → injected Queue instance for depth snapshots */
+  private readonly queues: Map<string, Queue>;
+
+  constructor(
+    @InjectRepository(IncidentEvidenceEntity)
+    private readonly repo: Repository<IncidentEvidenceEntity>,
+
+    private readonly tracingService: TracingService,
+
+    @InjectQueue(QUEUE_NAMES.STELLAR_TRANSACTIONS)
+    private readonly stellarQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.CONTRACT_WRITES)
+    private readonly contractWritesQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.IPFS_UPLOADS)
+    private readonly ipfsQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EVENT_INDEXING)
+    private readonly eventIndexingQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EMAIL_NOTIFICATIONS)
+    private readonly emailQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.REPORTS)
+    private readonly reportsQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EHR_IMPORT)
+    private readonly ehrImportQueue: Queue,
+  ) {
+    this.queues = new Map([
+      [QUEUE_NAMES.STELLAR_TRANSACTIONS, this.stellarQueue],
+      [QUEUE_NAMES.CONTRACT_WRITES, this.contractWritesQueue],
+      [QUEUE_NAMES.IPFS_UPLOADS, this.ipfsQueue],
+      [QUEUE_NAMES.EVENT_INDEXING, this.eventIndexingQueue],
+      [QUEUE_NAMES.EMAIL_NOTIFICATIONS, this.emailQueue],
+      [QUEUE_NAMES.REPORTS, this.reportsQueue],
+      [QUEUE_NAMES.EHR_IMPORT, this.ehrImportQueue],
+    ]);
+  }
+
+  /**
+   * Capture a full evidence bundle and persist it.
+   * Call this as soon as an incident is detected — the snapshot is point-in-time.
+   */
+  async capture(dto: CaptureIncidentDto): Promise<IncidentEvidenceEntity> {
+    const [memorySnapshot, cpuSnapshot, queueSnapshot, recentLogs, traceContext] =
+      await Promise.all([
+        this.snapshotMemory(),
+        this.snapshotCpu(),
+        this.snapshotQueues(),
+        Promise.resolve(getRecentLogs(50)),
+        Promise.resolve(this.tracingService.getCurrentTraceContext()),
+      ]);
+
+    const entity = this.repo.create({
+      title: dto.title,
+      description: dto.description,
+      severity: dto.severity ?? IncidentSeverity.HIGH,
+      status: IncidentStatus.OPEN,
+      triggeredBy: dto.triggeredBy,
+      traceId: traceContext.traceId,
+      memorySnapshot,
+      cpuSnapshot,
+      queueSnapshot,
+      recentLogs,
+      traceContext,
+      metadata: dto.metadata,
+    });
+
+    const saved = await this.repo.save(entity);
+
+    this.logger.warn(
+      `[incident] Evidence captured — id=${saved.id} severity=${saved.severity} ` +
+      `rss=${memorySnapshot.rss}MB title="${saved.title}"`,
+    );
+
+    return saved;
+  }
+
+  async list(query: IncidentQueryDto): Promise<IncidentEvidenceEntity[]> {
+    const where: Partial<IncidentEvidenceEntity> = {};
+    if (query.severity) where.severity = query.severity;
+    if (query.status) where.status = query.status;
+
+    return this.repo.find({
+      where,
+      order: { capturedAt: 'DESC' },
+      take: query.limit ?? 20,
+    });
+  }
+
+  async get(id: string): Promise<IncidentEvidenceEntity> {
+    const entity = await this.repo.findOne({ where: { id } });
+    if (!entity) throw new NotFoundException(`Incident evidence ${id} not found`);
+    return entity;
+  }
+
+  async resolve(id: string, dto: ResolveIncidentDto, resolvedBy: string): Promise<IncidentEvidenceEntity> {
+    const entity = await this.get(id);
+    entity.status = IncidentStatus.RESOLVED;
+    entity.resolvedAt = new Date();
+    entity.resolvedBy = resolvedBy;
+    if (dto.notes) {
+      entity.notes = entity.notes ? `${entity.notes}\n${dto.notes}` : dto.notes;
+    }
+    const saved = await this.repo.save(entity);
+    this.logger.log(`[incident] Evidence ${id} resolved by ${resolvedBy}`);
+    return saved;
+  }
+
+  async addNotes(id: string, dto: UpdateIncidentNotesDto): Promise<IncidentEvidenceEntity> {
+    const entity = await this.get(id);
+    entity.notes = entity.notes ? `${entity.notes}\n${dto.notes}` : dto.notes;
+    entity.status = IncidentStatus.INVESTIGATING;
+    return this.repo.save(entity);
+  }
+
+  // ── Private snapshot helpers ──────────────────────────────────────────────
+
+  private snapshotMemory() {
+    const m = process.memoryUsage();
+    const mb = (bytes: number) => Math.round(bytes / 1024 / 1024);
+    return Promise.resolve({
+      rss: mb(m.rss),
+      heapUsed: mb(m.heapUsed),
+      heapTotal: mb(m.heapTotal),
+      external: mb(m.external),
+      arrayBuffers: mb(m.arrayBuffers),
+    });
+  }
+
+  private snapshotCpu() {
+    const c = process.cpuUsage();
+    return Promise.resolve({ user: c.user, system: c.system });
+  }
+
+  private async snapshotQueues(): Promise<
+    Record<string, { waiting: number; active: number; failed: number; delayed: number }>
+  > {
+    const snapshot: Record<string, { waiting: number; active: number; failed: number; delayed: number }> = {};
+
+    await Promise.all(
+      Array.from(this.queues.entries()).map(async ([name, queue]) => {
+        try {
+          const [waiting, active, failed, delayed] = await Promise.all([
+            queue.getWaitingCount(),
+            queue.getActiveCount(),
+            queue.getFailedCount(),
+            queue.getDelayedCount(),
+          ]);
+          snapshot[name] = { waiting, active, failed, delayed };
+        } catch (err) {
+          this.logger.warn(`[incident] Could not snapshot queue ${name}: ${err}`);
+          snapshot[name] = { waiting: -1, active: -1, failed: -1, delayed: -1 };
+        }
+      }),
+    );
+
+    return snapshot;
+  }
+}

--- a/src/incident/incident-log.buffer.ts
+++ b/src/incident/incident-log.buffer.ts
@@ -1,0 +1,33 @@
+/**
+ * In-memory ring buffer that captures the last N structured log entries.
+ *
+ * Pino writes to stdout; we can't easily tail it at runtime. Instead, the
+ * CustomLoggerService pushes entries here so IncidentEvidenceService can
+ * include recent logs in an evidence bundle without hitting the database or
+ * an external log aggregator.
+ *
+ * The buffer is intentionally small (default 200 entries) to keep memory
+ * overhead negligible. It is a singleton so all logger instances share it.
+ */
+
+export interface LogEntry {
+  level: string;
+  message: string;
+  timestamp: string;
+  context?: string;
+  traceId?: string;
+}
+
+const MAX_ENTRIES = parseInt(process.env.INCIDENT_LOG_BUFFER_SIZE || '200', 10);
+const buffer: LogEntry[] = [];
+
+export function pushLogEntry(entry: LogEntry): void {
+  if (buffer.length >= MAX_ENTRIES) {
+    buffer.shift(); // drop oldest
+  }
+  buffer.push(entry);
+}
+
+export function getRecentLogs(n = 50): LogEntry[] {
+  return buffer.slice(-n);
+}

--- a/src/incident/incident.module.ts
+++ b/src/incident/incident.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bullmq';
+import { IncidentEvidenceEntity } from './entities/incident-evidence.entity';
+import { IncidentEvidenceService } from './incident-evidence.service';
+import { IncidentEvidenceController } from './incident-evidence.controller';
+import { CommonModule } from '../common/common.module';
+import { QUEUE_NAMES } from '../queues/queue.constants';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([IncidentEvidenceEntity]),
+    CommonModule, // provides TracingService
+    BullModule.registerQueue(
+      { name: QUEUE_NAMES.STELLAR_TRANSACTIONS },
+      { name: QUEUE_NAMES.CONTRACT_WRITES },
+      { name: QUEUE_NAMES.IPFS_UPLOADS },
+      { name: QUEUE_NAMES.EVENT_INDEXING },
+      { name: QUEUE_NAMES.EMAIL_NOTIFICATIONS },
+      { name: QUEUE_NAMES.REPORTS },
+      { name: QUEUE_NAMES.EHR_IMPORT },
+    ),
+  ],
+  controllers: [IncidentEvidenceController],
+  providers: [IncidentEvidenceService],
+  exports: [IncidentEvidenceService],
+})
+export class IncidentModule {}

--- a/src/medical-records/processors/report.processor.ts
+++ b/src/medical-records/processors/report.processor.ts
@@ -13,8 +13,36 @@ import { Patient } from '../../patients/entities/patient.entity';
 import * as path from 'path';
 import * as fs from 'fs';
 
+/**
+ * ReportProcessor
+ *
+ * Throttling strategy to prevent CPU/memory starvation of other queues:
+ *
+ *  concurrency: 1
+ *    Only one report builds at a time per worker instance.
+ *    PDF/CSV generation is CPU-bound; running multiple in parallel would
+ *    spike CPU and RSS, starving stellar-transactions and contract-writes.
+ *
+ *  limiter: 2 jobs per 10 s
+ *    Even if multiple worker replicas are running, the shared Redis-backed
+ *    rate limiter caps total throughput to 2 reports/10 s cluster-wide.
+ *    This keeps the reports queue from monopolising Redis I/O.
+ *
+ *  maxStalledCount: 2
+ *    BullMQ will re-queue a stalled job up to 2 times before marking it
+ *    failed, giving the DLQ capture listener a chance to record it.
+ */
 @Injectable()
-@Processor(QUEUE_NAMES.REPORTS)
+@Processor(QUEUE_NAMES.REPORTS, {
+  concurrency: 1,
+  limiter: {
+    max: 2,
+    duration: 10_000, // 2 jobs per 10 seconds across all workers
+  },
+  settings: {
+    maxStalledCount: 2,
+  },
+})
 export class ReportProcessor extends WorkerHost {
   private readonly logger = new Logger(ReportProcessor.name);
 
@@ -32,6 +60,28 @@ export class ReportProcessor extends WorkerHost {
   async process(job: Job): Promise<void> {
     const { jobId, patientId, format } = job.data;
 
+    // Memory guard: if RSS > 85 % of available memory, pause this worker and
+    // re-queue the job so a less-loaded replica can pick it up.
+    const memUsage = process.memoryUsage();
+    const rssMb = memUsage.rss / 1024 / 1024;
+    const heapTotalMb = memUsage.heapTotal / 1024 / 1024;
+    const RSS_LIMIT_MB = parseInt(process.env.REPORT_WORKER_RSS_LIMIT_MB || '512', 10);
+
+    if (rssMb > RSS_LIMIT_MB) {
+      this.logger.warn(
+        `[reports] Memory pressure detected — RSS=${rssMb.toFixed(0)} MB > limit=${RSS_LIMIT_MB} MB. ` +
+        `Re-queuing job ${jobId} with 30 s delay.`,
+      );
+      // Move back to waiting with a delay so another worker can pick it up
+      await job.moveToDelayed(Date.now() + 30_000);
+      return;
+    }
+
+    this.logger.log(
+      `[reports] Processing job=${jobId} format=${format} attempt=${job.attemptsMade + 1} ` +
+      `rss=${rssMb.toFixed(0)}MB heap=${heapTotalMb.toFixed(0)}MB`,
+    );
+
     try {
       this.logger.log(`Processing report job: ${jobId}`);
       await this.reportGenerationService.markAsProcessing(jobId);
@@ -44,14 +94,20 @@ export class ReportProcessor extends WorkerHost {
       const fileName = `report-${jobId}.${format}`;
       const filePath = path.join(tempDir, fileName);
 
+      await job.updateProgress(20);
+
       if (format === ReportFormat.PDF) {
         await this.reportBuilderService.generatePDF(patientId, filePath);
       } else {
         await this.reportBuilderService.generateCSV(patientId, filePath);
       }
 
+      await job.updateProgress(60);
+
       const ipfsHash = await this.ipfsService.uploadFile(filePath);
       fs.unlinkSync(filePath);
+
+      await job.updateProgress(80);
 
       await this.reportGenerationService.markAsCompleted(jobId, ipfsHash);
 
@@ -71,6 +127,7 @@ export class ReportProcessor extends WorkerHost {
         }
       }
 
+      await job.updateProgress(100);
       this.logger.log(`Report job completed: ${jobId}`);
     } catch (error) {
       this.logger.error(`Report job failed: ${jobId}`, error.stack);

--- a/src/medical-records/services/report-generation.service.ts
+++ b/src/medical-records/services/report-generation.service.ts
@@ -32,6 +32,14 @@ export class ReportGenerationService {
       jobId: job.id,
       patientId,
       format,
+    }, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5_000 },
+      // Hard timeout: kill the job if it runs longer than 10 minutes.
+      // This prevents a single runaway report from blocking the worker indefinitely.
+      timeout: 10 * 60 * 1000,
+      removeOnComplete: true,
+      removeOnFail: false, // keep for DLQ capture
     });
 
     this.logger.log(`Report generation queued: ${job.id}`);

--- a/src/migrations/1775800000000-CreateIncidentEvidenceTable.ts
+++ b/src/migrations/1775800000000-CreateIncidentEvidenceTable.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateIncidentEvidenceTable1775800000000 implements MigrationInterface {
+  name = 'CreateIncidentEvidenceTable1775800000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "public"."incident_evidence_severity_enum" AS ENUM (
+        'low', 'medium', 'high', 'critical'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "public"."incident_evidence_status_enum" AS ENUM (
+        'open', 'investigating', 'resolved'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "incident_evidence" (
+        "id"               UUID NOT NULL DEFAULT uuid_generate_v4(),
+        "title"            VARCHAR(255) NOT NULL,
+        "description"      TEXT,
+        "severity"         "public"."incident_evidence_severity_enum" NOT NULL DEFAULT 'high',
+        "status"           "public"."incident_evidence_status_enum"   NOT NULL DEFAULT 'open',
+        "triggeredBy"      VARCHAR(255),
+        "traceId"          VARCHAR(64),
+        "memorySnapshot"   JSONB,
+        "cpuSnapshot"      JSONB,
+        "queueSnapshot"    JSONB,
+        "recentLogs"       JSONB,
+        "traceContext"     JSONB,
+        "metadata"         JSONB,
+        "notes"            TEXT,
+        "capturedAt"       TIMESTAMP NOT NULL DEFAULT now(),
+        "resolvedAt"       TIMESTAMP,
+        "resolvedBy"       VARCHAR(255),
+        CONSTRAINT "PK_incident_evidence" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_incident_evidence_severity_status"
+        ON "incident_evidence" ("severity", "status")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_incident_evidence_capturedAt"
+        ON "incident_evidence" ("capturedAt")
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_incident_evidence_capturedAt"`);
+    await queryRunner.query(`DROP INDEX "IDX_incident_evidence_severity_status"`);
+    await queryRunner.query(`DROP TABLE "incident_evidence"`);
+    await queryRunner.query(`DROP TYPE "public"."incident_evidence_status_enum"`);
+    await queryRunner.query(`DROP TYPE "public"."incident_evidence_severity_enum"`);
+  }
+}

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -158,7 +158,7 @@ export class ReportsService {
 
       const downloadToken = uuidv4();
       const expiresAt = new Date();
-      expiresAt.setHours(expiresAt.getHours() + 48); // 48 hours local IPFS expiry rule proxy equivalent
+      expiresAt.setHours(expiresAt.getHours() + 48);
 
       await this.reportJobRepository.update(jobId, {
         status: ReportStatus.COMPLETED,
@@ -219,7 +219,6 @@ export class ReportsService {
       doc.on('end', () => resolve(Buffer.concat(chunks)));
       doc.on('error', reject);
 
-      // Header
       doc.fontSize(20).text('Patient Activity Report', { align: 'center' });
       doc.moveDown();
       doc.fontSize(12).text(`Patient Name: ${patient?.firstName || ''} ${patient?.lastName || ''}`);
@@ -227,16 +226,13 @@ export class ReportsService {
       doc.text(`Generated On: ${new Date().toLocaleString()}`);
       doc.moveDown(2);
 
-      // Records
       doc.fontSize(16).text('Medical Records Summary');
       doc.moveDown(0.5);
       if (records.length === 0) doc.fontSize(10).text('No recent active records found.');
       records.forEach((record) => {
-        doc
-          .fontSize(10)
-          .text(
-            `- [${new Date(record.createdAt).toLocaleDateString()}] ${record.recordType?.toUpperCase() || 'UNKNOWN'}`,
-          );
+        doc.fontSize(10).text(
+          `- [${new Date(record.createdAt).toLocaleDateString()}] ${record.recordType?.toUpperCase() || 'UNKNOWN'}`,
+        );
         if (record.title) doc.text(`  Title: ${record.title}`);
         if (record.metadata?.transactionHash) {
           doc.fillColor('blue').fontSize(8).text(`  Tx Hash: ${record.metadata.transactionHash}`);
@@ -246,7 +242,6 @@ export class ReportsService {
       });
       doc.moveDown();
 
-      // Grants
       doc.fontSize(16).text('Access Grants & Consents');
       doc.moveDown(0.5);
       if (grants.length === 0) doc.fontSize(10).text('No access grants found.');
@@ -263,16 +258,13 @@ export class ReportsService {
       });
       doc.moveDown();
 
-      // Logs
       doc.fontSize(16).text('Recent Audit Logs');
       doc.moveDown(0.5);
       if (logs.length === 0) doc.fontSize(10).text('No audit logs found.');
       logs.forEach((log) => {
-        doc
-          .fontSize(9)
-          .text(
-            `[${new Date(log.timestamp).toLocaleString()}] ${log.action} - ${log.description || ''}`,
-          );
+        doc.fontSize(9).text(
+          `[${new Date(log.timestamp).toLocaleString()}] ${log.action} - ${log.description || ''}`,
+        );
         if (log.details?.transactionHash) {
           doc.fillColor('gray').fontSize(7).text(`  Tx Hash: ${log.details?.transactionHash}`);
           doc.fillColor('black');


### PR DESCRIPTION
- Add concurrency=1, rate limiter (2/10s), and memory guard to ReportProcessor to prevent CPU/RSS spikes from starving stellar-transactions and contract-writes
- Add 10-minute job timeout to ReportGenerationService queue dispatch
- Implement IncidentEvidenceService with point-in-time snapshot capture: memory (RSS/heap), CPU usage, per-queue depths, last 50 log entries, and active OTel trace context
- Add in-memory log ring buffer (200 entries) fed by CustomLoggerService so recent logs are available at capture time without hitting a log aggregator
- Expose REST API: POST/GET /incidents, PATCH /incidents/:id/resolve|notes
- Add migration 1775800000000-CreateIncidentEvidenceTable

Closes #451
Closes #457