### PR TITLE
feat(pharmacy): drug interaction checker integration

### DIFF
--- a/src/pharmacy/entities/prescription.entity.ts
+++ b/src/pharmacy/entities/prescription.entity.ts
@@ -69,6 +69,10 @@ export class Prescription {
   @Column('simple-json', { nullable: true })
   safetyChecks: any;
 
+  /** Drug-drug interaction check result captured at prescription creation. */
+  @Column('simple-json', { nullable: true })
+  interactionCheck: any;
+
   @Column('text', { nullable: true })
   notes: string;
 

--- a/src/pharmacy/services/drug-interaction.service.ts
+++ b/src/pharmacy/services/drug-interaction.service.ts
@@ -51,6 +51,15 @@ function maxSeverity(
 export class DrugInteractionService {
   private readonly logger = new Logger(DrugInteractionService.name);
 
+  // ─── Circuit breaker for the external OpenFDA API ──────────────────────────
+  // Protects prescription creation from a slow/down external dependency: after
+  // CB_THRESHOLD consecutive failures the circuit opens for CB_COOLDOWN_MS,
+  // during which OpenFDA lookups are skipped (local checks still run).
+  private cbConsecutiveFailures = 0;
+  private cbOpenUntil = 0;
+  private readonly CB_THRESHOLD = 3;
+  private readonly CB_COOLDOWN_MS = 30_000;
+
   constructor(
     @InjectRepository(DrugInteraction)
     private readonly interactionRepo: Repository<DrugInteraction>,
@@ -177,6 +186,13 @@ export class DrugInteractionService {
   // relations. Falls back gracefully on network errors.
 
   private async queryOpenFda(drugIds: string[]): Promise<InteractionWarning[]> {
+    // Circuit breaker open — skip the external call entirely so a downed API
+    // never blocks or slows prescription creation.
+    if (Date.now() < this.cbOpenUntil) {
+      this.logger.warn('OpenFDA circuit breaker open — skipping external interaction lookup');
+      return [];
+    }
+
     // Load drug names so we can query OpenFDA by generic name
     const drugs = await this.interactionRepo.manager
       .getRepository('Drug')
@@ -191,6 +207,7 @@ export class DrugInteractionService {
         const name = encodeURIComponent(drug.genericName ?? drug.name);
         const url = `https://api.fda.gov/drug/label.json?search=drug_interactions:"${name}"&limit=1`;
         const resp = await firstValueFrom(this.httpService.get(url, { timeout: 5000 }));
+        this.recordOpenFdaSuccess();
         const results: any[] = resp.data?.results ?? [];
 
         for (const label of results) {
@@ -218,11 +235,28 @@ export class DrugInteractionService {
           }
         }
       } catch (err) {
+        this.recordOpenFdaFailure();
         this.logger.warn(`OpenFDA query failed for ${drug.name}: ${err.message}`);
+        // If the breaker just tripped, stop hammering the dependency for this batch.
+        if (Date.now() < this.cbOpenUntil) break;
       }
     }
 
     return warnings;
+  }
+
+  private recordOpenFdaSuccess(): void {
+    this.cbConsecutiveFailures = 0;
+  }
+
+  private recordOpenFdaFailure(): void {
+    this.cbConsecutiveFailures += 1;
+    if (this.cbConsecutiveFailures >= this.CB_THRESHOLD) {
+      this.cbOpenUntil = Date.now() + this.CB_COOLDOWN_MS;
+      this.logger.error(
+        `OpenFDA circuit breaker opened for ${this.CB_COOLDOWN_MS}ms after ${this.cbConsecutiveFailures} consecutive failures`,
+      );
+    }
   }
 
   // ─── Helpers ──────────────────────────────────────────────────────────────

--- a/src/pharmacy/services/prescription.service.ts
+++ b/src/pharmacy/services/prescription.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Between } from 'typeorm';
 import { Prescription } from '../entities/prescription.entity';
@@ -8,10 +14,13 @@ import { UpdatePrescriptionDto, SearchPrescriptionsDto } from '../dto/manage-pre
 import { SafetyAlertService } from './safety-alert.service';
 import { PharmacyInventoryService } from './pharmacy-inventory.service';
 import { ControlledSubstanceService } from './controlled-substance.service';
+import { DrugInteractionService } from './drug-interaction.service';
 import { Drug } from '../entities/drug.entity';
 
 @Injectable()
 export class PrescriptionService {
+  private readonly logger = new Logger(PrescriptionService.name);
+
   constructor(
     @InjectRepository(Prescription)
     private prescriptionRepository: Repository<Prescription>,
@@ -22,13 +31,37 @@ export class PrescriptionService {
     private safetyAlertService: SafetyAlertService,
     private inventoryService: PharmacyInventoryService,
     private controlledSubstanceService: ControlledSubstanceService,
+    private drugInteractionService: DrugInteractionService,
   ) {}
 
   async create(createDto: CreatePrescriptionDto): Promise<Prescription> {
+    // Run an automated drug-drug interaction check before persisting. Critical
+    // (major/contraindicated) interactions block creation (422); moderate
+    // interactions are recorded as warnings but do not block.
+    const drugIds = [...new Set((createDto.items ?? []).map((item) => item.drugId).filter(Boolean))];
+    const interactionCheck = await this.drugInteractionService.checkInteractions(drugIds);
+
+    if (
+      interactionCheck.highestSeverity === 'major' ||
+      interactionCheck.highestSeverity === 'contraindicated'
+    ) {
+      throw new UnprocessableEntityException({
+        message: 'Prescription blocked: critical drug interaction detected',
+        interactionCheck,
+      });
+    }
+
+    if (interactionCheck.highestSeverity === 'moderate') {
+      this.logger.warn(
+        `Moderate drug interaction(s) detected for patient ${createDto.patientId}; prescription allowed with warnings`,
+      );
+    }
+
     const prescription = this.prescriptionRepository.create({
       ...createDto,
       status: 'pending',
       refillsRemaining: createDto.refillsAllowed,
+      interactionCheck,
     });
 
     const savedPrescription = await this.prescriptionRepository.save(prescription);


### PR DESCRIPTION
## Summary
Adds automated drug interaction checking to prescription creation.

- `PrescriptionService.create()` now runs `DrugInteractionService.checkInteractions()` over the prescribed drugs **before** persisting.
- **Critical interactions** (`major`/`contraindicated`) block creation with **HTTP 422** (`UnprocessableEntityException`), returning the interaction details.
- **Moderate interactions** are logged as warnings but do **not** block.
- The full interaction check result is stored on the prescription record (new `interactionCheck` column).
- Added a **circuit breaker** around the external OpenFDA API in `DrugInteractionService`: after 3 consecutive failures the circuit opens for 30s, skipping external lookups so a downed API never blocks prescriptions (local checks still run).

External API integration (OpenFDA) was already present in `DrugInteractionService`; this issue wires it into the prescription flow and hardens it.

Closes #629

## Validation
- `tsc --noEmit` clean on all changed files.
- Jest not run: shared test setup imports `@faker-js/faker`, which is not installed in this environment (pre-existing).