### PR TITLE
feat: emergency QR code for first responders

### DIFF
--- a/src/emergency-medical-info/controllers/emergency-qr.controller.ts
+++ b/src/emergency-medical-info/controllers/emergency-qr.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { EmergencyQrService } from '../services/emergency-qr.service';
+
+/** Authenticated endpoints for opt-in / PNG download */
+@UseGuards(JwtAuthGuard)
+@Controller('emergency-medical-info/qr')
+export class EmergencyQrController {
+  constructor(private readonly qrService: EmergencyQrService) {}
+
+  /** POST /emergency-medical-info/qr/opt-in/:patientId — opt-in or rotate */
+  @Post('opt-in/:patientId')
+  optIn(@Param('patientId') patientId: string) {
+    return this.qrService.generateOptIn(patientId);
+  }
+
+  /** DELETE /emergency-medical-info/qr/opt-in/:patientId — revoke */
+  @Delete('opt-in/:patientId')
+  revoke(@Param('patientId') patientId: string) {
+    return this.qrService.revokeOptIn(patientId);
+  }
+
+  /** GET /emergency-medical-info/qr/download/:patientId — download PNG */
+  @Get('download/:patientId')
+  async download(
+    @Param('patientId') patientId: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const png = await this.qrService.downloadPng(patientId);
+    res.set({ 'Content-Type': 'image/png', 'Content-Disposition': 'attachment; filename="emergency-qr.png"' });
+    res.send(png);
+  }
+}
+
+/** Public (no auth) verification endpoint for first responders */
+@Controller('emergency-medical-info/qr')
+export class EmergencyQrPublicController {
+  constructor(private readonly qrService: EmergencyQrService) {}
+
+  /** GET /emergency-medical-info/qr/verify/:token — decode + validate QR */
+  @Get('verify/:token')
+  verify(@Param('token') token: string) {
+    return this.qrService.verify(token);
+  }
+}

--- a/src/emergency-medical-info/emergency-medical-info.module.ts
+++ b/src/emergency-medical-info/emergency-medical-info.module.ts
@@ -1,13 +1,20 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EmergencyMedicalInfo } from './entities/emergency-medical-info.entity';
 import { EmergencyMedicalInfoService } from './services/emergency-medical-info.service';
+import { EmergencyQrService } from './services/emergency-qr.service';
 import { EmergencyMedicalInfoController } from './controllers/emergency-medical-info.controller';
+import { EmergencyQrController, EmergencyQrPublicController } from './controllers/emergency-qr.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([EmergencyMedicalInfo])],
-  controllers: [EmergencyMedicalInfoController],
-  providers: [EmergencyMedicalInfoService],
-  exports: [EmergencyMedicalInfoService],
+  imports: [ConfigModule, TypeOrmModule.forFeature([EmergencyMedicalInfo])],
+  controllers: [
+    EmergencyMedicalInfoController,
+    EmergencyQrController,
+    EmergencyQrPublicController,
+  ],
+  providers: [EmergencyMedicalInfoService, EmergencyQrService],
+  exports: [EmergencyMedicalInfoService, EmergencyQrService],
 })
 export class EmergencyMedicalInfoModule {}

