### PR TITLE
Closes #678feat(stellar-stream): catchup replay with stale cursor warning and tx…

### DIFF
--- a/src/stellar-stream/stellar-stream.service.ts
+++ b/src/stellar-stream/stellar-stream.service.ts
@@ -18,6 +18,9 @@ import { AccessGrant, GrantStatus } from '../access-control/entities/access-gran
 export type StreamStatus = 'connected' | 'reconnecting' | 'failed';
 
 const CURSOR_KEY = 'stellar:stream:cursor';
+const CURSOR_TS_KEY = 'stellar:stream:cursor:savedAt';
+const STALE_CURSOR_MS = 24 * 60 * 60 * 1000; // 24 hours
+const TX_DEDUP_TTL_S = 48 * 60 * 60; // 48-hour dedup window in seconds
 const MAX_BACKOFF_MS = 5 * 60 * 1000; // 5 minutes
 const BASE_BACKOFF_MS = 1_000;
 
@@ -121,6 +124,15 @@ export class StellarStreamService implements OnModuleInit, OnModuleDestroy {
 
   async _handleTransaction(tx: StellarSdk.Horizon.ServerApi.TransactionRecord): Promise<void> {
     try {
+      // Idempotency guard — skip already-processed transactions (e.g. replay after restart)
+      const dedupKey = `stellar:stream:processed:${tx.hash}`;
+      const isNew = await this.redis.set(dedupKey, '1', 'EX', TX_DEDUP_TTL_S, 'NX');
+      if (isNew === null) {
+        this.logger.debug(`[StellarStream] Duplicate tx skipped: ${tx.hash}`);
+        this.eventsCounter.inc({ result: 'skipped' });
+        return;
+      }
+
       // Filter: only process txs involving our contract address
       if (this.contractAddress && !this._involvesContract(tx)) {
         this.eventsCounter.inc({ result: 'skipped' });
@@ -179,8 +191,20 @@ export class StellarStreamService implements OnModuleInit, OnModuleDestroy {
 
   async _getCursor(): Promise<string> {
     try {
-      const val = await this.redis.get(CURSOR_KEY);
-      return val ?? 'now';
+      const [val, savedAt] = await this.redis.mget(CURSOR_KEY, CURSOR_TS_KEY);
+      if (!val) return 'now';
+
+      if (savedAt) {
+        const ageMs = Date.now() - parseInt(savedAt, 10);
+        if (ageMs > STALE_CURSOR_MS) {
+          this.logger.warn(
+            `[StellarStream] Stale cursor detected: last saved ${Math.round(ageMs / 3600_000)}h ago. ` +
+            `Replaying missed events from cursor=${val}. Alert ops if replay volume is large.`,
+          );
+        }
+      }
+
+      return val;
     } catch {
       return 'now';
     }
@@ -188,7 +212,7 @@ export class StellarStreamService implements OnModuleInit, OnModuleDestroy {
 
   async _saveCursor(pagingToken: string): Promise<void> {
     try {
-      await this.redis.set(CURSOR_KEY, pagingToken);
+      await this.redis.mset(CURSOR_KEY, pagingToken, CURSOR_TS_KEY, Date.now().toString());
     } catch {
       // Non-fatal — cursor will reset to 'now' on next restart
     }

--- a/src/stellar-stream/stellar-stream.spec.ts
+++ b/src/stellar-stream/stellar-stream.spec.ts
@@ -212,6 +212,148 @@ describe('StellarStreamService', () => {
     });
   });
 
+  describe('worker restart / catchup replay', () => {
+    it('resumes from stored cursor on restart, not from "now"', async () => {
+      const { service } = await buildService(null, null);
+
+      // Simulate Redis having a stored cursor from before restart
+      const redisMock = (service as any).redis;
+      redisMock.mget = jest.fn().mockResolvedValue(['token-42', String(Date.now() - 1000)]);
+
+      const cursor = await service._getCursor();
+      expect(cursor).toBe('token-42');
+    });
+
+    it('logs a stale cursor warning when cursor is older than 24 hours', async () => {
+      const { service } = await buildService(null, null);
+      const warnSpy = jest.spyOn((service as any).logger, 'warn');
+
+      const staleTs = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
+      const redisMock = (service as any).redis;
+      redisMock.mget = jest.fn().mockResolvedValue(['token-old', String(staleTs)]);
+
+      await service._getCursor();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Stale cursor detected'),
+      );
+    });
+
+    it('does not warn when cursor is fresh (< 24 hours)', async () => {
+      const { service } = await buildService(null, null);
+      const warnSpy = jest.spyOn((service as any).logger, 'warn');
+
+      const freshTs = Date.now() - 60 * 1000; // 1 minute ago
+      const redisMock = (service as any).redis;
+      redisMock.mget = jest.fn().mockResolvedValue(['token-fresh', String(freshTs)]);
+
+      await service._getCursor();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('skips duplicate tx on replay without double-emitting events', async () => {
+      const { service, emitter, counter } = await buildService(makeRecord(), null);
+
+      // Restore real _getCursor/_saveCursor for this test; mock Redis SET NX
+      jest.spyOn(service as any, '_getCursor').mockRestore?.();
+      jest.spyOn(service as any, '_saveCursor').mockRestore?.();
+
+      const redisMock = (service as any).redis;
+      // First call returns 'OK' (new), second returns null (duplicate)
+      redisMock.set = jest.fn()
+        .mockResolvedValueOnce('OK')   // first processing
+        .mockResolvedValue(null);      // replay attempt — duplicate
+
+      const anchored: any[] = [];
+      emitter.on('record.anchored', (e) => anchored.push(e));
+
+      const tx = makeTx({ paging_token: 'tok-1' });
+
+      // First pass: should process and emit
+      await service._handleTransaction(tx as any);
+      expect(anchored).toHaveLength(1);
+
+      // Second pass (replay): should be deduped, no additional emit
+      await service._handleTransaction(tx as any);
+      expect(anchored).toHaveLength(1);
+      expect(counter.inc).toHaveBeenCalledWith({ result: 'skipped' });
+    });
+
+    it('processes all events exactly once across simulated restart', async () => {
+      // Simulate: 3 txs processed before restart, then stream restarts from
+      // cursor of tx-2 and replays tx-2 and tx-3 before receiving tx-4.
+      // Expected: tx-1, tx-2, tx-3 each processed once; tx-4 processed once.
+      const recordFindOne = jest.fn().mockResolvedValue(null);
+      const grantFindOne = jest.fn().mockResolvedValue(null);
+      const counter = { inc: jest.fn() };
+      const emitter = new EventEmitter2();
+
+      const module = await Test.createTestingModule({
+        providers: [
+          StellarStreamService,
+          { provide: getRepositoryToken(Record), useValue: { findOne: recordFindOne } },
+          { provide: getRepositoryToken(AccessGrant), useValue: { findOne: grantFindOne } },
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn().mockImplementation((key: string, def?: any) => {
+                if (key === 'STELLAR_NETWORK') return 'testnet';
+                if (key === 'STELLAR_CONTRACT_ID') return CONTRACT;
+                if (key === 'REDIS_HOST') return 'localhost';
+                if (key === 'REDIS_PORT') return 6379;
+                return def;
+              }),
+            },
+          },
+          { provide: EventEmitter2, useValue: emitter },
+          { provide: 'PROM_METRIC_MEDCHAIN_STELLAR_STREAM_EVENTS_PROCESSED_TOTAL', useValue: counter },
+        ],
+      }).compile();
+
+      const service = module.get(StellarStreamService);
+
+      // In-memory dedup store (mimics Redis SET NX behaviour)
+      const seen = new Set<string>();
+      const redisMock = (service as any).redis;
+      redisMock.set = jest.fn().mockImplementation(
+        (_key: string, _val: string, _ex: string, _ttl: number, flag: string) => {
+          if (flag !== 'NX') return Promise.resolve('OK');
+          const dedupKey = _key;
+          if (seen.has(dedupKey)) return Promise.resolve(null); // duplicate
+          seen.add(dedupKey);
+          return Promise.resolve('OK');
+        },
+      );
+      redisMock.mset = jest.fn().mockResolvedValue('OK');
+      jest.spyOn(service as any, '_getCursor').mockResolvedValue('now');
+      jest.spyOn(service as any, '_saveCursor').mockResolvedValue(undefined);
+
+      const processOrder: string[] = [];
+      counter.inc.mockImplementation(({ result }: { result: string }) => {
+        if (result !== 'skipped') processOrder.push(result);
+      });
+
+      // Pre-restart: process tx-1, tx-2, tx-3
+      for (const token of ['tok-1', 'tok-2', 'tok-3']) {
+        await service._handleTransaction(makeTx({ hash: token, paging_token: token }) as any);
+      }
+
+      // Post-restart replay: tx-2 and tx-3 replayed, then new tx-4
+      for (const token of ['tok-2', 'tok-3', 'tok-4']) {
+        await service._handleTransaction(makeTx({ hash: token, paging_token: token }) as any);
+      }
+
+      // tx-1, tx-2, tx-3, tx-4 each processed exactly once (4 non-skipped increments)
+      expect(processOrder).toHaveLength(4);
+      // Replayed tok-2 and tok-3 were deduped (2 skipped increments)
+      const skippedCalls = (counter.inc as jest.Mock).mock.calls.filter(
+        ([arg]: [{ result: string }]) => arg.result === 'skipped',
+      );
+      expect(skippedCalls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
   describe('health indicator', () => {
     it('reports connected when status is connected', async () => {
       const { service } = await buildService(null, null);


### PR DESCRIPTION
  Closes #678

- Persist cursor savedAt timestamp alongside paging token (CURSOR_TS_KEY) so restart age can be computed without an external clock
- Warn in logs when stored cursor is older than 24 h before starting replay, alerting ops that a large backfill may be in progress
- Deduplicate replayed transactions via Redis SET NX with a 48-hour TTL (stellar:stream:processed:<txHash>) — prevents double-processing of events that were already handled before the worker restarted
- Add 'worker restart mid-stream' test suite:
    - resumes from stored cursor, not 'now'
    - logs stale cursor warning for cursors > 24 h old
    - suppresses warning for fresh cursors
    - skips duplicate tx on replay without double-emitting domain events
    - end-to-end restart simulation: 4 unique txs processed exactly once even when 2 are replayed after reconnect