### PR TITLE
feat(monitoring): add Prometheus alert rules for SLA-critical endpoints

### DIFF
--- a/docker/monitoring/README.md
+++ b/docker/monitoring/README.md
@@ -1,0 +1,48 @@
+# Monitoring & Alerting
+
+Prometheus scrapes the app `/metrics` endpoint and evaluates the rule files listed
+in `prometheus.yml`. Alerts are dispatched through Alertmanager (`alertmanager.yml`).
+
+## Rule files
+
+| File | Purpose |
+| --- | --- |
+| `app-alerts.yml` | General application health (error rate, CPU/memory, dependencies) |
+| `slo-rules.yml` / `slo-alerts.yml` | SLO recording rules and burn-rate alerts |
+| `medical_alerts.yml` | Domain-specific medical workflow alerts |
+| `sla-alerts.yml` | **SLA-critical endpoint alerts** (patient reads, auth, queues) |
+
+## SLA-critical endpoint alerts (`sla-alerts.yml`)
+
+| Alert | Condition | Window |
+| --- | --- | --- |
+| `PatientsP99LatencyHigh` | p99 latency of `/patients/*` > 2s | 5m |
+| `AuthErrorRateHigh` | 5xx error rate of `/auth/*` > 1% | 2m |
+| `BullMQQueueDepthHigh` | BullMQ `queue_depth` > 1000 | 10m |
+
+Each alert is labelled `notify: sla-critical` and includes a `runbook_url`
+annotation linking to the matching operator runbook (`src/operator-runbook/`,
+served at `/operator/runbooks/<slug>`).
+
+## Notification routing
+
+`alertmanager.yml` routes `notify=sla-critical` alerts to the
+`sla-critical-receiver`, which fans out to **email** and **Slack**. Provide the
+following environment variables / secrets when deploying Alertmanager:
+
+| Variable | Description |
+| --- | --- |
+| `SLA_ALERT_EMAIL` | Destination email (default `oncall@healthystellar.io`) |
+| `ALERT_FROM_EMAIL` | From address |
+| `SMTP_SMARTHOST`, `SMTP_USERNAME`, `SMTP_PASSWORD` | SMTP relay credentials |
+| `SLACK_WEBHOOK_URL` | Slack incoming webhook URL |
+| `SLACK_ALERT_CHANNEL` | Slack channel (default `#sla-alerts`) |
+
+## Validation
+
+```bash
+# Check rule syntax
+promtool check rules docker/monitoring/sla-alerts.yml
+# Check Alertmanager config
+amtool check-config docker/monitoring/alertmanager.yml
+```

--- a/docker/monitoring/alertmanager.yml
+++ b/docker/monitoring/alertmanager.yml
@@ -7,8 +7,32 @@ route:
   group_interval: 5m
   repeat_interval: 4h
   receiver: 'default-receiver'
+  routes:
+    # SLA-critical endpoint alerts page the on-call team via email + Slack.
+    - matchers:
+        - notify = sla-critical
+      receiver: 'sla-critical-receiver'
+      group_wait: 10s
+      repeat_interval: 1h
+      continue: false
 
 receivers:
   - name: 'default-receiver'
     # In a real environment, you would configure email, slack, or pagerduty here.
     # For now, it just logs to stdout/internal storage.
+
+  - name: 'sla-critical-receiver'
+    # Credentials are injected from the environment / secret store at deploy time.
+    email_configs:
+      - to: '${SLA_ALERT_EMAIL:-oncall@healthystellar.io}'
+        from: '${ALERT_FROM_EMAIL:-alerts@healthystellar.io}'
+        smarthost: '${SMTP_SMARTHOST:-smtp:587}'
+        auth_username: '${SMTP_USERNAME}'
+        auth_password: '${SMTP_PASSWORD}'
+        send_resolved: true
+    slack_configs:
+      - api_url: '${SLACK_WEBHOOK_URL}'
+        channel: '${SLACK_ALERT_CHANNEL:-#sla-alerts}'
+        send_resolved: true
+        title: '{{ .CommonAnnotations.summary }}'
+        text: "{{ range .Alerts }}*{{ .Labels.alertname }}* ({{ .Labels.severity }})\n{{ .Annotations.description }}\nRunbook: {{ .Annotations.runbook_url }}\n{{ end }}"