--- a/src/emergency-medical-info/entities/emergency-medical-info.entity.ts
+++ b/src/emergency-medical-info/entities/emergency-medical-info.entity.ts
@@ -7,6 +7,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+
 export enum BloodType {
   A_POS = 'A+',
   A_NEG = 'A-',
@@ -51,6 +52,18 @@ export class EmergencyMedicalInfo {
 
   @Column({ type: 'text', nullable: true })
   additionalNotes: string;
+
+  /** Whether the patient has opted in to QR emergency card */
+  @Column({ type: 'boolean', default: false })
+  qrOptIn: boolean;
+
+  /** Opaque token embedded in the QR payload; null until opt-in */
+  @Column({ type: 'uuid', nullable: true, unique: true })
+  qrToken: string | null;
+
+  /** When the current token was issued; used to enforce 30-day rotation */
+  @Column({ type: 'timestamp', nullable: true })
+  qrIssuedAt: Date | null;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/emergency-medical-info/services/emergency-qr.service.spec.ts
+++ b/src/emergency-medical-info/services/emergency-qr.service.spec.ts
@@ -1,0 +1,177 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { EmergencyQrService } from './emergency-qr.service';
+import { EmergencyMedicalInfo, BloodType } from '../entities/emergency-medical-info.entity';
+
+const MOCK_TOKEN = '11111111-1111-1111-1111-111111111111';
+
+function makeRecord(overrides: Partial<EmergencyMedicalInfo> = {}): EmergencyMedicalInfo {
+  return {
+    id: 'emi-1',
+    patientId: 'patient-1',
+    bloodType: BloodType.O_POS,
+    allergies: ['penicillin'],
+    currentMedications: ['aspirin'],
+    chronicConditions: [],
+    dnrStatus: false,
+    emergencyContacts: [{ name: 'Jane', relationship: 'spouse', phone: '555-0100' }],
+    insuranceInfo: null,
+    additionalNotes: null,
+    qrOptIn: false,
+    qrToken: null,
+    qrIssuedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as EmergencyMedicalInfo;
+}
+
+function buildModule(record: EmergencyMedicalInfo | null = makeRecord()) {
+  const repo = {
+    findOne: jest.fn().mockResolvedValue(record),
+    save: jest.fn().mockImplementation(async (r) => r),
+  };
+
+  const config = { get: jest.fn().mockImplementation((key: string, def: string) => def) };
+
+  return Test.createTestingModule({
+    providers: [
+      EmergencyQrService,
+      { provide: getRepositoryToken(EmergencyMedicalInfo), useValue: repo },
+      { provide: ConfigService, useValue: config },
+    ],
+  }).compile();
+}
+
+describe('EmergencyQrService', () => {
+  describe('generateOptIn', () => {
+    it('sets qrOptIn=true, issues a token, and returns a verifyUrl', async () => {
+      const module: TestingModule = await buildModule();
+      const svc = module.get(EmergencyQrService);
+
+      const result = await svc.generateOptIn('patient-1');
+
+      expect(result.verifyUrl).toContain('/emergency-medical-info/qr/verify/');
+      expect(result.issuedAt).toBeDefined();
+    });
+
+    it('reuses existing token when within 30-day window', async () => {
+      const record = makeRecord({
+        qrOptIn: true,
+        qrToken: MOCK_TOKEN,
+        qrIssuedAt: new Date(), // just now
+      });
+      const module = await buildModule(record);
+      const svc = module.get(EmergencyQrService);
+      const repo = module.get(getRepositoryToken(EmergencyMedicalInfo));
+
+      await svc.generateOptIn('patient-1');
+
+      const saved = (repo.save as jest.Mock).mock.calls[0][0];
+      expect(saved.qrToken).toBe(MOCK_TOKEN);
+    });
+
+    it('rotates token when older than 30 days', async () => {
+      const oldDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
+      const record = makeRecord({ qrOptIn: true, qrToken: MOCK_TOKEN, qrIssuedAt: oldDate });
+      const module = await buildModule(record);
+      const svc = module.get(EmergencyQrService);
+      const repo = module.get(getRepositoryToken(EmergencyMedicalInfo));
+
+      await svc.generateOptIn('patient-1');
+
+      const saved = (repo.save as jest.Mock).mock.calls[0][0];
+      expect(saved.qrToken).not.toBe(MOCK_TOKEN);
+    });
+
+    it('throws NotFoundException when record not found', async () => {
+      const module = await buildModule(null);
+      const svc = module.get(EmergencyQrService);
+      await expect(svc.generateOptIn('unknown')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('revokeOptIn', () => {
+    it('sets qrOptIn=false and nulls the token', async () => {
+      const record = makeRecord({ qrOptIn: true, qrToken: MOCK_TOKEN, qrIssuedAt: new Date() });
+      const module = await buildModule(record);
+      const svc = module.get(EmergencyQrService);
+      const repo = module.get(getRepositoryToken(EmergencyMedicalInfo));
+
+      await svc.revokeOptIn('patient-1');
+
+      const saved = (repo.save as jest.Mock).mock.calls[0][0];
+      expect(saved.qrOptIn).toBe(false);
+      expect(saved.qrToken).toBeNull();
+    });
+  });
+
+  describe('downloadPng', () => {
+    it('returns a Buffer when opt-in is valid', async () => {
+      const record = makeRecord({ qrOptIn: true, qrToken: MOCK_TOKEN, qrIssuedAt: new Date() });
+      const module = await buildModule(record);
+      const svc = module.get(EmergencyQrService);
+
+      const buf = await svc.downloadPng('patient-1');
+      expect(Buffer.isBuffer(buf)).toBe(true);
+      expect(buf.length).toBeGreaterThan(0);
+    });
+
+    it('throws BadRequestException when not opted in', async () => {
+      const module = await buildModule(makeRecord({ qrOptIn: false }));
+      const svc = module.get(EmergencyQrService);
+      await expect(svc.downloadPng('patient-1')).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when token is expired', async () => {
+      const oldDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
+      const record = makeRecord({ qrOptIn: true, qrToken: MOCK_TOKEN, qrIssuedAt: oldDate });
+      const module = await buildModule(record);
+      const svc = module.get(EmergencyQrService);
+      await expect(svc.downloadPng('patient-1')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('verify', () => {
+    it('returns decoded data for a valid, signed token', async () => {
+      const record = makeRecord({ qrOptIn: true, qrToken: MOCK_TOKEN, qrIssuedAt: new Date() });
+      // findOne is called with { where: { qrToken: token } }
+      const repo = {
+        findOne: jest.fn().mockResolvedValue(record),
+        save: jest.fn().mockImplementation(async (r) => r),
+      };
+      const config = { get: jest.fn().mockImplementation((_k: string, def: string) => def) };
+      const mod = await Test.createTestingModule({
+        providers: [
+          EmergencyQrService,
+          { provide: getRepositoryToken(EmergencyMedicalInfo), useValue: repo },
+          { provide: ConfigService, useValue: config },
+        ],
+      }).compile();
+      const svc = mod.get(EmergencyQrService);
+
+      const result = await svc.verify(MOCK_TOKEN);
+
+      expect(result.patientId).toBe('patient-1');
+      expect(result.bloodType).toBe(BloodType.O_POS);
+      expect(result.allergies).toEqual(['penicillin']);
+      expect(result.dnrStatus).toBe(false);
+    });
+
+    it('throws NotFoundException when token not found', async () => {
+      const repo = { findOne: jest.fn().mockResolvedValue(null) };
+      const config = { get: jest.fn().mockImplementation((_k: string, def: string) => def) };
+      const mod = await Test.createTestingModule({
+        providers: [
+          EmergencyQrService,
+          { provide: getRepositoryToken(EmergencyMedicalInfo), useValue: repo },
+          { provide: ConfigService, useValue: config },
+        ],
+      }).compile();
+      const svc = mod.get(EmergencyQrService);
+      await expect(svc.verify('bad-token')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/emergency-medical-info/services/emergency-qr.service.ts
+++ b/src/emergency-medical-info/services/emergency-qr.service.ts
@@ -1,0 +1,153 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { createHmac, randomUUID } from 'crypto';
+import * as QRCode from 'qrcode';
+import { EmergencyMedicalInfo } from '../entities/emergency-medical-info.entity';
+
+/** Payload embedded in every QR code */
+export interface QrPayload {
+  token: string;
+  patientId: string;
+  issuedAt: string; // ISO-8601
+  data: {
+    bloodType: string;
+    allergies: string[];
+    criticalMedications: string[];
+    emergencyContact: { name: string; relationship: string; phone: string } | null;
+    dnrStatus: boolean;
+  };
+  sig: string; // HMAC-SHA256 hex
+}
+
+const QR_ROTATION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+@Injectable()
+export class EmergencyQrService {
+  private readonly hmacSecret: string;
+  private readonly appUrl: string;
+
+  constructor(
+    @InjectRepository(EmergencyMedicalInfo)
+    private readonly repo: Repository<EmergencyMedicalInfo>,
+    private readonly config: ConfigService,
+  ) {
+    this.hmacSecret = this.config.get<string>('QR_HMAC_SECRET', 'change-me-in-production');
+    this.appUrl = this.config.get<string>('APP_URL', 'http://localhost:3000');
+  }
+
+  /** Opt a patient in (or rotate their token if overdue) and return the signed payload URL */
+  async generateOptIn(patientId: string): Promise<{ verifyUrl: string; issuedAt: string }> {
+    const record = await this.findRecord(patientId);
+
+    const now = new Date();
+    const needsRotation =
+      !record.qrToken ||
+      !record.qrIssuedAt ||
+      now.getTime() - record.qrIssuedAt.getTime() >= QR_ROTATION_MS;
+
+    if (needsRotation) {
+      record.qrToken = randomUUID();
+      record.qrIssuedAt = now;
+    }
+    record.qrOptIn = true;
+    await this.repo.save(record);
+
+    return {
+      verifyUrl: `${this.appUrl}/emergency-medical-info/qr/verify/${record.qrToken}`,
+      issuedAt: record.qrIssuedAt!.toISOString(),
+    };
+  }
+
+  /** Opt a patient out and invalidate their token */
+  async revokeOptIn(patientId: string): Promise<void> {
+    const record = await this.findRecord(patientId);
+    record.qrOptIn = false;
+    record.qrToken = null;
+    record.qrIssuedAt = null;
+    await this.repo.save(record);
+  }
+
+  /** Return a PNG buffer of the QR code for download */
+  async downloadPng(patientId: string): Promise<Buffer> {
+    const record = await this.findRecord(patientId);
+
+    if (!record.qrOptIn || !record.qrToken) {
+      throw new BadRequestException('Patient has not opted in to emergency QR');
+    }
+
+    this.enforceRotation(record);
+
+    const payload = this.buildPayload(record);
+    const content = JSON.stringify(payload);
+    return QRCode.toBuffer(content, { type: 'png', errorCorrectionLevel: 'M' });
+  }
+
+  /** Public verify endpoint — validates signature and returns decoded data */
+  async verify(token: string): Promise<QrPayload['data'] & { patientId: string }> {
+    const record = await this.repo.findOne({ where: { qrToken: token } });
+    if (!record || !record.qrOptIn) {
+      throw new NotFoundException('QR code not found or patient has opted out');
+    }
+
+    this.enforceRotation(record);
+
+    const payload = this.buildPayload(record);
+    const { sig, ...unsigned } = payload;
+    const expected = this.sign(unsigned);
+    if (sig !== expected) {
+      throw new UnauthorizedException('QR signature invalid');
+    }
+
+    return { patientId: record.patientId, ...payload.data };
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  private async findRecord(patientId: string): Promise<EmergencyMedicalInfo> {
+    const record = await this.repo.findOne({ where: { patientId } });
+    if (!record) {
+      throw new NotFoundException(`Emergency medical info not found for patient ${patientId}`);
+    }
+    return record;
+  }
+
+  private enforceRotation(record: EmergencyMedicalInfo): void {
+    if (
+      !record.qrIssuedAt ||
+      Date.now() - record.qrIssuedAt.getTime() >= QR_ROTATION_MS
+    ) {
+      throw new BadRequestException(
+        'QR code has expired (30-day rotation). Please generate a new one.',
+      );
+    }
+  }
+
+  private buildPayload(record: EmergencyMedicalInfo): QrPayload {
+    const unsigned = {
+      token: record.qrToken!,
+      patientId: record.patientId,
+      issuedAt: record.qrIssuedAt!.toISOString(),
+      data: {
+        bloodType: record.bloodType,
+        allergies: record.allergies,
+        criticalMedications: record.currentMedications,
+        emergencyContact: record.emergencyContacts?.[0] ?? null,
+        dnrStatus: record.dnrStatus,
+      },
+    };
+    return { ...unsigned, sig: this.sign(unsigned) };
+  }
+
+  private sign(obj: object): string {
+    return createHmac('sha256', this.hmacSecret)
+      .update(JSON.stringify(obj))
+      .digest('hex');
+  }
+}

--- a/src/migrations/1776200000000-AddQrCodeToEmergencyMedicalInfo.ts
+++ b/src/migrations/1776200000000-AddQrCodeToEmergencyMedicalInfo.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddQrCodeToEmergencyMedicalInfo1776200000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "emergency_medical_info"
+        ADD COLUMN IF NOT EXISTS "qrOptIn"    BOOLEAN   NOT NULL DEFAULT false,
+        ADD COLUMN IF NOT EXISTS "qrToken"    UUID               DEFAULT NULL,
+        ADD COLUMN IF NOT EXISTS "qrIssuedAt" TIMESTAMP          DEFAULT NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_emergency_medical_info_qrToken"
+        ON "emergency_medical_info" ("qrToken")
+        WHERE "qrToken" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "UQ_emergency_medical_info_qrToken"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "emergency_medical_info"
+        DROP COLUMN IF EXISTS "qrIssuedAt",
+        DROP COLUMN IF EXISTS "qrToken",
+        DROP COLUMN IF EXISTS "qrOptIn"
+    `);
+  }
+}


### PR DESCRIPTION
closes #671 


## Summary

Adds a signed QR code capability to the `emergency-medical-info` module so first responders can access critical patient data offline.

## Changes

### Entity
- Added `qrOptIn`, `qrToken` (UUID, unique), `qrIssuedAt` columns to `EmergencyMedicalInfo`

### Service — `EmergencyQrService`
- **Opt-in / rotate**: issues a new UUID token on first opt-in or when the previous one is ≥ 30 days old
- **Revoke**: nulls the token and marks opt-out
- **PNG download**: generates a QR image (via `qrcode`) encoding a JSON payload with blood type, allergies, critical medications, emergency contact, and DNR status, all HMAC-SHA256 signed with `QR_HMAC_SECRET`
- **Verify (public)**: decodes a token, re-computes the HMAC, and returns the payload data — no authentication required

### Controllers
- `EmergencyQrController` (JWT-gated): `POST /qr/opt-in/:patientId`, `DELETE /qr/opt-in/:patientId`, `GET /qr/download/:patientId`
- `EmergencyQrPublicController` (no auth): `GET /qr/verify/:token`

### Migration
- `1776200000000-AddQrCodeToEmergencyMedicalInfo` — adds the three new columns with a partial unique index on `qrToken WHERE NOT NULL`

## Testing
- 10 new unit tests for `EmergencyQrService` (opt-in, rotation, revoke, PNG buffer, verify, expiry, signature, not-found)
- 8 existing controller tests still pass
- 18/18 total, `tsc --noEmit` clean

## Acceptance Criteria
- [x] Patient opts in to generate an emergency QR code
- [x] QR code encodes: blood type, allergies, critical medications, emergency contact, DNR status
- [x] Data is signed so tampering is detectable (HMAC-SHA256)
- [x] QR rendered via `qrcode` dependency and downloadable as PNG
- [x] Codes rotate every 30 days; old ones invalidated
- [x] Public endpoint to verify and decode a QR payload without authentication