### PR TITLE
feat:#519 bug: BackupService does not validate BACKUP_ENCRYPTION_KEY …

### DIFF
--- a/src/backup/services/backup.service.spec.ts
+++ b/src/backup/services/backup.service.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BackupService } from './backup.service';
+import { BackupLog } from '../entities/backup-log.entity';
+
+describe('BackupService', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  async function buildModule(): Promise<TestingModule> {
+    return Test.createTestingModule({
+      providers: [
+        BackupService,
+        {
+          provide: getRepositoryToken(BackupLog),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            find: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+  }
+
+  it('throws immediately when BACKUP_ENCRYPTION_KEY is missing', async () => {
+    process.env = {
+      ...originalEnv,
+      BACKUP_ENCRYPTION_KEY: '',
+    };
+
+    await expect(buildModule()).rejects.toThrow(
+      'BACKUP_ENCRYPTION_KEY environment variable is required for BackupService',
+    );
+  });
+
+  it('initialises when BACKUP_ENCRYPTION_KEY is set', async () => {
+    process.env = {
+      ...originalEnv,
+      BACKUP_ENCRYPTION_KEY: 'test-backup-key',
+    };
+
+    const module = await buildModule();
+
+    expect(module.get(BackupService)).toBeInstanceOf(BackupService);
+  });
+});

--- a/src/backup/services/backup.service.ts
+++ b/src/backup/services/backup.service.ts
@@ -117,7 +117,15 @@ export class BackupService {
   constructor(
     @InjectRepository(BackupLog)
     private backupLogRepository: Repository<BackupLog>,
-  ) {}
+  ) {
+    this.validateRequiredConfiguration();
+  }
+
+  private validateRequiredConfiguration(): void {
+    if (!this.encryptionKey) {
+      throw new Error('BACKUP_ENCRYPTION_KEY environment variable is required for BackupService');
+    }
+  }
 
   @Cron(CronExpression.EVERY_DAY_AT_2AM)
   async scheduledFullBackup() {

--- a/src/backup/services/disaster-recovery.service.ts
+++ b/src/backup/services/disaster-recovery.service.ts
@@ -43,7 +43,15 @@ export class DisasterRecoveryService {
     private backupLogRepository: Repository<BackupLog>,
     @InjectRepository(RecoveryTest)
     private recoveryTestRepository: Repository<RecoveryTest>,
-  ) {}
+  ) {
+    this.validateRequiredConfiguration();
+  }
+
+  private validateRequiredConfiguration(): void {
+    if (!this.encryptionKey) {
+      throw new Error('BACKUP_ENCRYPTION_KEY environment variable is required for DisasterRecoveryService');
+    }
+  }
 
   async createRecoveryPlan(backupId: string): Promise<RecoveryPlan> {
     const backup = await this.backupLogRepository.findOne({ where: { id: backupId } });


### PR DESCRIPTION
Done — the backup subsystem now fails fast if BACKUP_ENCRYPTION_KEY is missing.

Added startup validation to BackupService so construction throws immediately when the key is absent: src/backup/services/backup.service.ts:117
Added the same guard to DisasterRecoveryService for consistency, since it uses the same encryption key: src/backup/services/disaster-recovery.service.ts:41
Added a regression spec that verifies both the failure case and the happy path: src/backup/services/backup.service.spec.ts:1
Fail fast when BACKUP_ENCRYPTION_KEY is missing at startup to prevent plaintext backup writes and align backup services with required-key validation.

closes #519 