### PR TITLE
feat: event store snapshot cleanup, Stellar observability, IPFS health, Bull queue resilience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,10 @@ ENABLE_AUDIT_LOGGING=true
 # Data Retention Policy (medical data law default: 7 years)
 RECORD_RETENTION_YEARS=7
 
+# Event-store snapshot retention: number of most-recent snapshots to keep per aggregate.
+# Older snapshots are pruned nightly. Minimum 1.
+SNAPSHOT_RETENTION_COUNT=3
+
 # HIPAA Compliance Settings
 ENABLE_DATA_ENCRYPTION=true
 ENABLE_ACCESS_LOGGING=true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -67,6 +67,12 @@ services:
     networks:
       - healthy-stellar-network
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:5001/api/v0/id"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
 
 networks:
   healthy-stellar-network:

--- a/src/common/utils/connection-retry.util.ts
+++ b/src/common/utils/connection-retry.util.ts
@@ -24,13 +24,15 @@ export function createTypeOrmRetryCallback(
   };
 }
 
+const REDIS_BASE_DELAY_MS = 500;
+const REDIS_MAX_DELAY_MS = 30_000;
+
 /**
- * Returns an ioredis-compatible `retryStrategy` callback.
- * Logs each attempt, exits with code 1 after MAX_RETRIES exhausted.
+ * Returns an ioredis-compatible `retryStrategy` callback with exponential backoff.
+ * Exits with code 1 after MAX_RETRIES exhausted.
  */
 export function createRedisRetryStrategy(
   maxRetries = MAX_RETRIES,
-  delayMs = RETRY_DELAY_MS,
 ): (times: number) => number | null {
   return (times: number): number | null => {
     console.error(`[Redis] Connection attempt ${times} failed.`);
@@ -40,6 +42,7 @@ export function createRedisRetryStrategy(
       );
       process.exit(1);
     }
-    return delayMs;
+    const delay = Math.min(REDIS_BASE_DELAY_MS * Math.pow(2, times - 1), REDIS_MAX_DELAY_MS);
+    return delay;
   };
 }

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -10,8 +10,10 @@ import { RegionalIpfsService } from '../data-residency/services/regional-ipfs.se
 import { DataResidencyRegion } from '../enums/data-residency.enum';
 import { DetailedHealthIndicator } from './indicators/detailed-health.indicator';
 import { IpfsHealthIndicator } from './indicators/ipfs.health';
+import { QueueHealthIndicator } from './indicators/queue.health';
 import { RedisHealthIndicator } from './indicators/redis.health';
 import { StellarHealthIndicator } from './indicators/stellar.health';
