### PR TITLE
feat: add bed occupancy management module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -77,6 +77,7 @@ import { DlqModule } from './dlq/dlq.module';
 import { OperatorRunbookModule } from './operator-runbook/operator-runbook.module';
 import { IncidentModule } from './incident/incident.module';
 import { PiiRedactionInterceptor } from './common/interceptors/pii-redaction.interceptor';
+import { BedOccupancyModule } from './bed-occupancy/bed-occupancy.module';
 
 @Module({
   imports: [
@@ -157,6 +158,7 @@ import { PiiRedactionInterceptor } from './common/interceptors/pii-redaction.int
     DlqModule,
     OperatorRunbookModule,
     IncidentModule,
+    BedOccupancyModule,
     EventEmitterModule.forRoot(),
   ],
   controllers: [AppController],

--- a/src/bed-occupancy/bed-occupancy.controller.ts
+++ b/src/bed-occupancy/bed-occupancy.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { BedOccupancyService } from './bed-occupancy.service';
+import {
+  AssignBedDto,
+  BedOccupancyQueryDto,
+  CreateBedDto,
+  CreateRoomDto,
+  CreateWardDto,
+  UpdateBedStatusDto,
+} from './dto/bed-occupancy.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('bed-occupancy')
+export class BedOccupancyController {
+  constructor(private readonly service: BedOccupancyService) {}
+
+  // ── Wards ─────────────────────────────────────────────────────────────────
+
+  @Post('wards')
+  createWard(@Body() dto: CreateWardDto) {
+    return this.service.createWard(dto);
+  }
+
+  @Get('wards')
+  getWards() {
+    return this.service.getWards();
+  }
+
+  // ── Rooms ─────────────────────────────────────────────────────────────────
+
+  @Post('rooms')
+  createRoom(@Body() dto: CreateRoomDto) {
+    return this.service.createRoom(dto);
+  }
+
+  @Get('wards/:wardId/rooms')
+  getRoomsByWard(@Param('wardId') wardId: string) {
+    return this.service.getRoomsByWard(wardId);
+  }
+
+  // ── Beds ──────────────────────────────────────────────────────────────────
+
+  @Post('beds')
+  createBed(@Body() dto: CreateBedDto) {
+    return this.service.createBed(dto);
+  }
+
+  @Get('beds')
+  getBeds(@Query() query: BedOccupancyQueryDto) {
+    return this.service.getBeds(query);
+  }
+
+  @Get('beds/:id')
+  getBedById(@Param('id') id: string) {
+    return this.service.getBedById(id);
+  }
+
+  @Post('beds/assign')
+  assignBed(@Body() dto: AssignBedDto) {
+    return this.service.assignBed(dto);
+  }
+
+  @Patch('beds/:id/release')
+  releaseBed(@Param('id') id: string) {
+    return this.service.releaseBed(id);
+  }
+
+  @Patch('beds/:id/status')
+  updateBedStatus(@Param('id') id: string, @Body() dto: UpdateBedStatusDto) {
+    return this.service.updateBedStatus(id, dto);
+  }
+
+  // ── Summary ───────────────────────────────────────────────────────────────
+
+  @Get('summary')
+  getOccupancySummary(@Query('wardId') wardId?: string) {
+    return this.service.getOccupancySummary(wardId);
+  }
+}

--- a/src/bed-occupancy/bed-occupancy.module.ts
+++ b/src/bed-occupancy/bed-occupancy.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Bed } from './entities/bed.entity';
+import { Room } from './entities/room.entity';
+import { Ward } from './entities/ward.entity';
+import { BedOccupancyService } from './bed-occupancy.service';
+import { BedOccupancyController } from './bed-occupancy.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Bed, Room, Ward])],
+  controllers: [BedOccupancyController],
+  providers: [BedOccupancyService],
+  exports: [BedOccupancyService],
+})
+export class BedOccupancyModule {}

