### PR TITLE
feat(dlq): implement exponential backoff retry strategy with permanen…

### DIFF
--- a/src/dlq/dlq-capture.listener.ts
+++ b/src/dlq/dlq-capture.listener.ts
@@ -3,9 +3,22 @@ import { QueueEvents } from 'bullmq';
 import { ConfigService } from '@nestjs/config';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DlqService } from './dlq.service';
 import { QUEUE_NAMES } from '../queues/queue.constants';
 import { createRedisRetryStrategy } from '../common/utils/connection-retry.util';
+
+export const DLQ_PERMANENT_FAILURE_EVENT = 'dlq.job.permanent-failure';
+
+export interface DlqPermanentFailurePayload {
+  dlqEntityId: string;
+  jobId: string;
+  queueName: string;
+  jobName: string;
+  failedReason: string;
+  attemptsMade: number;
+  timestamp: string;
+}
 
 /**
  * Listens to BullMQ QueueEvents for every registered queue.
@@ -21,6 +34,7 @@ export class DlqCaptureListener implements OnModuleInit, OnModuleDestroy {
   constructor(
     private readonly configService: ConfigService,
     private readonly dlqService: DlqService,
+    private readonly eventEmitter: EventEmitter2,
 
     @InjectQueue(QUEUE_NAMES.STELLAR_TRANSACTIONS)
     private readonly stellarQueue: Queue,
@@ -71,16 +85,31 @@ export class DlqCaptureListener implements OnModuleInit, OnModuleDestroy {
           // Only capture when all retries are exhausted
           if (job.attemptsMade < maxAttempts) return;
 
-          await this.dlqService.capture({
+          const reason = failedReason ?? job.failedReason ?? 'Unknown error';
+          const saved = await this.dlqService.capture({
             jobId,
             queueName,
             jobName: job.name,
             data: job.data as Record<string, any>,
             opts: job.opts as Record<string, any>,
-            failedReason: failedReason ?? job.failedReason ?? 'Unknown error',
+            failedReason: reason,
             stackTrace: job.stacktrace?.join('\n') ?? undefined,
             attemptsMade: job.attemptsMade,
           });
+
+          const alertPayload: DlqPermanentFailurePayload = {
+            dlqEntityId: saved.id,
+            jobId,
+            queueName,
+            jobName: job.name,
+            failedReason: reason,
+            attemptsMade: job.attemptsMade,
+            timestamp: new Date().toISOString(),
+          };
+          this.eventEmitter.emit(DLQ_PERMANENT_FAILURE_EVENT, alertPayload);
+          this.logger.error(
+            `[DLQ] Permanent failure alert: job=${jobId} queue=${queueName} reason="${reason}"`,
+          );
         } catch (err) {
           this.logger.error(
             `[DLQ] Error capturing failed job ${jobId} from ${queueName}: ${(err as Error).message}`,

--- a/src/dlq/dlq-jobs.controller.ts
+++ b/src/dlq/dlq-jobs.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Query,
+  UseGuards,
+  Req,
+  ParseUUIDPipe,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery, ApiParam } from '@nestjs/swagger';
+import { Request } from 'express';
+import { DlqService, DlqListOptions } from './dlq.service';
+import { DlqJobStatus } from './dlq-job.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+
+@ApiTags('dlq/jobs')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('dlq')
+export class DlqJobsController {
+  constructor(private readonly dlqService: DlqService) {}
+
+  @Get('jobs')
+  @ApiOperation({ summary: 'Inspect DLQ jobs with optional filters' })
+  @ApiQuery({ name: 'queueName', required: false })
+  @ApiQuery({ name: 'status', required: false, enum: DlqJobStatus })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  listJobs(
+    @Query('queueName') queueName?: string,
+    @Query('status') status?: DlqJobStatus,
+    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit = 50,
+    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset = 0,
+  ) {
+    const opts: DlqListOptions = { queueName, status, limit, offset };
+    return this.dlqService.list(opts);
+  }
+
+  @Get('jobs/:id')
+  @ApiOperation({ summary: 'Get a single DLQ job by UUID' })
+  @ApiParam({ name: 'id', type: String })
+  findJob(@Param('id', ParseUUIDPipe) id: string) {
+    return this.dlqService.findOne(id);
+  }
+
+  @Post('jobs/:id/replay')
+  @ApiOperation({ summary: 'Manually replay a DLQ job back into its queue' })
+  @ApiParam({ name: 'id', type: String })
+  replayJob(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
+    const actor = (req as any).user?.email ?? (req as any).user?.id ?? 'unknown';
+    return this.dlqService.replay(id, actor);
+  }
+}

--- a/src/dlq/dlq-retry.strategy.ts
+++ b/src/dlq/dlq-retry.strategy.ts
@@ -1,0 +1,26 @@
+/** BullMQ backoff type identifier for the DLQ exponential strategy. */
+export const DLQ_BACKOFF_TYPE = 'dlq-exponential' as const;
+
+/**
+ * Total attempts per job (1 initial + 3 retries).
+ * Delays between retries: 1 s → 4 s → 16 s.
+ */
+export const DLQ_MAX_ATTEMPTS = 4;
+
+/** Base delay for the first retry (milliseconds). */
+export const DLQ_BASE_DELAY_MS = 1_000;
+
+/**
+ * Custom BullMQ backoff strategy.
+ *
+ * Uses a 4× multiplier per retry so delays follow 1 s → 4 s → 16 s:
+ *   attemptsMade=1 → 1 000 ms
+ *   attemptsMade=2 → 4 000 ms
+ *   attemptsMade=3 → 16 000 ms
+ *
+ * Register this function in every Worker's `settings.backoffStrategies`
+ * under the key `DLQ_BACKOFF_TYPE`.
+ */
+export function dlqBackoffStrategy(attemptsMade: number): number {
+  return DLQ_BASE_DELAY_MS * Math.pow(4, attemptsMade - 1);
+}

