### PR TITLE
feat: add SDK npm auto-publish workflow and publish script

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,65 @@
+name: Publish SDK
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    paths:
+      - 'packages/sdk/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+        working-directory: packages/sdk
+      - run: npm run build
+        working-directory: packages/sdk
+      - run: npm test
+        working-directory: packages/sdk
+      - run: npm publish --dry-run --access public
+        working-directory: packages/sdk
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+        working-directory: packages/sdk
+      - run: npm run build
+        working-directory: packages/sdk
+      - run: npm test
+        working-directory: packages/sdk
+      - run: npm publish --provenance --access public
+        working-directory: packages/sdk
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,8 @@ yarn-error.log*
 *.iml
 
 # GitHub
-.github/
+.github/*.zip
+.github/*.tar.gz
 
 # OS
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "check:sdk-drift": "node scripts/check-sdk-drift.js",
     "export:schema": "ts-node -r tsconfig-paths/register scripts/export-schema.ts",
     "version:sdk": "node scripts/version-sdk.js",
-    "publish:sdk": "npm publish packages/sdk --access public",
+    "publish:sdk": "bash scripts/publish-sdk.sh",
     "docs:generate": "ts-node -r tsconfig-paths/register 'src/swaggeropenapi-documentation-with-full-schema-coverage/export-openapi.ts'",
     "generate:graphql-types": "graphql-codegen --config codegen.yml"
   },

--- a/scripts/publish-sdk.sh
+++ b/scripts/publish-sdk.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Publishing @medchain/sdk to npm..."
+
+cd "$(dirname "$0")/../packages/sdk"
+
+npm ci
+npm run build
+npm test
+npm publish --provenance --access public
+
+echo "Published successfully."


### PR DESCRIPTION
closes #659 

## Summary

- Add .github/workflows/publish-sdk.yml with validate (PR dry-run) and publish (tag push) jobs
- Create scripts/publish-sdk.sh helper for local publishing
- Update root publish:sdk script to use shell helper
- Fix .gitignore to allow tracking .github/workflows/ files

The workflow:
- validate job: runs on PRs touching packages/sdk/; installs, builds, tests, and dry-run publishes
- publish job: runs on v* tag pushes; installs, builds, tests, publishes with npm provenance, and creates a GitHub Release with auto-generated notes from conventional commits