--- a/docker/monitoring/prometheus.yml
+++ b/docker/monitoring/prometheus.yml
@@ -7,6 +7,7 @@ rule_files:
   - "app-alerts.yml"
   - "slo-rules.yml"
   - "slo-alerts.yml"
+  - "sla-alerts.yml"
 
 alerting:
   alertmanagers:

--- a/docker/monitoring/sla-alerts.yml
+++ b/docker/monitoring/sla-alerts.yml
@@ -1,0 +1,62 @@
+# SLA-Critical Endpoint Alert Rules — Healthy Stellar Backend
+#
+# Covers the SLA-critical request paths (patient record reads, auth, billing/queues).
+# Each alert carries a `runbook_url` annotation linking to the operator runbook
+# (src/operator-runbook/, served at /operator/runbooks/<slug>) and is labelled
+# `notify: sla-critical` so Alertmanager routes it to the email + Slack receivers.
+#
+# Metric sources (src/metrics/custom-metrics.service.ts):
+#   http_request_duration_seconds{method,route,status}  — request latency histogram
+#   http_requests_total{method,route,status}            — request counter
+#   queue_depth{queue}                                   — BullMQ waiting jobs gauge
+
+groups:
+  - name: sla_critical_endpoints
+    interval: 30s
+    rules:
+      # p99 latency > 2s on /patients/* for 5 minutes
+      - alert: PatientsP99LatencyHigh
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(http_request_duration_seconds_bucket{route=~"/patients.*"}[5m])) by (le)
+          ) > 2
+        for: 5m
+        labels:
+          severity: critical
+          component: patients
+          notify: sla-critical
+        annotations:
+          summary: "p99 latency on /patients/* exceeds SLA (2s)"
+          description: "p99 latency for /patients/* is {{ $value | humanize }}s over the last 5m (threshold: 2s)."
+          runbook_url: "https://app.healthystellar.io/operator/runbooks/sla-patients-latency"
+
+      # Error rate > 1% on /auth/* for 2 minutes
+      - alert: AuthErrorRateHigh
+        expr: |
+          (
+            sum(rate(http_requests_total{route=~"/auth.*",status=~"5.."}[5m]))
+            /
+            sum(rate(http_requests_total{route=~"/auth.*"}[5m]))
+          ) * 100 > 1
+        for: 2m
+        labels:
+          severity: critical
+          component: auth
+          notify: sla-critical
+        annotations:
+          summary: "Error rate on /auth/* exceeds SLA (1%)"
+          description: "/auth/* 5xx error rate is {{ $value | humanizePercentage }} over the last 5m (threshold: 1%)."
+          runbook_url: "https://app.healthystellar.io/operator/runbooks/sla-auth-error-rate"
+
+      # BullMQ queue depth > 1000 for 10 minutes
+      - alert: BullMQQueueDepthHigh
+        expr: max(queue_depth) > 1000
+        for: 10m
+        labels:
+          severity: critical
+          component: queue
+          notify: sla-critical
+        annotations:
+          summary: "BullMQ queue depth exceeds SLA (1000)"
+          description: "Queue {{ $labels.queue }} has {{ $value }} waiting jobs for over 10m (threshold: 1000)."
+          runbook_url: "https://app.healthystellar.io/operator/runbooks/sla-queue-backlog"


### PR DESCRIPTION
## Summary
Adds Prometheus alerting for SLA-critical request paths.

- **`docker/monitoring/sla-alerts.yml`** — three alert rules:
  - `PatientsP99LatencyHigh`: p99 latency on `/patients/*` > 2s for 5m
  - `AuthErrorRateHigh`: 5xx error rate on `/auth/*` > 1% for 2m
  - `BullMQQueueDepthHigh`: `queue_depth` > 1000 for 10m
- Registered the rule file in `prometheus.yml`.
- Added an `sla-critical-receiver` in `alertmanager.yml` routing `notify=sla-critical` alerts to **email + Slack** (credentials via env/secrets).
- Each alert carries a `runbook_url` annotation linking to the operator runbook (`src/operator-runbook/`).
- Documented setup in `docker/monitoring/README.md`.

Metric names/labels match `src/metrics/custom-metrics.service.ts` (`http_request_duration_seconds`, `http_requests_total`, `queue_depth`).

Closes #637

## Validation
- YAML parses cleanly (`yaml.safe_load`). `promtool`/`amtool` not available in this environment; validation commands documented in the README.