--- a/src/dlq/dlq.module.ts
+++ b/src/dlq/dlq.module.ts
@@ -4,6 +4,7 @@ import { BullModule } from '@nestjs/bullmq';
 import { DlqJobEntity } from './dlq-job.entity';
 import { DlqService } from './dlq.service';
 import { DlqController } from './dlq.controller';
+import { DlqJobsController } from './dlq-jobs.controller';
 import { DlqCaptureListener } from './dlq-capture.listener';
 import { QUEUE_NAMES } from '../queues/queue.constants';
 
@@ -19,9 +20,10 @@ import { QUEUE_NAMES } from '../queues/queue.constants';
       { name: QUEUE_NAMES.EMAIL_NOTIFICATIONS },
       { name: QUEUE_NAMES.REPORTS },
       { name: QUEUE_NAMES.EHR_IMPORT },
+      { name: QUEUE_NAMES.WEBHOOK_DELIVERY },
     ),
   ],
-  controllers: [DlqController],
+  controllers: [DlqController, DlqJobsController],
   providers: [DlqService, DlqCaptureListener],
   exports: [DlqService],
 })

--- a/src/dlq/dlq.service.spec.ts
+++ b/src/dlq/dlq.service.spec.ts
@@ -1,0 +1,251 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { getQueueToken } from '@nestjs/bullmq';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { DlqService } from './dlq.service';
+import { DlqJobEntity, DlqJobStatus } from './dlq-job.entity';
+import { QUEUE_NAMES } from '../queues/queue.constants';
+import {
+  dlqBackoffStrategy,
+  DLQ_MAX_ATTEMPTS,
+  DLQ_BASE_DELAY_MS,
+  DLQ_BACKOFF_TYPE,
+} from './dlq-retry.strategy';
+
+// ── Backoff strategy unit tests ───────────────────────────────────────────────
+
+describe('dlqBackoffStrategy', () => {
+  it('returns 1 s on the first retry (attemptsMade=1)', () => {
+    expect(dlqBackoffStrategy(1)).toBe(1_000);
+  });
+
+  it('returns 4 s on the second retry (attemptsMade=2)', () => {
+    expect(dlqBackoffStrategy(2)).toBe(4_000);
+  });
+
+  it('returns 16 s on the third retry (attemptsMade=3)', () => {
+    expect(dlqBackoffStrategy(3)).toBe(16_000);
+  });
+
+  it('follows a 4× multiplier on each successive attempt', () => {
+    const delay1 = dlqBackoffStrategy(1);
+    const delay2 = dlqBackoffStrategy(2);
+    const delay3 = dlqBackoffStrategy(3);
+    expect(delay2 / delay1).toBe(4);
+    expect(delay3 / delay2).toBe(4);
+  });
+
+  it('uses DLQ_BASE_DELAY_MS as the base', () => {
+    expect(dlqBackoffStrategy(1)).toBe(DLQ_BASE_DELAY_MS);
+  });
+});
+
+describe('DLQ retry constants', () => {
+  it('DLQ_MAX_ATTEMPTS is 4 (1 initial + 3 retries)', () => {
+    expect(DLQ_MAX_ATTEMPTS).toBe(4);
+  });
+
+  it('DLQ_BACKOFF_TYPE is a non-empty string', () => {
+    expect(typeof DLQ_BACKOFF_TYPE).toBe('string');
+    expect(DLQ_BACKOFF_TYPE.length).toBeGreaterThan(0);
+  });
+});
+
+// ── DlqService unit tests ─────────────────────────────────────────────────────
+
+const MOCK_ENTITY: DlqJobEntity = {
+  id: 'uuid-1',
+  jobId: 'job-123',
+  queueName: QUEUE_NAMES.STELLAR_TRANSACTIONS,
+  jobName: 'anchorRecord',
+  data: { patientId: 'p1' },
+  opts: {},
+  failedReason: 'timeout',
+  stackTrace: null,
+  attemptsMade: DLQ_MAX_ATTEMPTS,
+  status: DlqJobStatus.FAILED,
+  replayCount: 0,
+  replayedBy: null,
+  failedAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+};
+
+function makeRepo(): jest.Mocked<Repository<DlqJobEntity>> {
+  return {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    findAndCount: jest.fn(),
+    update: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  } as any;
+}
+
+function makeQueue() {
+  return { add: jest.fn().mockResolvedValue({ id: 'new-bull-job-1' }) };
+}
+
+function makeQueueToken(name: string) {
+  return getQueueToken(name);
+}
+
+describe('DlqService', () => {
+  let service: DlqService;
+  let repo: jest.Mocked<Repository<DlqJobEntity>>;
+  let stellarQueue: ReturnType<typeof makeQueue>;
+
+  beforeEach(async () => {
+    repo = makeRepo();
+    stellarQueue = makeQueue();
+
+    const queueProviders = Object.values(QUEUE_NAMES).map((name) => ({
+      provide: makeQueueToken(name),
+      useValue: name === QUEUE_NAMES.STELLAR_TRANSACTIONS ? stellarQueue : makeQueue(),
+    }));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DlqService,
+        { provide: getRepositoryToken(DlqJobEntity), useValue: repo },
+        ...queueProviders,
+      ],
+    }).compile();
+
+    service = module.get(DlqService);
+  });
+
+  // ── capture ────────────────────────────────────────────────────────────────
+
+  describe('capture', () => {
+    it('persists the failed job to the repository', async () => {
+      const created = { ...MOCK_ENTITY };
+      repo.create.mockReturnValue(created);
+      repo.save.mockResolvedValue(created);
+
+      const result = await service.capture({
+        jobId: MOCK_ENTITY.jobId,
+        queueName: MOCK_ENTITY.queueName,
+        jobName: MOCK_ENTITY.jobName,
+        data: MOCK_ENTITY.data,
+        opts: {},
+        failedReason: 'timeout',
+        attemptsMade: DLQ_MAX_ATTEMPTS,
+      });
+
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: 'job-123',
+          status: DlqJobStatus.FAILED,
+        }),
+      );
+      expect(repo.save).toHaveBeenCalledWith(created);
+      expect(result).toEqual(created);
+    });
+  });
+
+  // ── list ───────────────────────────────────────────────────────────────────
+
+  describe('list', () => {
+    it('returns paginated items and total count', async () => {
+      repo.findAndCount.mockResolvedValue([[MOCK_ENTITY], 1]);
+      const { items, total } = await service.list({ limit: 10, offset: 0 });
+      expect(items).toHaveLength(1);
+      expect(total).toBe(1);
+    });
+
+    it('defaults to limit=50 and offset=0', async () => {
+      repo.findAndCount.mockResolvedValue([[], 0]);
+      await service.list();
+      expect(repo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 50, skip: 0 }),
+      );
+    });
+  });
+
+  // ── findOne ────────────────────────────────────────────────────────────────
+
+  describe('findOne', () => {
+    it('returns the entity when found', async () => {
+      repo.findOne.mockResolvedValue(MOCK_ENTITY);
+      await expect(service.findOne('uuid-1')).resolves.toEqual(MOCK_ENTITY);
+    });
+
+    it('throws NotFoundException when entity is missing', async () => {
+      repo.findOne.mockResolvedValue(null);
+      await expect(service.findOne('missing-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── replay ─────────────────────────────────────────────────────────────────
+
+  describe('replay', () => {
+    it('re-enqueues with DLQ_MAX_ATTEMPTS and dlq-exponential backoff', async () => {
+      repo.findOne.mockResolvedValue({ ...MOCK_ENTITY });
+      repo.update.mockResolvedValue({} as any);
+
+      await service.replay('uuid-1', 'admin@example.com');
+
+      expect(stellarQueue.add).toHaveBeenCalledWith(
+        MOCK_ENTITY.jobName,
+        MOCK_ENTITY.data,
+        expect.objectContaining({
+          attempts: DLQ_MAX_ATTEMPTS,
+          backoff: { type: DLQ_BACKOFF_TYPE },
+        }),
+      );
+    });
+
+    it('marks the DLQ entity as REPLAYED and increments replayCount', async () => {
+      repo.findOne.mockResolvedValue({ ...MOCK_ENTITY, replayCount: 1 });
+      repo.update.mockResolvedValue({} as any);
+
+      await service.replay('uuid-1', 'admin@example.com');
+
+      expect(repo.update).toHaveBeenCalledWith(
+        'uuid-1',
+        expect.objectContaining({
+          status: DlqJobStatus.REPLAYED,
+          replayCount: 2,
+          replayedBy: 'admin@example.com',
+        }),
+      );
+    });
+
+    it('throws BadRequestException when the entity is DISCARDED', async () => {
+      repo.findOne.mockResolvedValue({ ...MOCK_ENTITY, status: DlqJobStatus.DISCARDED });
+      await expect(service.replay('uuid-1', 'admin')).rejects.toThrow(BadRequestException);
+    });
+
+    it('returns the replay result with new BullMQ job id', async () => {
+      repo.findOne.mockResolvedValue({ ...MOCK_ENTITY });
+      repo.update.mockResolvedValue({} as any);
+
+      const result = await service.replay('uuid-1', 'admin@example.com');
+
+      expect(result).toEqual({
+        dlqId: 'uuid-1',
+        jobId: MOCK_ENTITY.jobId,
+        queueName: MOCK_ENTITY.queueName,
+        newBullJobId: 'new-bull-job-1',
+      });
+    });
+  });
+
+  // ── discard ────────────────────────────────────────────────────────────────
+
+  describe('discard', () => {
+    it('marks the entity as DISCARDED', async () => {
+      repo.findOne.mockResolvedValue({ ...MOCK_ENTITY });
+      repo.update.mockResolvedValue({} as any);
+
+      const result = await service.discard('uuid-1', 'admin@example.com');
+
+      expect(repo.update).toHaveBeenCalledWith(
+        'uuid-1',
+        expect.objectContaining({ status: DlqJobStatus.DISCARDED }),
+      );
+      expect(result.status).toBe(DlqJobStatus.DISCARDED);
+    });
+  });
+});

--- a/src/dlq/dlq.service.ts
+++ b/src/dlq/dlq.service.ts
@@ -5,6 +5,7 @@ import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { DlqJobEntity, DlqJobStatus } from './dlq-job.entity';
 import { QUEUE_NAMES } from '../queues/queue.constants';
+import { DLQ_BACKOFF_TYPE, DLQ_MAX_ATTEMPTS } from './dlq-retry.strategy';
 
 export interface DlqListOptions {
   queueName?: string;
@@ -134,8 +135,8 @@ export class DlqService {
     }
 
     const newJob = await queue.add(entity.jobName, entity.data, {
-      attempts: 3,
-      backoff: { type: 'exponential', delay: 2000 },
+      attempts: DLQ_MAX_ATTEMPTS,
+      backoff: { type: DLQ_BACKOFF_TYPE },
       removeOnComplete: true,
       removeOnFail: false,
     });

--- a/src/queues/processors/contract-writes.processor.ts
+++ b/src/queues/processors/contract-writes.processor.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@nestjs/config';
 import { QUEUE_NAMES, JOB_TYPES } from '../queue.constants';
 import { StellarContractService } from '../../blockchain/stellar-contract.service';
 import { verifyQueuePayload } from '../queue-payload.util';
+import { DLQ_BACKOFF_TYPE, dlqBackoffStrategy } from '../../dlq/dlq-retry.strategy';
 
 /**
  * ContractWritesProcessor
@@ -14,7 +15,8 @@ import { verifyQueuePayload } from '../queue-payload.util';
  * These are operations that modify on-chain state (anchorRecord, grantAccess, revokeAccess)
  */
 @Processor(QUEUE_NAMES.CONTRACT_WRITES, {
-  concurrency: 3, // Lower concurrency for contract writes to handle blockchain rate limits
+  concurrency: 3,
+  settings: { backoffStrategies: { [DLQ_BACKOFF_TYPE]: dlqBackoffStrategy } },
 })
 export class ContractWritesProcessor extends WorkerHost {
   private readonly logger = new Logger(ContractWritesProcessor.name);

--- a/src/queues/processors/event-indexing.processor.ts
+++ b/src/queues/processors/event-indexing.processor.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { QUEUE_NAMES } from '../queue.constants';
 import { verifyQueuePayload } from '../queue-payload.util';
+import { DLQ_BACKOFF_TYPE, dlqBackoffStrategy } from '../../dlq/dlq-retry.strategy';
 import { RecordEventStoreService } from '../../records/services/record-event-store.service';
 import { RecordEventType } from '../../records/entities/record-event.entity';
 import { RECORD_DELETED_EVENT } from '../../records/services/record-sync.service';
@@ -62,6 +63,7 @@ export interface EventIndexingResult {
  */
 @Processor(QUEUE_NAMES.EVENT_INDEXING, {
   concurrency: 2,
+  settings: { backoffStrategies: { [DLQ_BACKOFF_TYPE]: dlqBackoffStrategy } },
 })
 export class EventIndexingProcessor extends WorkerHost {
   private readonly logger = new Logger(EventIndexingProcessor.name);

--- a/src/queues/processors/stellar-transaction.processor.ts
+++ b/src/queues/processors/stellar-transaction.processor.ts
@@ -8,11 +8,13 @@ import { QUEUE_NAMES, JOB_TYPES } from '../queue.constants';
 import { StellarTransactionJobDto } from '../dto/stellar-transaction-job.dto';
 import { StellarWithBreakerService } from '../../stellar/services/stellar-with-breaker.service';
 import { verifyQueuePayload } from '../queue-payload.util';
+import { DLQ_BACKOFF_TYPE, dlqBackoffStrategy } from '../../dlq/dlq-retry.strategy';
 
 const IDEMPOTENCY_TTL_SECONDS = 86400; // 24 hours
 
 @Processor(QUEUE_NAMES.STELLAR_TRANSACTIONS, {
   concurrency: 5,
+  settings: { backoffStrategies: { [DLQ_BACKOFF_TYPE]: dlqBackoffStrategy } },
 })
 export class StellarTransactionProcessor extends WorkerHost implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(StellarTransactionProcessor.name);

--- a/src/queues/queue.module.ts
+++ b/src/queues/queue.module.ts
@@ -6,6 +6,7 @@ import { ExpressAdapter } from '@bull-board/express';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { QUEUE_NAMES } from './queue.constants';
+import { DLQ_BACKOFF_TYPE, DLQ_MAX_ATTEMPTS } from '../dlq/dlq-retry.strategy';
 import { QueueService } from './queue.service';
 import { QueueController } from './queue.controller';
 import { EhrImportDlqController } from './controllers/ehr-import-dlq.controller';
@@ -74,8 +75,8 @@ export class QueueModule {
               },
             },
             defaultJobOptions: {
-              attempts: 5,
-              backoff: { type: 'exponential', delay: 2000 },
+              attempts: DLQ_MAX_ATTEMPTS,
+              backoff: { type: DLQ_BACKOFF_TYPE },
               removeOnComplete: { count: 1000 },
               removeOnFail: { count: 5000 },
             },


### PR DESCRIPTION
…t DLQ alerting

Implements a structured retry strategy for failed BullMQ jobs so that transient errors are retried automatically before a job is permanently captured in the dead-letter queue, and operators are alerted when that happens.

Changes
───────

dlq-retry.strategy.ts (new)
  Single source of truth for retry configuration:
  - DLQ_MAX_ATTEMPTS = 4 (1 initial attempt + 3 retries)
  - DLQ_BASE_DELAY_MS = 1 000 ms
  - DLQ_BACKOFF_TYPE = 'dlq-exponential'
  - dlqBackoffStrategy(attemptsMade) → 1 s / 4 s / 16 s via 4× multiplier

queue.module.ts
  Updated defaultJobOptions from attempts=5 / exponential-2000ms to
  attempts=DLQ_MAX_ATTEMPTS / backoff type='dlq-exponential' so all
  queues inherit the new policy automatically.

processors (stellar-transaction, contract-writes, event-indexing)
  Registered dlqBackoffStrategy in each Worker's
  settings.backoffStrategies so BullMQ can compute the correct delay
  when a job is scheduled for retry.

dlq-capture.listener.ts
  After persisting an exhausted job to the dlq_jobs table, the listener
  now emits a 'dlq.job.permanent-failure' EventEmitter2 event carrying
  { dlqEntityId, jobId, queueName, jobName, failedReason, attemptsMade,
  timestamp }. Any module can subscribe to this event to trigger Slack
  alerts, PagerDuty incidents, or email notifications.
  Exports DLQ_PERMANENT_FAILURE_EVENT and DlqPermanentFailurePayload for
  typed subscriptions.

dlq.service.ts
  replay() now re-enqueues jobs with DLQ_MAX_ATTEMPTS and the custom
  backoff type instead of the previous hardcoded attempts=3 / exponential.

dlq-jobs.controller.ts (new)
  Admin-only REST controller at /dlq:
    GET  /dlq/jobs              list jobs (queueName, status, limit, offset)
    GET  /dlq/jobs/:id          inspect a single DLQ entry
    POST /dlq/jobs/:id/replay   manually re-enqueue a job

dlq.module.ts
  - Registers DlqJobsController alongside the existing DlqController.
  - Adds WEBHOOK_DELIVERY to BullModule.registerQueue (was missing, causing a runtime injection error in DlqService).

dlq.service.spec.ts (new)
  Unit tests covering:
  - dlqBackoffStrategy: 1 s / 4 s / 16 s delays and the 4× multiplier
  - DLQ_MAX_ATTEMPTS constant value
  - DlqService.capture: persists entity with FAILED status
  - DlqService.list: correct pagination defaults
  - DlqService.findOne: NotFoundException on missing entity
  - DlqService.replay: correct attempts/backoff opts, REPLAYED status update, increments replayCount, rejects DISCARDED entries
  - DlqService.discard: sets DISCARDED status

Acceptance criteria met
───────────────────────
- Retry up to 3 times with exponential backoff (1 s, 4 s, 16 s)
- After max retries, captured to permanent DLQ + alert event emitted
- GET/POST /dlq/jobs endpoints (admin-only, JWT + Roles guard)
- Unit tests for retry logic and service methods

closes #630 