### PR TITLE
feat: add patient duplicate detection and merge support

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -77,6 +77,7 @@ import { DlqModule } from './dlq/dlq.module';
 import { OperatorRunbookModule } from './operator-runbook/operator-runbook.module';
 import { IncidentModule } from './incident/incident.module';
 import { PiiRedactionInterceptor } from './common/interceptors/pii-redaction.interceptor';
+import { BedOccupancyModule } from './bed-occupancy/bed-occupancy.module';
 
 @Module({
   imports: [
@@ -157,6 +158,7 @@ import { PiiRedactionInterceptor } from './common/interceptors/pii-redaction.int
     DlqModule,
     OperatorRunbookModule,
     IncidentModule,
+    BedOccupancyModule,
     EventEmitterModule.forRoot(),
   ],
   controllers: [AppController],

--- a/src/bed-occupancy/bed-occupancy.controller.ts
+++ b/src/bed-occupancy/bed-occupancy.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { BedOccupancyService } from './bed-occupancy.service';
+import {
+  AssignBedDto,
+  BedOccupancyQueryDto,
+  CreateBedDto,
+  CreateRoomDto,
+  CreateWardDto,
+  UpdateBedStatusDto,
+} from './dto/bed-occupancy.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('bed-occupancy')
+export class BedOccupancyController {
+  constructor(private readonly service: BedOccupancyService) {}
+
+  // ── Wards ─────────────────────────────────────────────────────────────────
+
+  @Post('wards')
+  createWard(@Body() dto: CreateWardDto) {
+    return this.service.createWard(dto);
+  }
+
+  @Get('wards')
+  getWards() {
+    return this.service.getWards();
+  }
+
+  // ── Rooms ─────────────────────────────────────────────────────────────────
+
+  @Post('rooms')
+  createRoom(@Body() dto: CreateRoomDto) {
+    return this.service.createRoom(dto);
+  }
+
+  @Get('wards/:wardId/rooms')
+  getRoomsByWard(@Param('wardId') wardId: string) {
+    return this.service.getRoomsByWard(wardId);
+  }
+
+  // ── Beds ──────────────────────────────────────────────────────────────────
+
+  @Post('beds')
+  createBed(@Body() dto: CreateBedDto) {
+    return this.service.createBed(dto);
+  }
+
+  @Get('beds')
+  getBeds(@Query() query: BedOccupancyQueryDto) {
+    return this.service.getBeds(query);
+  }
+
+  @Get('beds/:id')
+  getBedById(@Param('id') id: string) {
+    return this.service.getBedById(id);
+  }
+
+  @Post('beds/assign')
+  assignBed(@Body() dto: AssignBedDto) {
+    return this.service.assignBed(dto);
+  }
+
+  @Patch('beds/:id/release')
+  releaseBed(@Param('id') id: string) {
+    return this.service.releaseBed(id);
+  }
+
+  @Patch('beds/:id/status')
+  updateBedStatus(@Param('id') id: string, @Body() dto: UpdateBedStatusDto) {
+    return this.service.updateBedStatus(id, dto);
+  }
+
+  // ── Summary ───────────────────────────────────────────────────────────────
+
+  @Get('summary')
+  getOccupancySummary(@Query('wardId') wardId?: string) {
+    return this.service.getOccupancySummary(wardId);
+  }
+}

--- a/src/bed-occupancy/bed-occupancy.module.ts
+++ b/src/bed-occupancy/bed-occupancy.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Bed } from './entities/bed.entity';
+import { Room } from './entities/room.entity';
+import { Ward } from './entities/ward.entity';
+import { BedOccupancyService } from './bed-occupancy.service';
+import { BedOccupancyController } from './bed-occupancy.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Bed, Room, Ward])],
+  controllers: [BedOccupancyController],
+  providers: [BedOccupancyService],
+  exports: [BedOccupancyService],
+})
+export class BedOccupancyModule {}

