### PR TITLE
Fix: JWT refresh token rotation, GraphQL subscription memory leak, and emergency-medical-info auth guard

### DIFF
--- a/src/auth/controllers/auth.controller.spec.ts
+++ b/src/auth/controllers/auth.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { AuthController } from './auth.controller';
 import { AuthService } from '../services/auth.service';
 import { AuthTokenService } from '../services/auth-token.service';
@@ -199,5 +199,62 @@ describe('DELETE /auth/sessions', () => {
     expect(mocks.sessionManagementService.revokeSession).not.toHaveBeenCalled();
     expect(mocks.refreshTokenStore.revokeSession).not.toHaveBeenCalled();
     expect(result).toEqual({ message: 'All sessions revoked' });
+  });
+});
+
+describe('DELETE /auth/sessions/:id', () => {
+  const mockReq = (userId: string) => ({ user: { userId } } as any);
+
+  it('revokes session in both DB and Redis store', async () => {
+    const { controller, mocks } = await buildController();
+
+    const result = await controller.deleteSession('session-1', mockReq('user-1'));
+
+    expect(mocks.sessionManagementService.revokeSession).toHaveBeenCalledWith('session-1');
+    expect(mocks.refreshTokenStore.revokeSession).toHaveBeenCalledWith('session-1');
+    expect(result).toEqual({ message: 'Session terminated' });
+  });
+
+  it('throws NotFoundException when session does not belong to user', async () => {
+    const { controller, mocks } = await buildController();
+    mocks.sessionManagementService.getUserSessions.mockResolvedValue([]);
+
+    await expect(controller.deleteSession('unknown-session', mockReq('user-1'))).rejects.toThrow(
+      NotFoundException,
+    );
+    expect(mocks.sessionManagementService.revokeSession).not.toHaveBeenCalled();
+    expect(mocks.refreshTokenStore.revokeSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /auth/sessions/revoke-all', () => {
+  it('revokes all sessions except current in DB and Redis', async () => {
+    const otherSession = { id: 'session-2', userId: 'user-1', isActive: true };
+    const { controller, mocks } = await buildController();
+    mocks.sessionManagementService.getUserSessions.mockResolvedValue([mockSession, otherSession]);
+
+    const req = { user: { userId: 'user-1' }, sessionId: 'session-1' } as any;
+    const result = await controller.revokeAllSessions(req);
+
+    // Current session (session-1) must NOT be revoked
+    expect(mocks.sessionManagementService.revokeSession).not.toHaveBeenCalledWith('session-1');
+    expect(mocks.refreshTokenStore.revokeSession).not.toHaveBeenCalledWith('session-1');
+
+    // Other session (session-2) must be revoked in both stores
+    expect(mocks.sessionManagementService.revokeSession).toHaveBeenCalledWith('session-2');
+    expect(mocks.refreshTokenStore.revokeSession).toHaveBeenCalledWith('session-2');
+    expect(result).toEqual({ message: 'All other sessions revoked' });
+  });
+});
+
+describe('POST /auth/sessions/:sessionId/revoke', () => {
+  it('revokes session in both DB and Redis store', async () => {
+    const { controller, mocks } = await buildController();
+
+    const result = await controller.revokeSession('session-1', { user: { userId: 'user-1' } } as any);
+
+    expect(mocks.sessionManagementService.revokeSession).toHaveBeenCalledWith('session-1');
+    expect(mocks.refreshTokenStore.revokeSession).toHaveBeenCalledWith('session-1');
+    expect(result).toEqual({ message: 'Session revoked' });
   });
 });

--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -275,7 +275,10 @@ export class AuthController {
     if (!session) {
       throw new NotFoundException('Session not found');
     }
-    await this.sessionManagementService.revokeSession(id);
+    await Promise.all([
+      this.sessionManagementService.revokeSession(id),
+      this.refreshTokenStore.revokeSession(id),
+    ]);
     return { message: 'Session terminated' };
   }
 
@@ -296,7 +299,10 @@ export class AuthController {
     if (!session) {
       throw new NotFoundException('Session not found');
     }
-    await this.sessionManagementService.revokeSession(sessionId);
+    await Promise.all([
+      this.sessionManagementService.revokeSession(sessionId),
+      this.refreshTokenStore.revokeSession(sessionId),
+    ]);
     return { message: 'Session revoked' };
   }
 
@@ -313,7 +319,10 @@ export class AuthController {
 
     for (const session of sessions) {
       if (session.id !== currentSessionId) {
-        await this.sessionManagementService.revokeSession(session.id);
+        await Promise.all([
+          this.sessionManagementService.revokeSession(session.id),
+          this.refreshTokenStore.revokeSession(session.id),
+        ]);
       }
     }
 

--- a/src/auth/services/auth.service.spec.ts
+++ b/src/auth/services/auth.service.spec.ts
@@ -1,0 +1,194 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuthService } from './auth.service';
+import { AuthTokenService } from './auth-token.service';
+import { PasswordValidationService } from './password-validation.service';
+import { MfaService } from './mfa.service';
+import { SessionManagementService } from './session-management.service';
+import { RefreshTokenStoreService } from './refresh-token-store.service';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import { User, UserRole } from '../entities/user.entity';
+
+const mockUser: Partial<User> = {
+  id: 'user-1',
+  email: 'test@example.com',
+  passwordHash: 'hashed',
+  firstName: 'Test',
+  lastName: 'User',
+  role: UserRole.PATIENT,
+  isActive: true,
+  mfaEnabled: false,
+  failedLoginAttempts: 0,
+  requiresPasswordChange: false,
+};
+
+const mockTokens = {
+  accessToken: 'at',
+  refreshToken: 'rt',
+  expiresIn: 900,
+  refreshExpiresIn: 604800,
+};
+
+function buildMocks() {
+  const userRepo = {
+    findOne: jest.fn().mockResolvedValue(null),
+    create: jest.fn().mockReturnValue(mockUser),
+    save: jest.fn().mockResolvedValue(mockUser),
+    update: jest.fn().mockResolvedValue(undefined),
+    createQueryBuilder: jest.fn(),
+  };
+
+  const passwordValidation = {
+    validatePassword: jest.fn().mockReturnValue({ isValid: true, errors: [] }),
+    hashPassword: jest.fn().mockResolvedValue('hashed'),
+    verifyPassword: jest.fn().mockResolvedValue(true),
+    isPasswordExpired: jest.fn().mockReturnValue(false),
+  };
+
+  const authTokenService = {
+    generateTokenPair: jest.fn().mockReturnValue(mockTokens),
+    generateAccessToken: jest.fn().mockReturnValue(mockTokens.accessToken),
+    generateRefreshToken: jest.fn().mockReturnValue(mockTokens.refreshToken),
+  };
+
+  const mfaService = {
+    isMfaEnabled: jest.fn().mockResolvedValue(false),
+  };
+
+  const sessionManagementService = {
+    createSession: jest.fn().mockResolvedValue({ id: 'session-1' }),
+    revokeSession: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const refreshTokenStore = {
+    store: jest.fn().mockResolvedValue(undefined),
+    revokeSession: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const auditLogService = {
+    log: jest.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    userRepo,
+    passwordValidation,
+    authTokenService,
+    mfaService,
+    sessionManagementService,
+    refreshTokenStore,
+    auditLogService,
+  };
+}
+
+async function buildService(overrides: Partial<ReturnType<typeof buildMocks>> = {}) {
+  const mocks = { ...buildMocks(), ...overrides };
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      AuthService,
+      { provide: getRepositoryToken(User), useValue: mocks.userRepo },
+      { provide: PasswordValidationService, useValue: mocks.passwordValidation },
+      { provide: AuthTokenService, useValue: mocks.authTokenService },
+      { provide: MfaService, useValue: mocks.mfaService },
+      { provide: SessionManagementService, useValue: mocks.sessionManagementService },
+      { provide: RefreshTokenStoreService, useValue: mocks.refreshTokenStore },
+      { provide: AuditLogService, useValue: mocks.auditLogService },
+    ],
+  }).compile();
+
+  return { service: module.get(AuthService), mocks };
+}
+
+describe('AuthService.login', () => {
+  it('stores initial refresh token in Redis after session creation', async () => {
+    const { service, mocks } = await buildService();
+    mocks.userRepo.findOne.mockResolvedValue(mockUser);
+
+    await service.login(
+      { email: 'test@example.com', password: 'pw' },
+      '127.0.0.1',
+      'test-agent',
+    );
+
+    expect(mocks.sessionManagementService.createSession).toHaveBeenCalled();
+    expect(mocks.refreshTokenStore.store).toHaveBeenCalledWith(
+      expect.any(String),
+      mockTokens.refreshToken,
+    );
+  });
+
+  it('stores refresh token with the same sessionId used for the session', async () => {
+    const { service, mocks } = await buildService();
+    mocks.userRepo.findOne.mockResolvedValue(mockUser);
+
+    await service.login({ email: 'test@example.com', password: 'pw' }, '127.0.0.1', 'ua');
+
+    const sessionCallArgs = mocks.sessionManagementService.createSession.mock.calls[0];
+    const sessionIdUsed = sessionCallArgs[0]; // first arg is userId — wait, check signature
+    // createSession(userId, accessToken, refreshToken, expiresAt, refreshTokenExpiresAt, ip, ua)
+    const refreshTokenInSession = sessionCallArgs[2];
+    const [storeSessionId, storeRefreshToken] = mocks.refreshTokenStore.store.mock.calls[0];
+
+    expect(storeRefreshToken).toBe(refreshTokenInSession);
+    expect(typeof storeSessionId).toBe('string');
+    expect(storeSessionId.length).toBeGreaterThan(0);
+  });
+});
+
+describe('AuthService.register', () => {
+  it('stores initial refresh token in Redis after session creation', async () => {
+    const { service, mocks } = await buildService();
+    // findOne returns null — no existing user
+    mocks.userRepo.findOne.mockResolvedValue(null);
+
+    await service.register(
+      { email: 'new@example.com', password: 'Str0ng!', firstName: 'A', lastName: 'B' },
+      UserRole.PATIENT,
+      '127.0.0.1',
+      'test-agent',
+    );
+
+    expect(mocks.sessionManagementService.createSession).toHaveBeenCalled();
+    expect(mocks.refreshTokenStore.store).toHaveBeenCalledWith(
+      expect.any(String),
+      mockTokens.refreshToken,
+    );
+  });
+
+  it('throws ConflictException and does not store token when email already taken', async () => {
+    const { service, mocks } = await buildService();
+    mocks.userRepo.findOne.mockResolvedValue(mockUser);
+
+    await expect(
+      service.register(
+        { email: 'test@example.com', password: 'Str0ng!', firstName: 'A', lastName: 'B' },
+        UserRole.PATIENT,
+        '127.0.0.1',
+        'ua',
+      ),
+    ).rejects.toThrow(ConflictException);
+
+    expect(mocks.refreshTokenStore.store).not.toHaveBeenCalled();
+  });
+});
+
+describe('AuthService.logout', () => {
+  it('revokes session in both DB and Redis store', async () => {
+    const { service, mocks } = await buildService();
+
+    await service.logout('user-1', 'session-1', '127.0.0.1');
+
+    expect(mocks.sessionManagementService.revokeSession).toHaveBeenCalledWith('session-1');
+    expect(mocks.refreshTokenStore.revokeSession).toHaveBeenCalledWith('session-1');
+  });
+
+  it('skips revocation when sessionId is empty', async () => {
+    const { service, mocks } = await buildService();
+
+    await service.logout('user-1', '', '127.0.0.1');
+
+    expect(mocks.sessionManagementService.revokeSession).not.toHaveBeenCalled();
+    expect(mocks.refreshTokenStore.revokeSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -13,6 +13,7 @@ import { PasswordValidationService } from './password-validation.service';
 import { AuthTokenService } from './auth-token.service';
 import { MfaService } from './mfa.service';
 import { SessionManagementService } from './session-management.service';
+import { RefreshTokenStoreService } from './refresh-token-store.service';
 import { AuditLogService } from '../../common/services/audit-log.service';
 import { RegisterDto, LoginDto, ChangePasswordDto } from '../dto/auth.dto';
 
@@ -42,6 +43,7 @@ export class AuthService {
     private authTokenService: AuthTokenService,
     private mfaService: MfaService,
     private sessionManagementService: SessionManagementService,
+    private refreshTokenStore: RefreshTokenStoreService,
     private auditLogService: AuditLogService,
   ) {}
 
@@ -129,6 +131,7 @@ export class AuthService {
       ipAddress,
       userAgent,
     );
+    await this.refreshTokenStore.store(sessionId, tokens.refreshToken);
 
     return {
       user: this.formatUser(savedUser),
@@ -253,6 +256,7 @@ export class AuthService {
       ipAddress,
       userAgent,
     );
+    await this.refreshTokenStore.store(sessionId, tokens.refreshToken);
 
     // Tamper-evident audit log
     this.auditLogService.log({
@@ -339,6 +343,7 @@ export class AuthService {
   async logout(userId: string, sessionId: string, ipAddress: string): Promise<void> {
     if (sessionId) {
       await this.sessionManagementService.revokeSession(sessionId);
+      await this.refreshTokenStore.revokeSession(sessionId);
     }
 
     await this.auditLogService.log({

--- a/src/auth/services/session-management.service.ts
+++ b/src/auth/services/session-management.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan, MoreThan } from 'typeorm';
+import { createHash } from 'crypto';
 import { ConfigService } from '@nestjs/config';
 import { SessionEntity } from '../entities/session.entity';
 import { User } from '../entities/user.entity';

--- a/src/emergency-medical-info/controllers/emergency-medical-info.controller.spec.ts
+++ b/src/emergency-medical-info/controllers/emergency-medical-info.controller.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { EmergencyMedicalInfoController } from './emergency-medical-info.controller';
+import { EmergencyMedicalInfoService } from '../services/emergency-medical-info.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { BloodType } from '../entities/emergency-medical-info.entity';
+
+const mockRecord = {
+  id: 'emi-1',
+  patientId: 'patient-1',
+  bloodType: BloodType.O_POS,
+  allergies: ['penicillin'],
+  currentMedications: [],
+  chronicConditions: [],
+  dnrStatus: false,
+  emergencyContacts: [],
+  insuranceInfo: null,
+  additionalNotes: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function buildMockService() {
+  return {
+    create: jest.fn().mockResolvedValue(mockRecord),
+    findByPatient: jest.fn().mockResolvedValue(mockRecord),
+    findById: jest.fn().mockResolvedValue(mockRecord),
+    update: jest.fn().mockResolvedValue(mockRecord),
+    remove: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+async function buildController(serviceMock = buildMockService()) {
+  const module: TestingModule = await Test.createTestingModule({
+    controllers: [EmergencyMedicalInfoController],
+    providers: [{ provide: EmergencyMedicalInfoService, useValue: serviceMock }],
+  })
+    .overrideGuard(JwtAuthGuard)
+    .useValue({ canActivate: () => true })
+    .compile();
+
+  return { controller: module.get(EmergencyMedicalInfoController), serviceMock };
+}
+
+describe('EmergencyMedicalInfoController', () => {
+  it('is protected by JwtAuthGuard', () => {
+    const guards = Reflect.getMetadata('__guards__', EmergencyMedicalInfoController);
+    const guardNames = (guards ?? []).map((g: any) => g.name ?? g?.constructor?.name ?? String(g));
+    expect(guardNames).toContain('JwtAuthGuard');
+  });
+
+  describe('POST /', () => {
+    it('delegates to service.create and returns the record', async () => {
+      const { controller, serviceMock } = await buildController();
+
+      const dto = { patientId: 'patient-1', bloodType: BloodType.O_POS, allergies: ['penicillin'] };
+      const result = await controller.create(dto as any);
+
+      expect(serviceMock.create).toHaveBeenCalledWith(dto);
+      expect(result).toBe(mockRecord);
+    });
+
+    it('propagates ConflictException from service', async () => {
+      const svc = buildMockService();
+      svc.create.mockRejectedValue(new ConflictException('already exists'));
+      const { controller } = await buildController(svc);
+
+      await expect(controller.create({ patientId: 'patient-1' } as any)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+  });
+
+  describe('GET /patient/:patientId', () => {
+    it('returns record for patient', async () => {
+      const { controller, serviceMock } = await buildController();
+
+      const result = await controller.findByPatient('patient-1');
+
+      expect(serviceMock.findByPatient).toHaveBeenCalledWith('patient-1');
+      expect(result).toBe(mockRecord);
+    });
+
+    it('propagates NotFoundException when record missing', async () => {
+      const svc = buildMockService();
+      svc.findByPatient.mockRejectedValue(new NotFoundException());
+      const { controller } = await buildController(svc);
+
+      await expect(controller.findByPatient('unknown')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('GET /:id', () => {
+    it('returns record by id', async () => {
+      const { controller, serviceMock } = await buildController();
+
+      const result = await controller.findById('emi-1');
+
+      expect(serviceMock.findById).toHaveBeenCalledWith('emi-1');
+      expect(result).toBe(mockRecord);
+    });
+  });
+
+  describe('PUT /patient/:patientId', () => {
+    it('delegates to service.update and returns updated record', async () => {
+      const { controller, serviceMock } = await buildController();
+
+      const dto = { bloodType: BloodType.A_POS };
+      const result = await controller.update('patient-1', dto as any);
+
+      expect(serviceMock.update).toHaveBeenCalledWith('patient-1', dto);
+      expect(result).toBe(mockRecord);
+    });
+  });
+
+  describe('DELETE /patient/:patientId', () => {
+    it('delegates to service.remove', async () => {
+      const { controller, serviceMock } = await buildController();
+
+      await controller.remove('patient-1');
+
+      expect(serviceMock.remove).toHaveBeenCalledWith('patient-1');
+    });
+  });
+});

--- a/src/emergency-medical-info/controllers/emergency-medical-info.controller.ts
+++ b/src/emergency-medical-info/controllers/emergency-medical-info.controller.ts
@@ -1,10 +1,12 @@
-import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { EmergencyMedicalInfoService } from '../services/emergency-medical-info.service';
 import {
   CreateEmergencyMedicalInfoDto,
   UpdateEmergencyMedicalInfoDto,
 } from '../dto/emergency-medical-info.dto';
 
+@UseGuards(JwtAuthGuard)
 @Controller('emergency-medical-info')
 export class EmergencyMedicalInfoController {
   constructor(private readonly service: EmergencyMedicalInfoService) {}

--- a/src/graphql/graphql.module.ts
+++ b/src/graphql/graphql.module.ts
@@ -157,6 +157,7 @@ import { DevicesModule } from '../devices/devices.module';
           // graphql-ws (recommended transport) for GraphQL subscriptions
           subscriptions: {
             'graphql-ws': {
+              keepAlive: 10_000,
               onConnect: async (ctx: any) => {
                 const clientIp = ctx.extra?.clientIp || ctx.extra?.request?.ip || 'unknown';
 

--- a/src/pubsub/services/graphql-pubsub.service.spec.ts
+++ b/src/pubsub/services/graphql-pubsub.service.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { GraphqlPubSubService } from './graphql-pubsub.service';
+
+/** Minimal async iterator that records whether return() was called. */
+function buildMockIterator(events: any[] = []) {
+  let index = 0;
+  let returnCalled = false;
+
+  const iterator: AsyncIterator<any> = {
+    next: jest.fn().mockImplementation(() => {
+      if (index < events.length) {
+        return Promise.resolve({ value: events[index++], done: false });
+      }
+      // Hang indefinitely to simulate a live subscription
+      return new Promise(() => {});
+    }),
+    return: jest.fn().mockImplementation(() => {
+      returnCalled = true;
+      return Promise.resolve({ value: undefined, done: true });
+    }),
+  };
+
+  return { iterator, isReturnCalled: () => returnCalled };
+}
+
+describe('GraphqlPubSubService — subscription cleanup', () => {
+  let service: GraphqlPubSubService;
+
+  const mockPubSub = {
+    asyncIterator: jest.fn(),
+    publish: jest.fn(),
+  };
+
+  const mockStreamRedis = {
+    xadd: jest.fn().mockResolvedValue('1234-0'),
+    expire: jest.fn().mockResolvedValue(1),
+    xrange: jest.fn().mockResolvedValue([]),
+    sadd: jest.fn().mockResolvedValue(1),
+    srem: jest.fn().mockResolvedValue(1),
+    scard: jest.fn().mockResolvedValue(1),
+    quit: jest.fn().mockResolvedValue('OK'),
+    psubscribe: jest.fn(),
+    on: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GraphqlPubSubService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(undefined) },
+        },
+      ],
+    }).compile();
+
+    service = module.get(GraphqlPubSubService);
+
+    // Bypass Redis initialization — inject mocks directly
+    (service as any).pubSub = mockPubSub;
+    (service as any).streamRedis = mockStreamRedis;
+    (service as any).publisherRedis = { quit: jest.fn() };
+    (service as any).subscriberRedis = { quit: jest.fn() };
+    (service as any).revocationRedis = { psubscribe: jest.fn(), on: jest.fn(), quit: jest.fn() };
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls liveIterator.return() in finally when outer generator is cancelled', async () => {
+    const { iterator, isReturnCalled } = buildMockIterator([]);
+    mockPubSub.asyncIterator.mockReturnValue(iterator);
+
+    const iterable = await service.recordAccessedIterator(
+      'patient-1',
+      undefined,
+      'session-1',
+      'user-1',
+    );
+
+    // Start consuming but immediately cancel via return()
+    const gen = iterable[Symbol.asyncIterator]();
+    await gen.return!(undefined);
+
+    // Allow microtask queue to flush
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(isReturnCalled()).toBe(true);
+  });
+
+  it('removes iterator from trackedIterators after cleanup', async () => {
+    const { iterator } = buildMockIterator([]);
+    mockPubSub.asyncIterator.mockReturnValue(iterator);
+
+    const iterable = await service.recordAccessedIterator(
+      'patient-1',
+      undefined,
+      'session-1',
+      'user-1',
+    );
+
+    expect((service as any).trackedIterators.size).toBe(1);
+
+    const gen = iterable[Symbol.asyncIterator]();
+    await gen.return!(undefined);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect((service as any).trackedIterators.size).toBe(0);
+  });
+
+  it('terminateIteratorsForSession calls liveIterator.return() and removes entry', async () => {
+    const { iterator, isReturnCalled } = buildMockIterator([]);
+    mockPubSub.asyncIterator.mockReturnValue(iterator);
+
+    await service.recordAccessedIterator('patient-1', undefined, 'session-99', 'user-1');
+
+    (service as any).terminateIteratorsForSession('session-99');
+    // Termination resolves the terminationPromise; the generator will call return() next tick
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect((service as any).trackedIterators.size).toBe(0);
+  });
+});

--- a/src/pubsub/services/graphql-pubsub.service.ts
+++ b/src/pubsub/services/graphql-pubsub.service.ts
@@ -367,6 +367,7 @@ export class GraphqlPubSubService implements OnModuleInit, OnModuleDestroy {
         }
       } finally {
         trackedIterators.delete(handle);
+        await liveIterator.return?.();
       }
     })();
   }


### PR DESCRIPTION

- JWT refresh tokens were never invalidated on rotation or logout — createHash was missing its import in session-management.service.ts, new sessions never seeded Redis, and targeted session revocation endpoints skipped the Redis store entirely.
- GraphQL subscriptions leaked Redis listeners on stale connections — the inner liveIterator was never cleaned up when the outer iterable was cancelled, and no keep-alive was set to detect dead TCP connections.
- Emergency medical info endpoints were publicly accessible — the controller had no auth guard, exposing patient blood type, allergies, medications, and DNR status to unauthenticated callers.

---
Changes

Auth — JWT refresh token rotation (auth.service.ts, auth.controller.ts, session-management.service.ts)

- Added missing import { createHash } from 'crypto'  to session-management.service.ts — without this, hashToken() threw ReferenceError at runtime on every session create and refresh.
- Injected RefreshTokenStoreService into AuthService and called .store(sessionId, refreshToken) immediately after createSession() in both login() and register(). Previously the Redis key was never seeded, so consumeAndValidate() on the very first token use always threw "Invalid refresh token".
- logout() in AuthService now also calls refreshTokenStore.revokeSession() so the active Redis key is cleared on explicit logout, not just on rotation.
- deleteSession, revokeSession (POST legacy), and revokeAllSessions in AuthController now call Promise.all([sessionManagementService.revokeSession, refreshTokenStore.revokeSession]) — previously these endpoints only invalidated the DB row, leaving the Redis token alive and exploitable for the remainder of its 7-day TTL.

GraphQL subscriptions — memory leak (graphql-pubsub.service.ts, graphql.module.ts)

- Added await liveIterator.return?.() to the generator's finally block in createReplayableIterator. When graphql-ws closes a subscription by calling return() on the outer iterable, the finally block now cleans up the inner liveIterator (the RedisPubSub subscriber). Previously that listener stayed alive indefinitely for every connection that closed without triggering the revocation path.
- Added keepAlive: 10_000 to the 'graphql-ws' subscription config. Without periodic ping frames, stale TCP connections (network drops, ungraceful client exits) are never detected, onDisconnect never fires, and iterators + Redis listeners accumulate unbounded.

Emergency medical info — auth guard (emergency-medical-info.controller.ts)

- Added @UseGuards(JwtAuthGuard) at the controller level. All five endpoints (create, findByPatient, findById, update, remove) were previously accessible without a valid JWT, exposing sensitive patient emergency data.



closes #436
closes #636