+import { SyntheticProbeIndicator } from './indicators/synthetic-probe.indicator';
 
 enum DependencyLevel {
   CRITICAL = 'critical', // Must be healthy for system to be ready
@@ -51,6 +53,11 @@ export class HealthController {
       level: DependencyLevel.IMPORTANT,
       check: () => this.ipfs.isHealthy('ipfs'),
     },
+    {
+      name: 'queues',
+      level: DependencyLevel.IMPORTANT,
+      check: () => this.queues.isHealthy('queues'),
+    },
   ];
 
   constructor(
@@ -58,6 +65,7 @@ export class HealthController {
     private db: TypeOrmHealthIndicator,
     private redis: RedisHealthIndicator,
     private ipfs: IpfsHealthIndicator,
+    private queues: QueueHealthIndicator,
     private stellar: StellarHealthIndicator,
     private detailedHealth: DetailedHealthIndicator,
     private syntheticProbe: SyntheticProbeIndicator,

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -9,6 +9,7 @@ import { QUEUE_NAMES } from '../queues/queue.constants';
 import { HealthController } from './health.controller';
 import { DetailedHealthIndicator } from './indicators/detailed-health.indicator';
 import { IpfsHealthIndicator } from './indicators/ipfs.health';
+import { QueueHealthIndicator } from './indicators/queue.health';
 import { RedisHealthIndicator } from './indicators/redis.health';
 import { StellarHealthIndicator } from './indicators/stellar.health';
 import { SyntheticProbeIndicator } from './indicators/synthetic-probe.indicator';
@@ -31,6 +32,7 @@ import { SyntheticProbeIndicator } from './indicators/synthetic-probe.indicator'
   providers: [
     RedisHealthIndicator,
     IpfsHealthIndicator,
+    QueueHealthIndicator,
     StellarHealthIndicator,
     DetailedHealthIndicator,
     SyntheticProbeIndicator,

--- a/src/health/indicators/ipfs.health.ts
+++ b/src/health/indicators/ipfs.health.ts
@@ -19,7 +19,7 @@ export class IpfsHealthIndicator extends HealthIndicator {
 
     try {
       await firstValueFrom(
-        this.httpService.post(`${ipfsUrl}/api/v0/version`, null, { timeout: 5000 }),
+        this.httpService.post(`${ipfsUrl}/api/v0/id`, null, { timeout: 3000 }),
       );
 
       const responseTime = Date.now() - startTime;

--- a/src/health/indicators/queue.health.ts
+++ b/src/health/indicators/queue.health.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from '@nestjs/terminus';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { QUEUE_NAMES } from '../../queues/queue.constants';
+
+@Injectable()
+export class QueueHealthIndicator extends HealthIndicator {
+  constructor(
+    @InjectQueue(QUEUE_NAMES.STELLAR_TRANSACTIONS)
+    private stellarQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.EMAIL_NOTIFICATIONS)
+    private emailQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.IPFS_UPLOADS)
+    private ipfsQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.REPORTS)
+    private reportsQueue: Queue,
+  ) {
+    super();
+  }
+
+  async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    const queues: [string, Queue][] = [
+      [QUEUE_NAMES.STELLAR_TRANSACTIONS, this.stellarQueue],
+      [QUEUE_NAMES.EMAIL_NOTIFICATIONS, this.emailQueue],
+      [QUEUE_NAMES.IPFS_UPLOADS, this.ipfsQueue],
+      [QUEUE_NAMES.REPORTS, this.reportsQueue],
+    ];
+
+    const details: Record<string, { waiting: number; active: number; failed: number }> = {};
+    let healthy = true;
+
+    for (const [name, queue] of queues) {
+      try {
+        const [waiting, active, failed] = await Promise.all([
+          queue.getWaitingCount(),
+          queue.getActiveCount(),
+          queue.getFailedCount(),
+        ]);
+        details[name] = { waiting, active, failed };
+      } catch {
+        healthy = false;
+        details[name] = { waiting: -1, active: -1, failed: -1 };
+      }
+    }
+
+    if (!healthy) {
+      throw new HealthCheckError(
+        'Queue health check failed',
+        this.getStatus(key, false, details),
+      );
+    }
+
+    return this.getStatus(key, true, details);
+  }
+}

--- a/src/health/indicators/stellar.health.ts
+++ b/src/health/indicators/stellar.health.ts
@@ -1,14 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from '@nestjs/terminus';
 import { ConfigService } from '@nestjs/config';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
+import { StellarTransactionRetryService } from '../../stellar/services/stellar-transaction-retry.service';
 
 @Injectable()
 export class StellarHealthIndicator extends HealthIndicator {
   constructor(
     private configService: ConfigService,
     private httpService: HttpService,
+    @Optional() private retryService?: StellarTransactionRetryService,
   ) {
     super();
   }
@@ -20,16 +22,27 @@ export class StellarHealthIndicator extends HealthIndicator {
       'https://horizon-testnet.stellar.org',
     );
 
+    const retryConfig = this.retryService?.getConfig();
+
     try {
       await firstValueFrom(this.httpService.get(`${horizonUrl}/`, { timeout: 5000 }));
 
       const responseTime = Date.now() - startTime;
-      return this.getStatus(key, true, { responseTime: `${responseTime}ms` });
+      return this.getStatus(key, true, {
+        responseTime: `${responseTime}ms`,
+        retryConfig,
+        metricsEndpoint: '/metrics',
+      });
     } catch (error) {
       const responseTime = Date.now() - startTime;
       throw new HealthCheckError(
         'Stellar Horizon check failed',
-        this.getStatus(key, false, { responseTime: `${responseTime}ms`, error: error.message }),
+        this.getStatus(key, false, {
+          responseTime: `${responseTime}ms`,
+          error: error.message,
+          retryConfig,
+          metricsEndpoint: '/metrics',
+        }),
       );
     }
   }

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -1,12 +1,18 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AccessGrant } from '../access-control/entities/access-grant.entity';
+import { AggregateSnapshotEntity } from '../event-store/aggregate-snapshot.entity';
 import { CommonModule } from '../common/common.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { AccessGrantCleanupTask } from './access-grant-cleanup.task';
