### PR TITLE
This PR closes #456: Add API version lifecycle enforcement

### DIFF
--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -15,16 +15,18 @@ app.enableVersioning({
 ```
 
 The `defaultVersion` means:
-- Requests to `/records` (no prefix) are treated as `/v1/records`
+
+- Unversioned legacy controllers are governed by the v1 lifecycle policy
+- Controllers or handlers decorated with `@Version('1')` are served at `/v1/...`
 - `VERSION_NEUTRAL` controllers (e.g. `GET /api`, health checks) respond without any prefix
 
 ---
 
 ## Available Versions
 
-| Version | Status     | Base URL | Sunset Date          |
-|---------|------------|----------|----------------------|
-| v1      | Current    | `/v1`    | —                    |
+| Version | Status  | Base URL | Sunset Date |
+| ------- | ------- | -------- | ----------- |
+| v1      | Current | `/v1`    | —           |
 
 Discover versions programmatically:
 
@@ -33,6 +35,7 @@ GET /api
 ```
 
 Response:
+
 ```json
 {
   "versions": [
@@ -63,15 +66,22 @@ export class RecordsController { ... }
 Deprecated endpoints return the following response headers:
 
 | Header        | Value                                      |
-|---------------|--------------------------------------------|
+| ------------- | ------------------------------------------ |
 | `Deprecation` | `true`                                     |
 | `Sunset`      | RFC 7231 date when the endpoint is removed |
 | `Link`        | Alternative route (`rel="alternate"`)      |
 
+All versioned API responses also include lifecycle metadata:
+
+| Header               | Value                                |
+| -------------------- | ------------------------------------ |
+| `API-Version`        | Effective API version, e.g. `v1`     |
+| `API-Version-Status` | `current`, `deprecated`, or `sunset` |
+
 After the sunset date, deprecated endpoints return:
 
-| Status Code | Meaning |
-|-------------|---------|
+| Status Code | Meaning                                                  |
+| ----------- | -------------------------------------------------------- |
 | `410 Gone`  | Endpoint has reached end-of-life and is no longer served |
 
 Example:
@@ -134,7 +144,7 @@ async findAllV1() { ... }
 
 ### 4. Update the versions registry
 
-Add the new version to `src/versioning/api-versions.controller.ts`:
+Add the new version to `src/versioning/api-version-lifecycle.policy.ts`:
 
 ```typescript
 {
@@ -145,11 +155,35 @@ Add the new version to `src/versioning/api-versions.controller.ts`:
 }
 ```
 
+Every routable API version must have a lifecycle policy. If a request reaches a
+versioned controller that is not listed in this registry, the request fails with
+`500 Internal Server Error` so missing lifecycle policy is caught during release
+testing instead of silently bypassing deprecation and removal rules.
+
+### 5. Deprecate and remove old versions
+
+When a version is superseded, update its policy:
+
+```typescript
+{
+  version: '1',
+  status: 'deprecated',
+  releaseDate: '2024-01-01',
+  baseUrl: '/v1',
+  sunsetDate: 'Wed, 01 Jan 2027 00:00:00 GMT',
+  replacementVersion: '2',
+}
+```
+
+Deprecated versions return `Deprecation`, `Sunset`, and replacement `Link`
+headers until the sunset date. After that date, or when status is changed to
+`sunset`, the whole version returns `410 Gone`.
+
 ---
 
 ## Client Migration Checklist
 
-- [ ] Update base URL from `/records` → `/v1/records` (or keep using the default — both work)
+- [ ] Update base URL from unversioned routes to `/v1/...` for explicitly versioned APIs
 - [ ] Watch for `Deprecation: true` response headers — these signal upcoming breaking changes
 - [ ] Check `Sunset` header for the removal date
 - [ ] Follow the `Link` header to find the replacement endpoint
@@ -159,15 +193,15 @@ Add the new version to `src/versioning/api-versions.controller.ts`:
 
 ## Breaking vs Non-Breaking Changes
 
-| Change type                        | Requires new version? |
-|------------------------------------|-----------------------|
-| Adding a new optional field        | No                    |
-| Adding a new endpoint              | No                    |
-| Removing a field                   | Yes                   |
-| Changing a field type              | Yes                   |
-| Changing HTTP status codes         | Yes                   |
-| Removing an endpoint               | Yes (deprecate first) |
-| Renaming a query parameter         | Yes                   |
+| Change type                 | Requires new version? |
+| --------------------------- | --------------------- |
+| Adding a new optional field | No                    |
+| Adding a new endpoint       | No                    |
+| Removing a field            | Yes                   |
+| Changing a field type       | Yes                   |
+| Changing HTTP status codes  | Yes                   |
+| Removing an endpoint        | Yes (deprecate first) |
+| Renaming a query parameter  | Yes                   |
 
 ---
 
@@ -175,5 +209,5 @@ Add the new version to `src/versioning/api-versions.controller.ts`:
 
 - `VERSION_NEUTRAL` is used for infrastructure endpoints: `GET /api`, `GET /health`, `GET /metrics`
 - The global `DeprecationInterceptor` automatically injects deprecation headers and enforces `410 Gone` when route-level sunset dates are reached
-- The global `ApiVersionLifecycleInterceptor` enforces version lifecycle policy (current/deprecated/sunset) for URI-prefixed versions
-- `defaultVersion: ['1', VERSION_NEUTRAL]` ensures backward compatibility: clients not sending a version prefix still hit v1
+- The global `ApiVersionLifecycleInterceptor` enforces version lifecycle policy (current/deprecated/sunset) for URI-prefixed versions and default-version requests without a `/v{n}` prefix
+- `defaultVersion: ['1', VERSION_NEUTRAL]` keeps unversioned legacy controllers under the v1 lifecycle policy while allowing explicitly neutral infrastructure endpoints

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,9 +1,8 @@
-import { Controller, Get, Version, VERSION_NEUTRAL } from '@nestjs/common';
+import { Controller, Get, VERSION_NEUTRAL } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AppService } from './app.service';
 
-@Version(VERSION_NEUTRAL)
-@Controller()
+@Controller({ version: VERSION_NEUTRAL })
 export class AppController {
   constructor(private readonly appService: AppService) {}
 

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,6 +1,11 @@
-import { Controller, Get, UseGuards, Version, VERSION_NEUTRAL } from '@nestjs/common';
+import { Controller, Get, UseGuards, VERSION_NEUTRAL } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator, HealthCheckResult } from '@nestjs/terminus';
+import {
+  HealthCheck,
+  HealthCheckService,
+  TypeOrmHealthIndicator,
+  HealthCheckResult,
+} from '@nestjs/terminus';
 import { AdminGuard } from '../auth/guards/admin.guard';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CircuitBreakerService } from '../common/circuit-breaker/circuit-breaker.service';
@@ -28,8 +33,7 @@ interface DependencyCheck {
 }
 
 @ApiTags('health')
-@Version(VERSION_NEUTRAL)
-@Controller('health')
+@Controller({ path: 'health', version: VERSION_NEUTRAL })
 @Public()
 export class HealthController {
   private readonly dependencies: DependencyCheck[] = [

--- a/src/records/controllers/records.controller.ts
+++ b/src/records/controllers/records.controller.ts
@@ -46,10 +46,10 @@ import { AdminGuard } from '../../auth/guards/admin.guard';
 import { JwtPayload } from '../../auth/services/auth-token.service';
 import { RecordResponseDto } from '../dto/record-response.dto';
 import { RecordAccessGuard } from '../guards/record-access.guard';
+import { DeprecatedRoute } from '../../common/decorators/deprecated.decorator';
 
 @ApiTags('Records')
-@Version('1')
-@Controller('records')
+@Controller({ path: 'records', version: '1' })
 export class RecordsController {
   constructor(
     private readonly recordsService: RecordsService,
@@ -71,7 +71,11 @@ export class RecordsController {
       },
     }),
   )
-  async uploadRecord(@Body() dto: CreateRecordDto, @UploadedFile() file: Express.Multer.File, @Req() req: any) {
+  async uploadRecord(
+    @Body() dto: CreateRecordDto,
+    @UploadedFile() file: Express.Multer.File,
+    @Req() req: any,
+  ) {
     if (!file) {
       throw new BadRequestException('Encrypted record file is required');
     }

--- a/src/versioning/api-version-lifecycle.interceptor.ts
+++ b/src/versioning/api-version-lifecycle.interceptor.ts
@@ -3,8 +3,11 @@ import {
   ExecutionContext,
   GoneException,
   Injectable,
+  InternalServerErrorException,
   NestInterceptor,
+  VERSION_NEUTRAL,
 } from '@nestjs/common';
+import { VERSION_METADATA } from '@nestjs/common/constants';
 import { Observable } from 'rxjs';
 import {
   API_VERSION_LIFECYCLE_POLICIES,
@@ -16,6 +19,7 @@ export class ApiVersionLifecycleInterceptor implements NestInterceptor {
   constructor(
     private readonly policies: ApiVersionLifecyclePolicy[] = API_VERSION_LIFECYCLE_POLICIES,
     private readonly nowProvider: () => Date = () => new Date(),
+    private readonly defaultVersion = '1',
   ) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
@@ -23,13 +27,23 @@ export class ApiVersionLifecycleInterceptor implements NestInterceptor {
     const request = http.getRequest();
     const response = http.getResponse();
 
-    const version = this.extractUriVersion(request?.originalUrl ?? request?.url ?? '');
+    const version = this.resolveEffectiveVersion(
+      context,
+      request?.originalUrl ?? request?.url ?? '',
+    );
     if (!version) return next.handle();
 
     const policy = this.policies.find((p) => p.version === version);
-    if (!policy) return next.handle();
+    if (!policy) {
+      throw new InternalServerErrorException(
+        `API version v${version} is not registered in the lifecycle policy.`,
+      );
+    }
 
-    if (policy.status === 'deprecated') {
+    response.setHeader('API-Version', `v${policy.version}`);
+    response.setHeader('API-Version-Status', policy.status);
+
+    if (policy.status === 'deprecated' || this.isSunset(policy)) {
       response.setHeader('Deprecation', 'true');
       if (policy.sunsetDate) response.setHeader('Sunset', policy.sunsetDate);
       if (policy.replacementVersion) {
@@ -55,9 +69,42 @@ export class ApiVersionLifecycleInterceptor implements NestInterceptor {
   }
 
   private buildSunsetMessage(policy: ApiVersionLifecyclePolicy): string {
-    const replacement = policy.replacementVersion ? ` Use /v${policy.replacementVersion} instead.` : '';
+    const replacement = policy.replacementVersion
+      ? ` Use /v${policy.replacementVersion} instead.`
+      : '';
     const sunset = policy.sunsetDate ? ` Sunset date: ${policy.sunsetDate}.` : '';
     return `API version v${policy.version} is no longer available.${sunset}${replacement}`.trim();
+  }
+
+  private resolveEffectiveVersion(context: ExecutionContext, urlPath: string): string | null {
+    const uriVersion = this.extractUriVersion(urlPath);
+    if (uriVersion) return uriVersion;
+
+    const routeVersion = this.getRouteVersion(context);
+    if (routeVersion === null) return null;
+    if (routeVersion) return routeVersion;
+
+    return this.defaultVersion;
+  }
+
+  private getRouteVersion(context: ExecutionContext): string | null | undefined {
+    const handlerVersion = this.normalizeVersion(
+      Reflect.getMetadata(VERSION_METADATA, context.getHandler()),
+    );
+    if (handlerVersion !== undefined) return handlerVersion;
+
+    return this.normalizeVersion(Reflect.getMetadata(VERSION_METADATA, context.getClass()));
+  }
+
+  private normalizeVersion(version: unknown): string | null | undefined {
+    if (version === undefined) return undefined;
+    if (version === VERSION_NEUTRAL) return null;
+    if (Array.isArray(version)) {
+      const concreteVersion = version.find((item) => item !== VERSION_NEUTRAL);
+      return concreteVersion === undefined ? null : String(concreteVersion);
+    }
+
+    return String(version);
   }
 
   private extractUriVersion(urlPath: string): string | null {

--- a/src/versioning/api-version-lifecycle.policy.ts
+++ b/src/versioning/api-version-lifecycle.policy.ts
@@ -16,7 +16,8 @@ export const API_VERSION_LIFECYCLE_POLICIES: ApiVersionLifecyclePolicy[] = [
     status: 'current',
     releaseDate: '2024-01-01',
     baseUrl: '/v1',
-    changelog: 'https://github.com/joel-metal/Healthy-Stellar-backend/blob/main/docs/api-versioning.md#v1',
+    changelog:
+      'https://github.com/Healthy-Stellar/Healthy-Stellar-backend/blob/main/docs/api-versioning.md#v1',
   },
   // Example for future rollout:
   // {

--- a/src/versioning/api-versions.controller.spec.ts
+++ b/src/versioning/api-versions.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { VersioningType, VERSION_NEUTRAL } from '@nestjs/common';
+import { VERSION_NEUTRAL } from '@nestjs/common';
+import { VERSION_METADATA } from '@nestjs/common/constants';
 import { ApiVersionsController } from './api-versions.controller';
 
 describe('ApiVersionsController', () => {
@@ -41,6 +42,10 @@ describe('ApiVersionsController', () => {
       const { versions } = controller.getVersions();
       const v1 = versions.find((v) => v.version === '1');
       expect(v1?.baseUrl).toBe('/v1');
+    });
+
+    it('is version-neutral so lifecycle discovery remains available', () => {
+      expect(Reflect.getMetadata(VERSION_METADATA, ApiVersionsController)).toBe(VERSION_NEUTRAL);
     });
   });
 });

--- a/src/versioning/api-versions.controller.ts
+++ b/src/versioning/api-versions.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, VERSION_NEUTRAL } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { API_VERSION_LIFECYCLE_POLICIES } from './api-version-lifecycle.policy';
 
@@ -17,7 +17,7 @@ export interface ApiVersionInfo {
  * regardless of the URI version prefix.
  */
 @ApiTags('API Versioning')
-@Controller('api')
+@Controller({ path: 'api', version: VERSION_NEUTRAL })
 export class ApiVersionsController {
   @Get()
   @ApiOperation({

--- a/src/versioning/versioning-routing.spec.ts
+++ b/src/versioning/versioning-routing.spec.ts
@@ -1,5 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, VersioningType, Controller, Get, Version, VERSION_NEUTRAL } from '@nestjs/common';
+import {
+  INestApplication,
+  VersioningType,
+  Controller,
+  Get,
+  Version,
+  VERSION_NEUTRAL,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import * as request from 'supertest';
 import { DeprecationInterceptor } from '../common/interceptors/deprecation.interceptor';
@@ -57,12 +64,38 @@ class TestV3Controller {
   }
 }
 
+@Controller('test-v4')
+class TestV4Controller {
+  @Version('4')
+  @Get()
+  getV4() {
+    return { version: 4 };
+  }
+}
+
+@Controller('test-v5')
+class TestV5Controller {
+  @Version('5')
+  @Get()
+  getV5() {
+    return { version: 5 };
+  }
+}
+
 @Controller('test-neutral')
 class TestNeutralController {
   @Version(VERSION_NEUTRAL)
   @Get()
   getNeutral() {
     return { neutral: true };
+  }
+}
+
+@Controller('test-legacy')
+class TestLegacyController {
+  @Get()
+  getLegacy() {
+    return { legacy: true };
   }
 }
 
@@ -95,21 +128,37 @@ describe('API Versioning (routing)', () => {
       sunsetDate: 'Wed, 01 Jan 2025 00:00:00 GMT',
       replacementVersion: '1',
     },
+    {
+      version: '5',
+      status: 'deprecated',
+      releaseDate: '2023-01-01',
+      baseUrl: '/v5',
+      sunsetDate: 'Wed, 01 Jan 2025 00:00:00 GMT',
+      replacementVersion: '1',
+    },
   ];
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      controllers: [TestV1Controller, TestV2Controller, TestV3Controller, TestNeutralController],
+      controllers: [
+        TestV1Controller,
+        TestV2Controller,
+        TestV3Controller,
+        TestV4Controller,
+        TestV5Controller,
+        TestNeutralController,
+        TestLegacyController,
+      ],
     }).compile();
 
     app = module.createNestApplication();
 
-    app.enableVersioning({ type: VersioningType.URI });
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: ['1', VERSION_NEUTRAL] });
     app.useGlobalInterceptors(new ApiVersionLifecycleInterceptor(policies, now));
     app.useGlobalInterceptors(new DeprecationInterceptor(app.get(Reflector)));
 
     await app.init();
-    httpApp = app.getHttpAdapter().getInstance();
+    httpApp = app.getHttpServer();
   });
 
   afterAll(async () => {
@@ -119,6 +168,8 @@ describe('API Versioning (routing)', () => {
   it('GET /v1/test-v1 routes to v1 controller', async () => {
     const res = await request(httpApp).get('/v1/test-v1').expect(200);
     expect(res.body.version).toBe(1);
+    expect(res.headers['api-version']).toBe('v1');
+    expect(res.headers['api-version-status']).toBe('current');
   });
 
   it('GET /v2/test-v1 routes to v2 controller', async () => {
@@ -128,6 +179,8 @@ describe('API Versioning (routing)', () => {
 
   it('deprecated version returns deprecation headers', async () => {
     const res = await request(httpApp).get('/v2/test-v1').expect(200);
+    expect(res.headers['api-version']).toBe('v2');
+    expect(res.headers['api-version-status']).toBe('deprecated');
     expect(res.headers['deprecation']).toBe('true');
     expect(res.headers['sunset']).toBe('Wed, 01 Jan 2030 00:00:00 GMT');
     expect(res.headers['link']).toContain('/v1');
@@ -138,9 +191,29 @@ describe('API Versioning (routing)', () => {
     expect(String(res.body.message)).toContain('API version v3 is no longer available');
   });
 
+  it('deprecated version returns 410 Gone after its sunset date', async () => {
+    const res = await request(httpApp).get('/v5/test-v5').expect(410);
+    expect(String(res.body.message)).toContain('API version v5 is no longer available');
+  });
+
+  it('unversioned legacy route is still governed by the default v1 lifecycle policy', async () => {
+    const res = await request(httpApp).get('/test-legacy').expect(200);
+    expect(res.body.legacy).toBe(true);
+    expect(res.headers['api-version']).toBe('v1');
+    expect(res.headers['api-version-status']).toBe('current');
+  });
+
+  it('fails closed when a routed API version is missing lifecycle policy', async () => {
+    const res = await request(httpApp).get('/v4/test-v4').expect(500);
+    expect(String(res.body.message)).toContain(
+      'API version v4 is not registered in the lifecycle policy',
+    );
+  });
+
   it('VERSION_NEUTRAL controller responds without version prefix', async () => {
     const res = await request(httpApp).get('/test-neutral').expect(200);
     expect(res.body.neutral).toBe(true);
+    expect(res.headers['api-version']).toBeUndefined();
   });
 
   it('deprecated endpoint returns Deprecation header', async () => {


### PR DESCRIPTION
This PR closes #456.

## Summary
- Enforce lifecycle policy for routed API versions, including current/deprecated/sunset states.
- Return API version lifecycle headers and fail closed when a routed version is missing policy.
- Mark version discovery, app root, health, and records controllers with controller-level version metadata compatible with Nest.
- Document deprecation/removal workflow and add routing coverage for sunset and missing policy behavior.

## Tests
- npx jest src/versioning/versioning-routing.spec.ts src/versioning/api-versions.controller.spec.ts --runInBand

## Notes
- npm run build still fails on existing unrelated repository errors outside this change, including duplicate module properties, unresolved imports, merge-marker text in src/app.module.ts, and GraphQL/FHIR/billing compile errors.