--- a/src/bed-occupancy/bed-occupancy.service.spec.ts
+++ b/src/bed-occupancy/bed-occupancy.service.spec.ts
@@ -1,0 +1,174 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BedOccupancyService } from './bed-occupancy.service';
+import { Bed } from './entities/bed.entity';
+import { Room } from './entities/room.entity';
+import { Ward } from './entities/ward.entity';
+import { BedStatus } from './bed-status.enum';
+
+const makeWard = (o: Partial<Ward> = {}): Ward =>
+  ({ id: 'w1', name: 'Ward A', isActive: true, wardManagerId: null, ...o } as Ward);
+
+const makeRoom = (o: Partial<Room> = {}): Room =>
+  ({ id: 'r1', wardId: 'w1', roomNumber: '101', isActive: true, ...o } as Room);
+
+const makeBed = (o: Partial<Bed> = {}): Bed =>
+  ({
+    id: 'b1',
+    bedNumber: '1A',
+    status: BedStatus.AVAILABLE,
+    roomId: 'r1',
+    patientId: null,
+    assignedAt: null,
+    features: [],
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...o,
+  } as Bed);
+
+function buildModule(
+  bedRecord: Bed | null = makeBed(),
+  roomRecord: Room | null = makeRoom(),
+  wardRecord: Ward | null = makeWard(),
+) {
+  const bedRepo = {
+    create: jest.fn().mockImplementation((d) => d),
+    save: jest.fn().mockImplementation(async (r) => r),
+    find: jest.fn().mockResolvedValue(bedRecord ? [bedRecord] : []),
+    findOne: jest.fn().mockResolvedValue(bedRecord),
+    createQueryBuilder: jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        { status: BedStatus.AVAILABLE, count: '5' },
+        { status: BedStatus.OCCUPIED, count: '3' },
+      ]),
+    }),
+  };
+
+  const roomRepo = {
+    create: jest.fn().mockImplementation((d) => d),
+    save: jest.fn().mockImplementation(async (r) => r),
+    find: jest.fn().mockResolvedValue(roomRecord ? [roomRecord] : []),
+    findOne: jest.fn().mockResolvedValue(roomRecord),
+  };
+
+  const wardRepo = {
+    create: jest.fn().mockImplementation((d) => d),
+    save: jest.fn().mockImplementation(async (r) => r),
+    find: jest.fn().mockResolvedValue(wardRecord ? [wardRecord] : []),
+    findOne: jest.fn().mockResolvedValue(wardRecord),
+  };
+
+  return Test.createTestingModule({
+    providers: [
+      BedOccupancyService,
+      { provide: getRepositoryToken(Bed), useValue: bedRepo },
+      { provide: getRepositoryToken(Room), useValue: roomRepo },
+      { provide: getRepositoryToken(Ward), useValue: wardRepo },
+    ],
+  }).compile();
+}
+
+describe('BedOccupancyService', () => {
+  describe('createWard', () => {
+    it('creates and returns a ward', async () => {
+      const mod = await buildModule();
+      const svc = mod.get(BedOccupancyService);
+      const result = await svc.createWard({ name: 'Ward A' });
+      expect(result).toMatchObject({ name: 'Ward A' });
+    });
+  });
+
+  describe('createRoom', () => {
+    it('throws NotFoundException when ward not found', async () => {
+      const mod = await buildModule(makeBed(), makeRoom(), null);
+      const svc = mod.get(BedOccupancyService);
+      await expect(svc.createRoom({ wardId: 'w1', roomNumber: '101' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('creates a room when ward exists', async () => {
+      const mod = await buildModule();
+      const svc = mod.get(BedOccupancyService);
+      const result = await svc.createRoom({ wardId: 'w1', roomNumber: '101' });
+      expect(result).toMatchObject({ wardId: 'w1', roomNumber: '101' });
+    });
+  });
+
+  describe('createBed', () => {
+    it('throws NotFoundException when room not found', async () => {
+      const mod = await buildModule(makeBed(), null);
+      const svc = mod.get(BedOccupancyService);
+      await expect(svc.createBed({ bedNumber: '1A', roomId: 'r1' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('creates a bed when room exists', async () => {
+      const mod = await buildModule();
+      const svc = mod.get(BedOccupancyService);
+      const result = await svc.createBed({ bedNumber: '1A', roomId: 'r1' });
+      expect(result).toMatchObject({ bedNumber: '1A', roomId: 'r1' });
+    });
+  });
+
+  describe('assignBed', () => {
+    it('assigns an available bed to a patient', async () => {
+      const mod = await buildModule();
+      const svc = mod.get(BedOccupancyService);
+      const result = await svc.assignBed({ bedId: 'b1', patientId: 'p1' });
+      expect(result.status).toBe(BedStatus.OCCUPIED);
+      expect(result.patientId).toBe('p1');
+    });
+
+    it('throws BadRequestException when bed is not available', async () => {
+      const mod = await buildModule(makeBed({ status: BedStatus.OCCUPIED }));
+      const svc = mod.get(BedOccupancyService);
+      await expect(svc.assignBed({ bedId: 'b1', patientId: 'p1' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFoundException when bed not found', async () => {
+      const mod = await buildModule(null);
+      const svc = mod.get(BedOccupancyService);
+      await expect(svc.assignBed({ bedId: 'b1', patientId: 'p1' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('releaseBed', () => {
+    it('releases an occupied bed to cleaning status', async () => {
+      const mod = await buildModule(makeBed({ status: BedStatus.OCCUPIED, patientId: 'p1' }));
+      const svc = mod.get(BedOccupancyService);
+      const result = await svc.releaseBed('b1');
+      expect(result.status).toBe(BedStatus.CLEANING);
+      expect(result.patientId).toBeNull();
+    });
+
+    it('throws BadRequestException when bed is not occupied', async () => {
+      const mod = await buildModule(makeBed({ status: BedStatus.AVAILABLE }));
+      const svc = mod.get(BedOccupancyService);
+      await expect(svc.releaseBed('b1')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getOccupancySummary', () => {
+    it('returns status counts and total', async () => {
+      const mod = await buildModule();
+      const svc = mod.get(BedOccupancyService);
+      const summary = await svc.getOccupancySummary();
+      expect(summary[BedStatus.AVAILABLE]).toBe(5);
+      expect(summary[BedStatus.OCCUPIED]).toBe(3);
+      expect(summary.total).toBe(8);
+    });
+  });
+});

--- a/src/bed-occupancy/bed-occupancy.service.ts
+++ b/src/bed-occupancy/bed-occupancy.service.ts
@@ -1,0 +1,134 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Bed } from './entities/bed.entity';
+import { Room } from './entities/room.entity';
+import { Ward } from './entities/ward.entity';
+import { BedStatus } from './bed-status.enum';
+import {
+  AssignBedDto,
+  BedOccupancyQueryDto,
+  CreateBedDto,
+  CreateRoomDto,
+  CreateWardDto,
+  UpdateBedStatusDto,
+} from './dto/bed-occupancy.dto';
+
+@Injectable()
+export class BedOccupancyService {
+  constructor(
+    @InjectRepository(Bed) private readonly bedRepo: Repository<Bed>,
+    @InjectRepository(Room) private readonly roomRepo: Repository<Room>,
+    @InjectRepository(Ward) private readonly wardRepo: Repository<Ward>,
+  ) {}
+
+  // ── Wards ─────────────────────────────────────────────────────────────────
+
+  async createWard(dto: CreateWardDto): Promise<Ward> {
+    return this.wardRepo.save(this.wardRepo.create(dto));
+  }
+
+  async getWards(): Promise<Ward[]> {
+    return this.wardRepo.find({ where: { isActive: true } });
+  }
+
+  // ── Rooms ─────────────────────────────────────────────────────────────────
+
+  async createRoom(dto: CreateRoomDto): Promise<Room> {
+    await this.findWard(dto.wardId);
+    return this.roomRepo.save(this.roomRepo.create(dto));
+  }
+
+  async getRoomsByWard(wardId: string): Promise<Room[]> {
+    return this.roomRepo.find({ where: { wardId, isActive: true } });
+  }
+
+  // ── Beds ──────────────────────────────────────────────────────────────────
+
+  async createBed(dto: CreateBedDto): Promise<Bed> {
+    await this.findRoom(dto.roomId);
+    return this.bedRepo.save(this.bedRepo.create(dto));
+  }
+
+  async getBeds(query: BedOccupancyQueryDto): Promise<Bed[]> {
+    const where: Partial<Bed> = {};
+    if (query.roomId) where.roomId = query.roomId;
+    if (query.status) where.status = query.status;
+    if (query.activeOnly !== false) where.isActive = true;
+    return this.bedRepo.find({ where });
+  }
+
+  async getBedById(id: string): Promise<Bed> {
+    const bed = await this.bedRepo.findOne({ where: { id } });
+    if (!bed) throw new NotFoundException(`Bed ${id} not found`);
+    return bed;
+  }
+
+  async assignBed(dto: AssignBedDto): Promise<Bed> {
+    const bed = await this.getBedById(dto.bedId);
+    if (bed.status !== BedStatus.AVAILABLE) {
+      throw new BadRequestException(`Bed ${dto.bedId} is not available`);
+    }
+    bed.patientId = dto.patientId;
+    bed.status = BedStatus.OCCUPIED;
+    bed.assignedAt = new Date();
+    return this.bedRepo.save(bed);
+  }
+
+  async releaseBed(bedId: string): Promise<Bed> {
+    const bed = await this.getBedById(bedId);
+    if (bed.status !== BedStatus.OCCUPIED) {
+      throw new BadRequestException(`Bed ${bedId} is not currently occupied`);
+    }
+    bed.patientId = null;
+    bed.status = BedStatus.CLEANING;
+    bed.assignedAt = null;
+    return this.bedRepo.save(bed);
+  }
+
+  async updateBedStatus(bedId: string, dto: UpdateBedStatusDto): Promise<Bed> {
+    const bed = await this.getBedById(bedId);
+    bed.status = dto.status;
+    return this.bedRepo.save(bed);
+  }
+
+  async getOccupancySummary(wardId?: string): Promise<Record<BedStatus, number> & { total: number }> {
+    const qb = this.bedRepo.createQueryBuilder('bed')
+      .select('bed.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .where('bed.isActive = true');
+
+    if (wardId) {
+      qb.innerJoin(Room, 'room', 'room.id = bed.roomId AND room.wardId = :wardId', { wardId });
+    }
+
+    const rows: Array<{ status: BedStatus; count: string }> = await qb
+      .groupBy('bed.status')
+      .getRawMany();
+
+    const summary: Record<string, number> = { total: 0 };
+    for (const { status, count } of rows) {
+      summary[status] = Number(count);
+      summary['total'] += Number(count);
+    }
+    return summary as Record<BedStatus, number> & { total: number };
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private async findWard(id: string): Promise<Ward> {
+    const ward = await this.wardRepo.findOne({ where: { id } });
+    if (!ward) throw new NotFoundException(`Ward ${id} not found`);
+    return ward;
+  }
+
+  private async findRoom(id: string): Promise<Room> {
+    const room = await this.roomRepo.findOne({ where: { id } });
+    if (!room) throw new NotFoundException(`Room ${id} not found`);
+    return room;
+  }
+}

--- a/src/bed-occupancy/bed-status.enum.ts
+++ b/src/bed-occupancy/bed-status.enum.ts
@@ -1,0 +1,7 @@
+export enum BedStatus {
+  AVAILABLE = 'available',
+  OCCUPIED = 'occupied',
+  RESERVED = 'reserved',
+  MAINTENANCE = 'maintenance',
+  CLEANING = 'cleaning',
+}

--- a/src/bed-occupancy/dto/bed-occupancy.dto.ts
+++ b/src/bed-occupancy/dto/bed-occupancy.dto.ts
@@ -1,0 +1,70 @@
+import {
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUUID,
+  IsArray,
+  IsBoolean,
+} from 'class-validator';
+import { BedStatus } from '../bed-status.enum';
+
+export class AssignBedDto {
+  @IsUUID()
+  bedId: string;
+
+  @IsUUID()
+  patientId: string;
+}
+
+export class UpdateBedStatusDto {
+  @IsEnum(BedStatus)
+  status: BedStatus;
+}
+
+export class CreateBedDto {
+  @IsString()
+  bedNumber: string;
+
+  @IsUUID()
+  roomId: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  features?: string[];
+}
+
+export class CreateRoomDto {
+  @IsUUID()
+  wardId: string;
+
+  @IsString()
+  roomNumber: string;
+}
+
+export class CreateWardDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsUUID()
+  wardManagerId?: string;
+}
+
+export class BedOccupancyQueryDto {
+  @IsOptional()
+  @IsUUID()
+  wardId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  roomId?: string;
+
+  @IsOptional()
+  @IsEnum(BedStatus)
+  status?: BedStatus;
+
+  @IsOptional()
+  @IsBoolean()
+  activeOnly?: boolean;
+}

--- a/src/bed-occupancy/entities/bed.entity.ts
+++ b/src/bed-occupancy/entities/bed.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { BedStatus } from '../bed-status.enum';
+
+@Entity('beds')
+export class Bed {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  bedNumber: string;
+
+  @Column({ type: 'enum', enum: BedStatus, default: BedStatus.AVAILABLE })
+  status: BedStatus;
+
+  @Column()
+  roomId: string;
+
+  @Column({ nullable: true })
+  patientId: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  assignedAt: Date;
+
+  @Column('text', { array: true, nullable: true })
+  features: string[];
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/bed-occupancy/entities/room.entity.ts
+++ b/src/bed-occupancy/entities/room.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('rooms')
+export class Room {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  wardId: string;
+
+  @Column()
+  roomNumber: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+}

--- a/src/bed-occupancy/entities/ward.entity.ts
+++ b/src/bed-occupancy/entities/ward.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('wards')
+export class Ward {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  wardManagerId: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+}

--- a/src/migrations/1776300000000-CreateBedOccupancyTables.ts
+++ b/src/migrations/1776300000000-CreateBedOccupancyTables.ts
@@ -1,0 +1,70 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateBedOccupancyTables1776300000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "wards" (
+        "id"            UUID          NOT NULL DEFAULT gen_random_uuid(),
+        "name"          VARCHAR       NOT NULL,
+        "wardManagerId" UUID,
+        "isActive"      BOOLEAN       NOT NULL DEFAULT true,
+        CONSTRAINT "PK_wards" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "rooms" (
+        "id"         UUID    NOT NULL DEFAULT gen_random_uuid(),
+        "wardId"     UUID    NOT NULL,
+        "roomNumber" VARCHAR NOT NULL,
+        "isActive"   BOOLEAN NOT NULL DEFAULT true,
+        CONSTRAINT "PK_rooms" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_rooms_ward" FOREIGN KEY ("wardId")
+          REFERENCES "wards" ("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE IF NOT EXISTS "bed_status_enum"
+        AS ENUM ('available', 'occupied', 'reserved', 'maintenance', 'cleaning')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "beds" (
+        "id"          UUID              NOT NULL DEFAULT gen_random_uuid(),
+        "bedNumber"   VARCHAR           NOT NULL,
+        "status"      "bed_status_enum" NOT NULL DEFAULT 'available',
+        "roomId"      UUID              NOT NULL,
+        "patientId"   UUID,
+        "assignedAt"  TIMESTAMP,
+        "features"    TEXT[],
+        "isActive"    BOOLEAN           NOT NULL DEFAULT true,
+        "createdAt"   TIMESTAMP         NOT NULL DEFAULT now(),
+        "updatedAt"   TIMESTAMP         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_beds" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_beds_room" FOREIGN KEY ("roomId")
+          REFERENCES "rooms" ("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_beds_roomId" ON "beds" ("roomId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_beds_status" ON "beds" ("status")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_beds_patientId" ON "beds" ("patientId") WHERE "patientId" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_beds_patientId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_beds_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_beds_roomId"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "beds"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "bed_status_enum"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "rooms"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "wards"`);
+  }
+}


### PR DESCRIPTION
closes #668 

## Summary
- add a bed occupancy module with ward, room, and bed entities
- expose CRUD-style service and controller endpoints for occupancy management
- add a database migration for the new occupancy tables
- register the module in the application

## Testing
- pnpm exec jest src/bed-occupancy/bed-occupancy.service.spec.ts --runInBand