+import { SnapshotCleanupTask } from './snapshot-cleanup.task';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AccessGrant]), NotificationsModule, CommonModule],
-  providers: [AccessGrantCleanupTask],
+  imports: [
+    TypeOrmModule.forFeature([AccessGrant, AggregateSnapshotEntity]),
+    NotificationsModule,
+    CommonModule,
+  ],
+  providers: [AccessGrantCleanupTask, SnapshotCleanupTask],
 })
 export class JobsModule {}

--- a/src/jobs/snapshot-cleanup.task.ts
+++ b/src/jobs/snapshot-cleanup.task.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { AggregateSnapshotEntity } from '../event-store/aggregate-snapshot.entity';
+
+@Injectable()
+export class SnapshotCleanupTask {
+  private readonly logger = new Logger(SnapshotCleanupTask.name);
+
+  constructor(
+    @InjectRepository(AggregateSnapshotEntity)
+    private readonly snapshotRepo: Repository<AggregateSnapshotEntity>,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async pruneStaleSnapshots(): Promise<void> {
+    const retainCount = this.configService.get<number>('SNAPSHOT_RETENTION_COUNT', 3);
+    this.logger.log(`SnapshotCleanupTask: pruning snapshots, retaining latest ${retainCount} per aggregate`);
+
+    // Get all distinct aggregate IDs that have more than retainCount snapshots
+    const aggregates: { aggregate_id: string; total: string }[] = await this.snapshotRepo
+      .createQueryBuilder('s')
+      .select('s.aggregate_id', 'aggregate_id')
+      .addSelect('COUNT(*)', 'total')
+      .groupBy('s.aggregate_id')
+      .having('COUNT(*) > :retainCount', { retainCount })
+      .getRawMany();
+
+    let deleted = 0;
+    let errors = 0;
+
+    for (const { aggregate_id } of aggregates) {
+      try {
+        // Find IDs to keep (latest retainCount by version)
+        const toKeep = await this.snapshotRepo.find({
+          where: { aggregateId: aggregate_id },
+          order: { version: 'DESC' },
+          take: retainCount,
+          select: ['id'],
+        });
+
+        const keepIds = toKeep.map((s) => s.id);
+
+        if (keepIds.length === 0) continue;
+
+        const result = await this.snapshotRepo
+          .createQueryBuilder()
+          .delete()
+          .where('aggregate_id = :aggregateId', { aggregateId: aggregate_id })
+          .andWhere('id NOT IN (:...keepIds)', { keepIds })
+          .execute();
+
+        deleted += result.affected ?? 0;
+      } catch (err) {
+        errors++;
+        this.logger.error(`SnapshotCleanupTask: error pruning aggregate ${aggregate_id}: ${err.message}`);
+      }
+    }
+
+    this.logger.log(`SnapshotCleanupTask: done — deleted ${deleted} stale snapshots, errors: ${errors}`);
+  }
+}

--- a/src/metrics/custom-metrics.service.ts
+++ b/src/metrics/custom-metrics.service.ts
@@ -110,6 +110,26 @@ export const SubscriptionsActiveGauge = makeGaugeProvider({
   help: 'Current number of live GraphQL subscription iterators',
 });
 
+// ── Stellar transaction recovery metrics (issue #570) ─────────────────────────
+
+export const StellarTxAttemptsCounter = makeCounterProvider({
+  name: 'stellar_tx_attempts_total',
+  help: 'Total number of Stellar transaction submission attempts',
+  labelNames: ['operation'],
+});
+
+export const StellarTxRetriesCounter = makeCounterProvider({
+  name: 'stellar_tx_retries_total',
+  help: 'Total number of Stellar transaction retry attempts',
+  labelNames: ['operation', 'error_type'],
+});
+
+export const StellarTxFailuresCounter = makeCounterProvider({
+  name: 'stellar_tx_failures_total',
+  help: 'Total number of Stellar transactions that permanently failed',
+  labelNames: ['operation', 'error_type'],
+});
+
 // ── Service ───────────────────────────────────────────────────────────────────
 
 @Injectable()
@@ -148,6 +168,14 @@ export class CustomMetricsService {
     public activeProvidersGauge: Gauge<string>,
     @InjectMetric('subscriptions_active')
     public subscriptionsActiveGauge: Gauge<string>,
+
+    // Stellar recovery metrics
+    @InjectMetric('stellar_tx_attempts_total')
+    public stellarTxAttemptsCounter: Counter<string>,
+    @InjectMetric('stellar_tx_retries_total')
+    public stellarTxRetriesCounter: Counter<string>,
+    @InjectMetric('stellar_tx_failures_total')
+    public stellarTxFailuresCounter: Counter<string>,
   ) {}
 
   // ── Existing helpers ────────────────────────────────────────────────────────
@@ -230,5 +258,17 @@ export class CustomMetricsService {
 
   setActiveProviders(count: number) {
     this.activeProvidersGauge.set(count);
+  }
+
+  recordStellarTxAttempt(operation: string) {
+    this.stellarTxAttemptsCounter.inc({ operation });
+  }
+
+  recordStellarTxRetry(operation: string, errorType: string) {
+    this.stellarTxRetriesCounter.inc({ operation, error_type: errorType });
+  }
+
+  recordStellarTxFailure(operation: string, errorType: string) {
+    this.stellarTxFailuresCounter.inc({ operation, error_type: errorType });
   }
 }

--- a/src/metrics/metrics.module.ts
+++ b/src/metrics/metrics.module.ts
@@ -24,6 +24,9 @@ import {
   ActivePatientsTotalGauge,
   ActiveProvidersTotalGauge,
   SubscriptionsActiveGauge,
+  StellarTxAttemptsCounter,
+  StellarTxRetriesCounter,
+  StellarTxFailuresCounter,
 } from './custom-metrics.service';
 import { HttpMetricsInterceptor } from './interceptors/http-metrics.interceptor';
 import { DbMetricsSubscriber } from './subscribers/db-metrics.subscriber';
@@ -76,6 +79,10 @@ import { QUEUE_NAMES } from '../queues/queue.constants';
     ActivePatientsTotalGauge,
     ActiveProvidersTotalGauge,
     SubscriptionsActiveGauge,
+    // Stellar recovery metric providers
+    StellarTxAttemptsCounter,
+    StellarTxRetriesCounter,
+    StellarTxFailuresCounter,
     // Interceptor, subscriber, collectors
     HttpMetricsInterceptor,
     DbMetricsSubscriber,

--- a/src/queues/queue.module.ts
+++ b/src/queues/queue.module.ts
@@ -34,6 +34,16 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
           db: configService.get('REDIS_DB', 0),
           maxRetriesPerRequest: null,
           retryStrategy: createRedisRetryStrategy(),
+          reconnectOnError: (err: Error) => {
+            // Reconnect on READONLY errors (e.g. Redis failover)
+            return err.message.includes('READONLY');
+          },
+        },
+        defaultJobOptions: {
+          attempts: 5,
+          backoff: { type: 'exponential', delay: 2000 },
+          removeOnComplete: { count: 1000 },
+          removeOnFail: { count: 5000 },
         },
       }),
       inject: [ConfigService],