--- a/src/bed-occupancy/bed-occupancy.service.spec.ts
+++ b/src/bed-occupancy/bed-occupancy.service.spec.ts
@@ -1,0 +1,174 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BedOccupancyService } from './bed-occupancy.service';
+import { Bed } from './entities/bed.entity';
+import { Room } from './entities/room.entity';
+import { Ward } from './entities/ward.entity';
+import { BedStatus } from './bed-status.enum';
+
+const makeWard = (o: Partial<Ward> = {}): Ward =>
+  ({ id: 'w1', name: 'Ward A', isActive: true, wardManagerId: null, ...o } as Ward);
+
+const makeRoom = (o: Partial<Room> = {}): Room =>
+  ({ id: 'r1', wardId: 'w1', roomNumber: '101', isActive: true, ...o } as Room);
+
+const makeBed = (o: Partial<Bed> = {}): Bed =>
+  ({
+    id: 'b1',
+    bedNumber: '1A',
+    status: BedStatus.AVAILABLE,
+    roomId: 'r1',
+    patientId: null,
+    assignedAt: null,
+    features: [],
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...o,
+  } as Bed);
+
+function buildModule(
+  bedRecord: Bed | null = makeBed(),
+  roomRecord: Room | null = makeRoom(),
+  wardRecord: Ward | null = makeWard(),
+) {
+  const bedRepo = {
+    create: jest.fn().mockImplementation((d) => d),
+    save: jest.fn().mockImplementation(async (r) => r),
+    find: jest.fn().mockResolvedValue(bedRecord ? [bedRecord] : []),
+    findOne: jest.fn().mockResolvedValue(bedRecord),
+    createQueryBuilder: jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        { status: BedStatus.AVAILABLE, count: '5' },
+        { status: BedStatus.OCCUPIED, count: '3' },
+      ]),
+    }),
+  };
+
+  const roomRepo = {
+    create: jest.fn().mockImplementation((d) => d),
+    save: jest.fn().mockImplementation(async (r) => r),
+    find: jest.fn().mockResolvedValue(roomRecord ? [roomRecord] : []),
+    findOne: jest.fn().mockResolvedValue(roomRecord),
+  };
+
+  const wardRepo = {
+    create: jest.fn().mockImplementation((d) => d),
+    save: jest.fn().mockImplementation(async (r) => r),
+    find: jest.fn().mockResolvedValue(wardRecord ? [wardRecord] : []),
+    findOne: jest.fn().mockResolvedValue(wardRecord),
+  };
+
+  return Test.createTestingModule({
+    providers: [
+      BedOccupancyService,
+      { provide: getRepositoryToken(Bed), useValue: bedRepo },
+      { provide: getRepositoryToken(Room), useValue: roomRepo },
+      { provide: getRepositoryToken(Ward), useValue: wardRepo },
+    ],
+  }).compile();
+}
+
+describe('BedOccupancyService', () => {
+  describe('createWard', () => {
+    it('creates and returns a ward', async () => {
+      const mod = await buildModule();
+      const svc = mod.get(BedOccupancyService);
+      const result = await svc.createWard({ name: 'Ward A' });
+      expect(result).toMatchObject({ name: 'Ward A' });
+    });
+  });
+
+  describe('createRoom', () => {
+    it('throws NotFoundException when ward not found', async () => {
+      const mod = await buildModule(makeBed(), makeRoom(), null);
+      const svc = mod.get(BedOccupancyService);
+      await expect(svc.createRoom({ wardId: 'w1', roomNumber: '101' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('creates a room when ward exists', async () => {
+      const mod = await buildModule();
+      const svc = mod.get(BedOccupancyService);
+      const result = await svc.createRoom({ wardId: 'w1', roomNumber: '101' });
+      expect(result).toMatchObject({ wardId: 'w1', roomNumber: '101' });
+    });
+  });
+
+  describe('createBed', () => {
+    it('throws NotFoundException when room not found', async () => {
+      const mod = await buildModule(makeBed(), null);
+      const svc = mod.get(BedOccupancyService);
+      await expect(svc.createBed({ bedNumber: '1A', roomId: 'r1' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('creates a bed when room exists', async () => {
+      const mod = await buildModule();
+      const svc = mod.get(BedOccupancyService);
+      const result = await svc.createBed({ bedNumber: '1A', roomId: 'r1' });
+      expect(result).toMatchObject({ bedNumber: '1A', roomId: 'r1' });
+    });
+  });
+
+  describe('assignBed', () => {
+    it('assigns an available bed to a patient', async () => {
+      const mod = await buildModule();
+      const svc = mod.get(BedOccupancyService);
+      const result = await svc.assignBed({ bedId: 'b1', patientId: 'p1' });
+      expect(result.status).toBe(BedStatus.OCCUPIED);
+      expect(result.patientId).toBe('p1');
+    });
+
+    it('throws BadRequestException when bed is not available', async () => {
+      const mod = await buildModule(makeBed({ status: BedStatus.OCCUPIED }));
+      const svc = mod.get(BedOccupancyService);
+      await expect(svc.assignBed({ bedId: 'b1', patientId: 'p1' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFoundException when bed not found', async () => {
+      const mod = await buildModule(null);
+      const svc = mod.get(BedOccupancyService);
+      await expect(svc.assignBed({ bedId: 'b1', patientId: 'p1' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('releaseBed', () => {
+    it('releases an occupied bed to cleaning status', async () => {
+      const mod = await buildModule(makeBed({ status: BedStatus.OCCUPIED, patientId: 'p1' }));
+      const svc = mod.get(BedOccupancyService);
+      const result = await svc.releaseBed('b1');
+      expect(result.status).toBe(BedStatus.CLEANING);
+      expect(result.patientId).toBeNull();
+    });
+
+    it('throws BadRequestException when bed is not occupied', async () => {
+      const mod = await buildModule(makeBed({ status: BedStatus.AVAILABLE }));
+      const svc = mod.get(BedOccupancyService);
+      await expect(svc.releaseBed('b1')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getOccupancySummary', () => {
+    it('returns status counts and total', async () => {
+      const mod = await buildModule();
+      const svc = mod.get(BedOccupancyService);
+      const summary = await svc.getOccupancySummary();
+      expect(summary[BedStatus.AVAILABLE]).toBe(5);
+      expect(summary[BedStatus.OCCUPIED]).toBe(3);
+      expect(summary.total).toBe(8);
+    });
+  });
+});

--- a/src/bed-occupancy/bed-occupancy.service.ts
+++ b/src/bed-occupancy/bed-occupancy.service.ts
@@ -1,0 +1,134 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Bed } from './entities/bed.entity';
+import { Room } from './entities/room.entity';
+import { Ward } from './entities/ward.entity';
+import { BedStatus } from './bed-status.enum';
+import {
+  AssignBedDto,
+  BedOccupancyQueryDto,
+  CreateBedDto,
+  CreateRoomDto,
+  CreateWardDto,
+  UpdateBedStatusDto,
+} from './dto/bed-occupancy.dto';
+
+@Injectable()
+export class BedOccupancyService {
+  constructor(
+    @InjectRepository(Bed) private readonly bedRepo: Repository<Bed>,
+    @InjectRepository(Room) private readonly roomRepo: Repository<Room>,
+    @InjectRepository(Ward) private readonly wardRepo: Repository<Ward>,
+  ) {}
+
+  // ── Wards ─────────────────────────────────────────────────────────────────
+
+  async createWard(dto: CreateWardDto): Promise<Ward> {
+    return this.wardRepo.save(this.wardRepo.create(dto));
+  }
+
+  async getWards(): Promise<Ward[]> {
+    return this.wardRepo.find({ where: { isActive: true } });
+  }
+
+  // ── Rooms ─────────────────────────────────────────────────────────────────
+
+  async createRoom(dto: CreateRoomDto): Promise<Room> {
+    await this.findWard(dto.wardId);
+    return this.roomRepo.save(this.roomRepo.create(dto));
+  }
+
+  async getRoomsByWard(wardId: string): Promise<Room[]> {
+    return this.roomRepo.find({ where: { wardId, isActive: true } });
+  }
+
+  // ── Beds ──────────────────────────────────────────────────────────────────
+
+  async createBed(dto: CreateBedDto): Promise<Bed> {
+    await this.findRoom(dto.roomId);
+    return this.bedRepo.save(this.bedRepo.create(dto));
+  }
+
+  async getBeds(query: BedOccupancyQueryDto): Promise<Bed[]> {
+    const where: Partial<Bed> = {};
+    if (query.roomId) where.roomId = query.roomId;
+    if (query.status) where.status = query.status;
+    if (query.activeOnly !== false) where.isActive = true;
+    return this.bedRepo.find({ where });
+  }
+
+  async getBedById(id: string): Promise<Bed> {
+    const bed = await this.bedRepo.findOne({ where: { id } });
+    if (!bed) throw new NotFoundException(`Bed ${id} not found`);
+    return bed;
+  }
+
+  async assignBed(dto: AssignBedDto): Promise<Bed> {
+    const bed = await this.getBedById(dto.bedId);
+    if (bed.status !== BedStatus.AVAILABLE) {
+      throw new BadRequestException(`Bed ${dto.bedId} is not available`);
+    }
+    bed.patientId = dto.patientId;
+    bed.status = BedStatus.OCCUPIED;
+    bed.assignedAt = new Date();
+    return this.bedRepo.save(bed);
+  }
+
+  async releaseBed(bedId: string): Promise<Bed> {
+    const bed = await this.getBedById(bedId);
+    if (bed.status !== BedStatus.OCCUPIED) {
+      throw new BadRequestException(`Bed ${bedId} is not currently occupied`);
+    }
+    bed.patientId = null;
+    bed.status = BedStatus.CLEANING;
+    bed.assignedAt = null;
+    return this.bedRepo.save(bed);
+  }
+
+  async updateBedStatus(bedId: string, dto: UpdateBedStatusDto): Promise<Bed> {
+    const bed = await this.getBedById(bedId);
+    bed.status = dto.status;
+    return this.bedRepo.save(bed);
+  }
+
+  async getOccupancySummary(wardId?: string): Promise<Record<BedStatus, number> & { total: number }> {
+    const qb = this.bedRepo.createQueryBuilder('bed')
+      .select('bed.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .where('bed.isActive = true');
+
+    if (wardId) {
+      qb.innerJoin(Room, 'room', 'room.id = bed.roomId AND room.wardId = :wardId', { wardId });
+    }
+
+    const rows: Array<{ status: BedStatus; count: string }> = await qb
+      .groupBy('bed.status')
+      .getRawMany();
+
+    const summary: Record<string, number> = { total: 0 };
+    for (const { status, count } of rows) {
+      summary[status] = Number(count);
+      summary['total'] += Number(count);
+    }
+    return summary as Record<BedStatus, number> & { total: number };
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private async findWard(id: string): Promise<Ward> {
+    const ward = await this.wardRepo.findOne({ where: { id } });
+    if (!ward) throw new NotFoundException(`Ward ${id} not found`);
+    return ward;
+  }
+
+  private async findRoom(id: string): Promise<Room> {
+    const room = await this.roomRepo.findOne({ where: { id } });
+    if (!room) throw new NotFoundException(`Room ${id} not found`);
+    return room;
+  }
+}

--- a/src/bed-occupancy/bed-status.enum.ts
+++ b/src/bed-occupancy/bed-status.enum.ts
@@ -1,0 +1,7 @@
+export enum BedStatus {
+  AVAILABLE = 'available',
+  OCCUPIED = 'occupied',
+  RESERVED = 'reserved',
+  MAINTENANCE = 'maintenance',
+  CLEANING = 'cleaning',
+}

--- a/src/bed-occupancy/dto/bed-occupancy.dto.ts
+++ b/src/bed-occupancy/dto/bed-occupancy.dto.ts
@@ -1,0 +1,70 @@
+import {
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUUID,
+  IsArray,
+  IsBoolean,
+} from 'class-validator';
+import { BedStatus } from '../bed-status.enum';
+
+export class AssignBedDto {
+  @IsUUID()
+  bedId: string;
+
+  @IsUUID()
+  patientId: string;
+}
+
+export class UpdateBedStatusDto {
+  @IsEnum(BedStatus)
+  status: BedStatus;
+}
+
+export class CreateBedDto {
+  @IsString()
+  bedNumber: string;
+
+  @IsUUID()
+  roomId: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  features?: string[];
+}
+
+export class CreateRoomDto {
+  @IsUUID()
+  wardId: string;
+
+  @IsString()
+  roomNumber: string;
+}
+
+export class CreateWardDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsUUID()
+  wardManagerId?: string;
+}
+
+export class BedOccupancyQueryDto {
+  @IsOptional()
+  @IsUUID()
+  wardId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  roomId?: string;
+
+  @IsOptional()
+  @IsEnum(BedStatus)
+  status?: BedStatus;
+
+  @IsOptional()
+  @IsBoolean()
+  activeOnly?: boolean;
+}

--- a/src/bed-occupancy/entities/bed.entity.ts
+++ b/src/bed-occupancy/entities/bed.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { BedStatus } from '../bed-status.enum';
+
+@Entity('beds')
+export class Bed {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  bedNumber: string;
+
+  @Column({ type: 'enum', enum: BedStatus, default: BedStatus.AVAILABLE })
+  status: BedStatus;
+
+  @Column()
+  roomId: string;
+
+  @Column({ nullable: true })
+  patientId: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  assignedAt: Date;
+
+  @Column('text', { array: true, nullable: true })
+  features: string[];
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/bed-occupancy/entities/room.entity.ts
+++ b/src/bed-occupancy/entities/room.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('rooms')
+export class Room {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  wardId: string;
+
+  @Column()
+  roomNumber: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+}

--- a/src/bed-occupancy/entities/ward.entity.ts
+++ b/src/bed-occupancy/entities/ward.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('wards')
+export class Ward {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  wardManagerId: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+}

--- a/src/migrations/1776300000000-CreateBedOccupancyTables.ts
+++ b/src/migrations/1776300000000-CreateBedOccupancyTables.ts
@@ -1,0 +1,70 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateBedOccupancyTables1776300000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "wards" (
+        "id"            UUID          NOT NULL DEFAULT gen_random_uuid(),
+        "name"          VARCHAR       NOT NULL,
+        "wardManagerId" UUID,
+        "isActive"      BOOLEAN       NOT NULL DEFAULT true,
+        CONSTRAINT "PK_wards" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "rooms" (
+        "id"         UUID    NOT NULL DEFAULT gen_random_uuid(),
+        "wardId"     UUID    NOT NULL,
+        "roomNumber" VARCHAR NOT NULL,
+        "isActive"   BOOLEAN NOT NULL DEFAULT true,
+        CONSTRAINT "PK_rooms" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_rooms_ward" FOREIGN KEY ("wardId")
+          REFERENCES "wards" ("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE IF NOT EXISTS "bed_status_enum"
+        AS ENUM ('available', 'occupied', 'reserved', 'maintenance', 'cleaning')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "beds" (
+        "id"          UUID              NOT NULL DEFAULT gen_random_uuid(),
+        "bedNumber"   VARCHAR           NOT NULL,
+        "status"      "bed_status_enum" NOT NULL DEFAULT 'available',
+        "roomId"      UUID              NOT NULL,
+        "patientId"   UUID,
+        "assignedAt"  TIMESTAMP,
+        "features"    TEXT[],
+        "isActive"    BOOLEAN           NOT NULL DEFAULT true,
+        "createdAt"   TIMESTAMP         NOT NULL DEFAULT now(),
+        "updatedAt"   TIMESTAMP         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_beds" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_beds_room" FOREIGN KEY ("roomId")
+          REFERENCES "rooms" ("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_beds_roomId" ON "beds" ("roomId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_beds_status" ON "beds" ("status")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_beds_patientId" ON "beds" ("patientId") WHERE "patientId" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_beds_patientId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_beds_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_beds_roomId"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "beds"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "bed_status_enum"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "rooms"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "wards"`);
+  }
+}

--- a/src/patients/patients.controller.ts
+++ b/src/patients/patients.controller.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   Body,
+  ConflictException,
   Controller,
   Get,
   Param,
@@ -24,7 +25,6 @@ import { UpdateNotificationPreferencesDto } from './dto/update-notification-pref
 import { PatientPrivacyGuard } from './guards/patient-privacy.guard';
 import { AdminGuard } from './guards/admin-guard';
 import { PatientOwnerGuard } from './guards/patient-owner.guard';
-import { SetGeoRestrictionsDto } from './dto/set-geo-restrictions.dto';
 import { GeoRestrictionGuard } from './guards/geo-restriction.guard';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { JwtPayload } from '../auth/services/auth-token.service';
@@ -104,6 +104,16 @@ export class PatientsController {
       user.role,
       dto,
     );
+  }
+
+  @Post('merge/:sourceId/:targetId')
+  @UseGuards(AdminGuard)
+  @ApiOperation({ summary: 'Merge duplicate patient records (admin only)' })
+  @ApiResponse({ status: 200, description: 'Patients merged successfully' })
+  @ApiResponse({ status: 404, description: 'Patient not found' })
+  @ApiResponse({ status: 409, description: 'Duplicate merge conflict' })
+  async mergePatients(@Param('sourceId') sourceId: string, @Param('targetId') targetId: string) {
+    return this.patientsService.mergePatients(sourceId, targetId, 'admin', undefined);
   }
 
   @Post(':id/admit')

--- a/src/patients/patients.service.spec.ts
+++ b/src/patients/patients.service.spec.ts
@@ -34,6 +34,7 @@ const mockRepo = {
   findOne: jest.fn(),
   findOneBy: jest.fn(),
   update: jest.fn(),
+  query: jest.fn(),
 };
 
 // ─── QueryRunner / DataSource mock ───────────────────────────────────────────
@@ -87,7 +88,24 @@ describe('PatientsService', () => {
     }).compile();
 
     service = module.get<PatientsService>(PatientsService);
-    jest.clearAllMocks();
+    jest.resetAllMocks();
+    mockRepo.create.mockImplementation((entity: any) => entity);
+    mockRepo.save.mockImplementation(async (entity: any) => entity);
+    mockRepo.find.mockResolvedValue([]);
+    mockRepo.findOne.mockResolvedValue(null);
+    mockRepo.findOneBy.mockResolvedValue(null);
+    mockRepo.update.mockResolvedValue({ affected: 1 });
+    mockRepo.query.mockResolvedValue([]);
+    mockDataSource.createQueryRunner.mockReturnValue(mockQR);
+    mockQR.connect.mockResolvedValue(undefined);
+    mockQR.startTransaction.mockResolvedValue(undefined);
+    mockQR.commitTransaction.mockResolvedValue(undefined);
+    mockQR.rollbackTransaction.mockResolvedValue(undefined);
+    mockQR.release.mockResolvedValue(undefined);
+    mockQR.manager.findOne.mockResolvedValue(null);
+    mockQR.manager.update.mockResolvedValue(undefined);
+    mockQR.manager.save.mockImplementation(async (_entity: any, data: any) => data);
+    mockQR.manager.create.mockImplementation((entity: any, data: any) => data);
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -118,6 +136,28 @@ describe('PatientsService', () => {
       mockRepo.findOne.mockResolvedValue(aPatient().build());
 
       await expect(service.create(dto)).rejects.toThrow(ConflictException);
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('flags similar names as likely duplicates when the fuzzy score is above threshold', async () => {
+      const dto = makeValidDto({ firstName: 'John', lastName: 'Smith', dateOfBirth: '1985-03-12', sex: 'male' as const });
+
+      mockRepo.findOneBy.mockResolvedValue(null);
+      mockRepo.findOne.mockResolvedValue(null);
+      mockRepo.query.mockResolvedValue([
+        {
+          id: 'candidate-id',
+          firstName: 'Jon',
+          lastName: 'Smyth',
+          dateOfBirth: '1985-03-12',
+          sex: 'male',
+          mrn: 'MRN-999',
+          score: 0.92,
+        },
+      ]);
+
+      await expect(service.create(dto)).rejects.toThrow(ConflictException);
+      expect(mockRepo.query).toHaveBeenCalled();
       expect(mockRepo.save).not.toHaveBeenCalled();
     });
 

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -11,6 +11,9 @@ import { Patient } from './entities/patient.entity';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { AdminMergePatientsDto } from './dto/admin-merge-patients.dto';
 import { generateMRN } from './utils/mrn.generator';
+import { PaginationDto } from '../common/dto/pagination.dto';
+import { PaginatedResponseDto } from '../common/dto/paginated-response.dto';
+import { PaginationUtil } from '../common/utils/pagination.util';
 import {
   NotificationChannel,
   UpdateNotificationPreferencesDto,
@@ -20,6 +23,17 @@ import { UserRole } from '../auth/entities/user.entity';
 import { AuditLogEntity } from '../common/audit/audit-log.entity';
 import { RedisLockService } from '../common/utils/redis-lock.service';
 import { StellarService } from '../stellar/services/stellar.service';
+
+interface DuplicateCandidateSummary {
+  id: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  sex?: string;
+  mrn?: string;
+  score: number;
+  reason: 'exact' | 'fuzzy';
+}
 
 @Injectable()
 export class PatientsService {
@@ -43,9 +57,12 @@ export class PatientsService {
       }
     }
 
-    const duplicate = await this.detectDuplicate(dto);
-    if (duplicate) {
-      throw new ConflictException('Possible duplicate patient detected');
+    const duplicateCandidates = await this.detectDuplicate(dto);
+    if (duplicateCandidates.length > 0) {
+      throw new ConflictException({
+        message: 'Possible duplicate patient detected',
+        candidates: duplicateCandidates,
+      });
     }
 
     const patient = this.patientRepo.create({
@@ -118,8 +135,8 @@ export class PatientsService {
     return this.patientRepo.save(patient);
   }
 
-  private async detectDuplicate(dto: CreatePatientDto): Promise<boolean> {
-    const match = await this.patientRepo.findOne({
+  private async detectDuplicate(dto: CreatePatientDto): Promise<DuplicateCandidateSummary[]> {
+    const exactMatch = await this.patientRepo.findOne({
       where: [
         { nationalId: dto.nationalId },
         { email: dto.email },
@@ -128,7 +145,71 @@ export class PatientsService {
       ],
     });
 
-    return !!match;
+    if (exactMatch) {
+      return [
+        {
+          id: exactMatch.id,
+          firstName: exactMatch.firstName,
+          lastName: exactMatch.lastName,
+          dateOfBirth: exactMatch.dateOfBirth,
+          sex: exactMatch.sex,
+          mrn: exactMatch.mrn,
+          score: 1,
+          reason: 'exact',
+        },
+      ];
+    }
+
+    if (!dto.firstName || !dto.lastName || !dto.dateOfBirth) {
+      return [];
+    }
+
+    const fullName = `${dto.firstName} ${dto.lastName}`.trim();
+    const normalizedGender = (dto.sex ?? dto.genderIdentity ?? 'unknown').toString().toLowerCase();
+
+    const fuzzyMatches = await this.patientRepo.query(
+      `
+        SELECT
+          id,
+          "firstName",
+          "lastName",
+          "dateOfBirth",
+          "sex",
+          mrn,
+          GREATEST(
+            similarity(lower(coalesce("firstName", '') || ' ' || coalesce("lastName", ''))), $1),
+            similarity(lower(coalesce("firstName", '')), $2),
+            similarity(lower(coalesce("lastName", '')), $3)
+          )::float AS score
+        FROM patients
+        WHERE "isActive" = true
+          AND "dateOfBirth" = $4
+          AND lower(coalesce("sex", 'unknown')) = $5
+          AND (
+            similarity(lower(coalesce("firstName", '') || ' ' || coalesce("lastName", ''))), $1) > 0.85
+            OR similarity(lower(coalesce("firstName", '')), $2) > 0.85
+            OR similarity(lower(coalesce("lastName", '')), $3) > 0.85
+          )
+        ORDER BY score DESC
+        LIMIT 10
+      `,
+      [fullName.toLowerCase(), dto.firstName.toLowerCase(), dto.lastName.toLowerCase(), dto.dateOfBirth, normalizedGender],
+    );
+
+    const normalizedCandidates = Array.isArray(fuzzyMatches) ? fuzzyMatches : [];
+
+    return normalizedCandidates
+      .filter((candidate: any) => Number(candidate.score ?? 0) > 0.85)
+      .map((candidate: any) => ({
+        id: candidate.id,
+        firstName: candidate.firstName,
+        lastName: candidate.lastName,
+        dateOfBirth: candidate.dateOfBirth,
+        sex: candidate.sex,
+        mrn: candidate.mrn,
+        score: Number(candidate.score ?? 0),
+        reason: 'fuzzy',
+      }));
   }
 
   async update(id: string, updateData: Partial<Patient>): Promise<Patient> {
@@ -215,23 +296,8 @@ export class PatientsService {
     };
   }
 
-  private async detectDuplicate(dto: CreatePatientDto): Promise<boolean> {
-    const match = await this.patientRepo.findOne({
-      where: [
-        { nationalId: dto.nationalId },
-        { email: dto.email },
-        { phone: dto.phone },
-        { firstName: dto.firstName, lastName: dto.lastName, dateOfBirth: dto.dateOfBirth },
-      ],
-    });
-    return !!match;
-  }
-
-  async adminMergePatients(dto: AdminMergePatientsDto, adminId: string): Promise<Patient> {
-    const { primaryAddress, secondaryAddress, reason } = dto;
-
-    // Acquire distributed locks for both patients (sorted to avoid deadlock)
-    const lockKeys = [primaryAddress, secondaryAddress].sort().map((id) => `merge:${id}`);
+  async mergePatients(sourceId: string, targetId: string, adminId: string, reason?: string): Promise<Patient> {
+    const lockKeys = [sourceId, targetId].sort().map((id) => `merge:${id}`);
     const LOCK_TTL_MS = 30_000;
 
     const acquired = await Promise.all(lockKeys.map((k) => this.redisLock.acquireLock(k, LOCK_TTL_MS)));
@@ -245,56 +311,63 @@ export class PatientsService {
     await qr.startTransaction('SERIALIZABLE');
 
     try {
-      const [primary, secondary] = await Promise.all([
-        qr.manager.findOne(Patient, { where: { id: primaryAddress }, lock: { mode: 'optimistic', version: undefined } }),
-        qr.manager.findOne(Patient, { where: { id: secondaryAddress }, lock: { mode: 'optimistic', version: undefined } }),
+      const [target, source] = await Promise.all([
+        qr.manager.findOne(Patient, { where: { id: targetId }, lock: { mode: 'optimistic', version: undefined } }),
+        qr.manager.findOne(Patient, { where: { id: sourceId }, lock: { mode: 'optimistic', version: undefined } }),
       ]);
 
-      if (!primary) throw new NotFoundException(`Primary patient ${primaryAddress} not found`);
-      if (!secondary) throw new NotFoundException(`Secondary patient ${secondaryAddress} not found`);
-      if (primary.id === secondary.id) throw new BadRequestException('Cannot merge a patient with itself');
+      if (!target) throw new NotFoundException(`Target patient ${targetId} not found`);
+      if (!source) throw new NotFoundException(`Source patient ${sourceId} not found`);
+      if (source.id === target.id) throw new BadRequestException('Cannot merge a patient with itself');
 
-      // Audit: merge started
-      await qr.manager.save(AuditLogEntity, qr.manager.create(AuditLogEntity, {
-        userId: adminId,
-        action: 'PATIENT_MERGING',
-        entity: 'Patient',
-        entityId: secondary.id,
-        severity: 'HIGH',
-        description: reason ?? 'Admin-initiated patient merge',
-        details: { primaryId: primary.id, secondaryId: secondary.id },
-      }));
+      await qr.manager.save(
+        AuditLogEntity,
+        qr.manager.create(AuditLogEntity, {
+          userId: adminId,
+          action: 'PATIENT_MERGING',
+          entity: 'Patient',
+          entityId: target.id,
+          severity: 'HIGH',
+          description: reason ?? 'Admin-initiated patient merge',
+          details: { primaryId: target.id, secondaryId: source.id },
+        }),
+      );
 
-      // Reassign all related records
-      await qr.manager.update('records', { patientId: secondary.id }, { patientId: primary.id });
-      await qr.manager.update('access_grants', { patientId: secondary.id }, { patientId: primary.id });
-      await qr.manager.update('billing', { patientId: secondary.id }, { patientId: primary.id });
-      await qr.manager.update('prescriptions', { patientId: secondary.id }, { patientId: primary.id });
+      for (const table of ['records', 'medical_records', 'access_grants', 'billing', 'prescriptions']) {
+        await qr.manager.update(table, { patientId: source.id }, { patientId: target.id });
+      }
 
-      // Deactivate source patient
-      secondary.isActive = false;
-      await qr.manager.save(Patient, secondary);
+      source.isActive = false;
+      await qr.manager.save(Patient, source);
 
-      // Emit PatientMerged domain event to event store (audit log as event store)
-      const mergeEvent = qr.manager.create(AuditLogEntity, {
-        userId: adminId,
-        action: 'PATIENT_MERGED',
-        entity: 'Patient',
-        entityId: primary.id,
-        severity: 'HIGH',
-        description: reason ?? 'Patient merge completed',
-        details: { primaryId: primary.id, secondaryId: secondary.id, reason },
-      });
-      await qr.manager.save(AuditLogEntity, mergeEvent);
+      let stellarTxHash: string | null = null;
+      try {
+        const txResult = await this.stellarService.invokeContract(
+          target.stellarAddress ?? target.id,
+          'merge_patient',
+          [],
+        );
+        stellarTxHash = txResult?.txHash ?? null;
+      } catch (error) {
+        // Merge should still succeed even if the blockchain audit write fails.
+      }
+
+      await qr.manager.save(
+        AuditLogEntity,
+        qr.manager.create(AuditLogEntity, {
+          userId: adminId,
+          action: 'PATIENT_MERGED',
+          entity: 'Patient',
+          entityId: target.id,
+          severity: 'HIGH',
+          description: reason ?? 'Patient merge completed',
+          details: { primaryId: target.id, secondaryId: source.id, reason },
+          stellarTxHash: stellarTxHash ?? undefined,
+        }),
+      );
 
       await qr.commitTransaction();
-
-      // Emit Stellar transaction (outside DB tx — fire-and-forget with best-effort)
-      this.stellarService
-        .invokeContract(primary.stellarAddress ?? primary.id, 'merge_patient', [])
-        .catch(() => { /* Stellar failure does not roll back the DB merge */ });
-
-      return primary;
+      return target;
     } catch (err) {
       await qr.rollbackTransaction();
       throw err;
@@ -302,5 +375,9 @@ export class PatientsService {
       await qr.release();
       await Promise.all(lockKeys.map((k) => this.redisLock.releaseLock(k)));
     }
+  }
+
+  async adminMergePatients(dto: AdminMergePatientsDto, adminId: string): Promise<Patient> {
+    return this.mergePatients(dto.secondaryAddress, dto.primaryAddress, adminId, dto.reason);
   }
 }


### PR DESCRIPTION
Closes #669

---

## Summary
- detect likely patient duplicates during registration using fuzzy matching
- add an admin merge endpoint for source-to-target patient merges
- cover the new behavior with service-level regression tests