### PR TITLE
fix(#512): remove duplicate AuditService injection, use AuditLogService consistently

### DIFF
--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -13,8 +13,6 @@ import { PasswordValidationService } from './password-validation.service';
 import { AuthTokenService } from './auth-token.service';
 import { MfaService } from './mfa.service';
 import { SessionManagementService } from './session-management.service';
-import { AuditService } from '../../common/audit/audit.service';
-import { AuditAction } from '../../common/audit/audit-log.entity';
 import { AuditLogService } from '../../common/services/audit-log.service';
 import { RegisterDto, LoginDto, ChangePasswordDto } from '../dto/auth.dto';
 
@@ -44,7 +42,6 @@ export class AuthService {
     private authTokenService: AuthTokenService,
     private mfaService: MfaService,
     private sessionManagementService: SessionManagementService,
-    private auditService: AuditService,
     private auditLogService: AuditLogService,
   ) {}
 
@@ -63,10 +60,11 @@ export class AuthService {
     });
 
     if (existingUser) {
-      await this.auditService.logAuthenticationEvent('USER_CREATED', false, {
-        email: registerDto.email,
-        reason: 'Email already exists',
+      await this.auditLogService.log({
+        actorAddress: registerDto.email,
+        action: 'USER_CREATED',
         ipAddress,
+        metadata: { reason: 'Email already exists', success: false },
       });
       throw new ConflictException('Email already registered');
     }
@@ -101,11 +99,12 @@ export class AuthService {
     const savedUser = await this.userRepository.save(user);
 
     // Log user creation
-    await this.auditService.logAuthenticationEvent(AuditAction.USER_CREATED, true, {
-      userId: savedUser.id,
-      email: savedUser.email,
-      role: savedUser.role,
+    await this.auditLogService.log({
+      actorAddress: savedUser.id,
+      action: 'USER_CREATED',
+      targetAddress: savedUser.id,
       ipAddress,
+      metadata: { email: savedUser.email, role: savedUser.role, success: true },
     });
 
     // For healthcare staff, require MFA setup
@@ -161,20 +160,22 @@ export class AuthService {
         // Lock account after 5 failed attempts
         if (user.failedLoginAttempts >= 5) {
           user.lockedUntil = new Date(Date.now() + 30 * 60 * 1000); // 30 minutes
-          await this.auditService.logAuthenticationEvent('ACCOUNT_LOCKED', false, {
-            userId: user.id,
-            reason: 'Too many failed login attempts',
+          await this.auditLogService.log({
+            actorAddress: user.id,
+            action: 'ACCOUNT_LOCKED',
             ipAddress,
+            metadata: { reason: 'Too many failed login attempts', success: false },
           });
         }
 
         await this.userRepository.save(user);
       }
 
-      await this.auditService.logAuthenticationEvent('LOGIN_FAILED', false, {
-        email,
-        reason: 'Invalid credentials',
+      await this.auditLogService.log({
+        actorAddress: email,
+        action: 'LOGIN_FAILED',
         ipAddress,
+        metadata: { reason: 'Invalid credentials', success: false },
       });
 
       throw new UnauthorizedException('Invalid email or password');
@@ -182,20 +183,22 @@ export class AuthService {
 
     // Check if account is locked
     if (user.lockedUntil && user.lockedUntil > new Date()) {
-      await this.auditService.logAuthenticationEvent('LOGIN_FAILED', false, {
-        userId: user.id,
-        reason: 'Account is locked',
+      await this.auditLogService.log({
+        actorAddress: user.id,
+        action: 'LOGIN_FAILED',
         ipAddress,
+        metadata: { reason: 'Account is locked', success: false },
       });
       throw new UnauthorizedException('Account is locked. Try again later');
     }
 
     // Check if user is active
     if (!user.isActive) {
-      await this.auditService.logAuthenticationEvent('LOGIN_FAILED', false, {
-        userId: user.id,
-        reason: 'User account is inactive',
+      await this.auditLogService.log({
+        actorAddress: user.id,
+        action: 'LOGIN_FAILED',
         ipAddress,
+        metadata: { reason: 'User account is inactive', success: false },
       });
       throw new UnauthorizedException('User account is inactive');
     }
@@ -214,10 +217,11 @@ export class AuthService {
 
     // If healthcare staff and MFA not enabled, require it
     if (user.role !== UserRole.PATIENT && !mfaEnabled) {
-      await this.auditService.logAuthenticationEvent('LOGIN_FAILED', false, {
-        userId: user.id,
-        reason: 'MFA required but not enabled',
+      await this.auditLogService.log({
+        actorAddress: user.id,
+        action: 'LOGIN_FAILED',
         ipAddress,
+        metadata: { reason: 'MFA required but not enabled', success: false },
       });
 
       throw new BadRequestException({
@@ -250,18 +254,12 @@ export class AuthService {
       userAgent,
     );
 
-    await this.auditService.logAuthenticationEvent('LOGIN', true, {
-      userId: user.id,
-      email: user.email,
-      ipAddress,
-    });
-
     // Tamper-evident audit log
     this.auditLogService.log({
       actorAddress: user.id,
       action: 'LOGIN',
       ipAddress,
-      metadata: { email: user.email },
+      metadata: { email: user.email, success: true },
     }).catch(() => {});
 
     return {
@@ -301,11 +299,11 @@ export class AuthService {
       user.passwordHash,
     );
     if (!isValid) {
-      await this.auditService.logAuthenticationEvent('PASSWORD_CHANGE', false, {
-        userId,
-        reason: 'Invalid current password',
+      await this.auditLogService.log({
+        actorAddress: userId,
+        action: 'PASSWORD_CHANGE',
         ipAddress,
-        severity: 'MEDIUM',
+        metadata: { reason: 'Invalid current password', severity: 'MEDIUM', success: false },
       });
       throw new UnauthorizedException('Current password is incorrect');
     }
@@ -327,9 +325,11 @@ export class AuthService {
 
     await this.userRepository.save(user);
 
-    await this.auditService.logAuthenticationEvent('PASSWORD_CHANGE', true, {
-      userId,
+    await this.auditLogService.log({
+      actorAddress: userId,
+      action: 'PASSWORD_CHANGE',
       ipAddress,
+      metadata: { success: true },
     });
   }
 
@@ -341,10 +341,11 @@ export class AuthService {
       await this.sessionManagementService.revokeSession(sessionId);
     }
 
-    await this.auditService.logAuthenticationEvent('LOGOUT', true, {
-      userId,
-      sessionId,
+    await this.auditLogService.log({
+      actorAddress: userId,
+      action: 'LOGOUT',
       ipAddress,
+      metadata: { sessionId, success: true },
     });
   }
 
@@ -409,9 +410,10 @@ export class AuthService {
       passwordResetTokenExpiresAt: expiresAt,
     });
 
-    await this.auditService.logAuthenticationEvent('PASSWORD_RESET_REQUESTED', true, {
-      userId: user.id,
-      email: user.email,
+    await this.auditLogService.log({
+      actorAddress: user.id,
+      action: 'PASSWORD_RESET_REQUESTED',
+      metadata: { email: user.email, success: true },
     });
 
     return { token };
@@ -453,9 +455,10 @@ export class AuthService {
       requiresPasswordChange: false,
     });
 
-    await this.auditService.logAuthenticationEvent('PASSWORD_RESET_COMPLETED', true, {
-      userId: user.id,
-      email: user.email,
+    await this.auditLogService.log({
+      actorAddress: user.id,
+      action: 'PASSWORD_RESET_COMPLETED',
+      metadata: { email: user.email, success: true },
     });
   }
 


### PR DESCRIPTION
##Closes #512 

- Removed AuditService and AuditAction imports from AuthService
- Removed auditService constructor injection (was duplicate of auditLogService)
- Replaced all auditService.logAuthenticationEvent() calls with auditLogService.log()
- In register(): only one log entry per event (previously logged twice)
- In login(): consolidated duplicate LOGIN audit into single AuditLogService call
- All methods (register, login, changePassword, logout, forgotPassword, resetPassword) now use AuditLogService consistently