--- a/src/stellar/TRANSACTION_RETRY_RECOVERY.md
+++ b/src/stellar/TRANSACTION_RETRY_RECOVERY.md
@@ -24,6 +24,7 @@ This system provides robust transaction submission capabilities for Stellar bloc
 - ✅ Comprehensive error classification
 - ✅ Transaction persistence and recovery
 - ✅ Health monitoring and statistics
+- ✅ Prometheus observability metrics
 
 ## Configuration
 
@@ -466,11 +467,45 @@ async anchorRecord(patientId: string, cid: string) {
 - Exponential backoff reduces network pressure
 - Consider rate limiting if submitting many transactions
 
+## Observability
+
+### Prometheus Metrics
+
+The following counters are emitted to `/metrics` by `CustomMetricsService`:
+
+| Metric | Labels | Description |
+|---|---|---|
+| `stellar_tx_attempts_total` | `operation` | Every submission attempt (first try + retries) |
+| `stellar_tx_retries_total` | `operation`, `error_type` | Retry attempts after a transient failure |
+| `stellar_tx_failures_total` | `operation`, `error_type` | Permanent failures (all retries exhausted) |
+
+### Grafana Alert (suggested)
+
+Create a Grafana alert rule on `stellar_tx_failures_total` to page on-call when the failure rate spikes:
+
+```yaml
+# Example Grafana alert rule
+- alert: StellarTxFailureSpike
+  expr: increase(stellar_tx_failures_total[5m]) > 3
+  for: 2m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Stellar transaction failures spiking"
+    description: "{{ $value }} permanent failures in the last 5 minutes"
+```
+
+### Health Endpoint
+
+`GET /health/ready` includes a `stellar` section with:
+- Horizon node connectivity status and response time
+- Active retry configuration (`maxRetries`, `baseDelayMs`, etc.)
+- Pointer to `/metrics` for time-series data
+
 ## Future Enhancements
 
 - [ ] Persistent queue storage (Redis/Database)
 - [ ] Distributed queue for multi-instance deployments
-- [ ] Advanced metrics and alerting
 - [ ] Transaction priority adjustment based on age
 - [ ] Automatic fee adjustment for insufficient fee errors
 - [ ] Transaction batching for improved throughput

--- a/src/stellar/services/stellar-transaction-retry.service.ts
+++ b/src/stellar/services/stellar-transaction-retry.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as StellarSdk from '@stellar/stellar-sdk';
+import { CustomMetricsService } from '../../metrics/custom-metrics.service';
 
 /**
  * Stellar Transaction Retry and Failure Recovery Service
@@ -51,7 +52,10 @@ export class StellarTransactionRetryService {
   private readonly logger = new Logger(StellarTransactionRetryService.name);
   private readonly config: RetryConfig;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    @Optional() private readonly metrics?: CustomMetricsService,
+  ) {
     this.config = {
       maxRetries: parseInt(this.configService.get<string>('STELLAR_RETRY_MAX_ATTEMPTS', '5'), 10),
       baseDelayMs: parseInt(
@@ -94,6 +98,7 @@ export class StellarTransactionRetryService {
 
     for (let attempt = 1; attempt <= this.config.maxRetries; attempt++) {
       const attemptStart = Date.now();
+      this.metrics?.recordStellarTxAttempt(context.operation);
 
       try {
         // Sign the transaction
@@ -166,6 +171,7 @@ export class StellarTransactionRetryService {
 
         // Check if we should retry
         if (attempt < this.config.maxRetries && this.shouldRetry(errorType)) {
+          this.metrics?.recordStellarTxRetry(context.operation, errorType);
           const delay = this.calculateBackoffDelay(attempt);
           this.logger.log(
             `[${context.operation}] Retrying in ${delay}ms (error type: ${errorType})`,
@@ -180,6 +186,7 @@ export class StellarTransactionRetryService {
 
     const totalDuration = Date.now() - startTime;
 
+    this.metrics?.recordStellarTxFailure(context.operation, errorType);
     this.logger.error(
       `[${context.operation}] Transaction failed after ${this.config.maxRetries} attempts (${totalDuration}ms): ${lastError?.message}`,
     );

--- a/src/stellar/stellar.module.ts
+++ b/src/stellar/stellar.module.ts
@@ -11,11 +11,13 @@ import { StellarTransactionQueueService } from './services/stellar-transaction-q
 import { StellarRecoveryManagerService } from './services/stellar-recovery-manager.service';
 import { StellarRetryStoreService } from './services/stellar-retry-store.service';
 import { CircuitBreakerModule } from '../common/circuit-breaker/circuit-breaker.module';
+import { MetricsModule } from '../metrics/metrics.module';
 
 @Module({
   imports: [
     ConfigModule,
     CircuitBreakerModule,
+    MetricsModule,
     HttpModule.register({
       timeout: 10000,
       maxRedirects: 5,


### PR DESCRIPTION
## Summary

Resolves four reliability/observability issues in the Stellar Wave milestone.

- Closes #569 — Event store snapshot cleanup policy
- Closes #570 — Observability and alerting for Stellar transaction recovery flow
- Closes #571 — IPFS node health check in Terminus
- Closes #572 — Bull queue jobs graceful Redis failure handling

## Changes

### #569 — Snapshot cleanup (event store)
- **`src/jobs/snapshot-cleanup.task.ts`** — nightly cron job that prunes stale `AggregateSnapshotEntity` rows, retaining the latest `SNAPSHOT_RETENTION_COUNT` snapshots per aggregate (default 3)
- **`src/jobs/jobs.module.ts`** — registers `SnapshotCleanupTask` and `AggregateSnapshotEntity`
- **`.env.example`** — documents `SNAPSHOT_RETENTION_COUNT`

### #570 — Stellar transaction recovery observability
- **`src/metrics/custom-metrics.service.ts`** — adds `stellar_tx_attempts_total`, `stellar_tx_retries_total`, `stellar_tx_failures_total` Prometheus counter providers and helper methods
- **`src/metrics/metrics.module.ts`** — registers the three new counter providers
- **`src/stellar/services/stellar-transaction-retry.service.ts`** — emits metrics on each attempt, retry, and final failure via `@Optional() CustomMetricsService`
- **`src/stellar/stellar.module.ts`** — imports `MetricsModule`
- **`src/health/indicators/stellar.health.ts`** — includes retry config and `/metrics` pointer in the `/health/ready` stellar section
- **`src/stellar/TRANSACTION_RETRY_RECOVERY.md`** — adds Observability section with metric table and Grafana alert rule example

### #571 — IPFS health check
- **`src/health/indicators/ipfs.health.ts`** — switches to `/api/v0/id` endpoint (was `/api/v0/version`) and reduces timeout to 3 s
- **`docker-compose.dev.yml`** — adds `healthcheck` block to the `ipfs` service

### #572 — Bull queue resilience
- **`src/queues/queue.module.ts`** — adds global `defaultJobOptions` (`attempts: 5`, exponential backoff, auto-remove limits) and `reconnectOnError` for Redis READONLY failover
- **`src/common/utils/connection-retry.util.ts`** — updates `createRedisRetryStrategy` to use exponential backoff (500 ms base, 30 s cap)
- **`src/health/indicators/queue.health.ts`** — new `QueueHealthIndicator` (Terminus) reporting waiting/active/failed counts for critical queues
- **`src/health/health.module.ts`** / **`src/health/health.controller.ts`** — registers `QueueHealthIndicator` and surfaces it in the `GET /health/ready` readiness check as an IMPORTANT dependency

## Test plan
- [ ] `SnapshotCleanupTask` can be unit-tested by mocking `Repository<AggregateSnapshotEntity>`
- [ ] Stellar retry metrics appear in `GET /metrics` after a failed Stellar submission
- [ ] `GET /health/ready` returns `stellar` section with `retryConfig`
- [ ] `GET /health/ready` returns `queues` section with per-queue counts
- [ ] IPFS health check marks as `down` when IPFS node is unreachable within 3 s
- [ ] BullMQ jobs retry up to 5 times with exponential backoff when Redis reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)