### PR TITLE
feat(healthcare-monitoring): implement metric alerting system (#757)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -82,6 +82,7 @@ import { IncidentModule } from './incident/incident.module';
 import { PiiRedactionInterceptor } from './common/interceptors/pii-redaction.interceptor';
 import { BedOccupancyModule } from './bed-occupancy/bed-occupancy.module';
 import { MedicalStaffModule } from './medical-staff/medical-staff.module';
+import { HealthcareMonitoringModule } from './healthcare-monitoring/healthcare-monitoring.module';
 
 @Module({
   imports: [
@@ -170,6 +171,7 @@ import { MedicalStaffModule } from './medical-staff/medical-staff.module';
     BedOccupancyModule,
     MedicalStaffModule,
     EhrImportModule,
+    HealthcareMonitoringModule,
     EventEmitterModule.forRoot(),
   ],
   controllers: [AppController],

--- a/src/healthcare-monitoring/controllers/monitoring.controller.ts
+++ b/src/healthcare-monitoring/controllers/monitoring.controller.ts
@@ -1,0 +1,77 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { AlertRuleService } from '../services/alert-rule.service';
+import { ClinicalAlertService } from '../services/clinical-alert.service';
+import { CreateAlertRuleDto } from '../dto/create-alert-rule.dto';
+import { UpdateAlertDto } from '../dto/update-alert.dto';
+import { AlertStatus } from '../entities/clinical-alert.entity';
+
+@ApiTags('monitoring')
+@Controller('monitoring')
+export class MonitoringController {
+  constructor(
+    private readonly alertRuleService: AlertRuleService,
+    private readonly clinicalAlertService: ClinicalAlertService,
+  ) {}
+
+  /** Create a configurable threshold rule for a patient metric. */
+  @Post('alert-rules')
+  @ApiOperation({ summary: 'Create a per-patient metric alert rule' })
+  async createAlertRule(
+    @Body() dto: CreateAlertRuleDto,
+    @Req() req: Request,
+  ) {
+    const user = (req as any).user;
+    const createdBy: string = user?.userId ?? user?.sub ?? 'system';
+    const tenantId: string | undefined = user?.tenantId;
+    return this.alertRuleService.create(dto, createdBy, tenantId);
+  }
+
+  /** List all alert rules, optionally filtered by patient. */
+  @Get('alert-rules')
+  @ApiOperation({ summary: 'List alert rules' })
+  async getAlertRules(
+    @Query('patientId') patientId?: string,
+    @Req() req?: Request,
+  ) {
+    const user = (req as any)?.user;
+    const tenantId: string | undefined = user?.tenantId;
+    return this.alertRuleService.findAll(patientId, tenantId);
+  }
+
+  /**
+   * Transition an alert's lifecycle state.
+   * Accepts status = 'acknowledged' | 'resolved'.
+   */
+  @Patch('alerts/:id')
+  @ApiOperation({ summary: 'Acknowledge or resolve an alert' })
+  async updateAlert(
+    @Param('id') alertId: string,
+    @Body() dto: UpdateAlertDto,
+    @Req() req: Request,
+  ) {
+    const user = (req as any).user;
+    const userId: string = user?.userId ?? user?.sub ?? 'system';
+
+    if (dto.status === AlertStatus.ACKNOWLEDGED) {
+      return this.clinicalAlertService.acknowledgeAlert(alertId, userId);
+    }
+
+    if (dto.status === AlertStatus.RESOLVED) {
+      return this.clinicalAlertService.resolveAlert(alertId, userId, dto.resolutionNotes);
+    }
+
+    throw new BadRequestException(`Unsupported status transition: ${dto.status}`);
+  }
+}

--- a/src/healthcare-monitoring/dto/create-alert-rule.dto.ts
+++ b/src/healthcare-monitoring/dto/create-alert-rule.dto.ts
@@ -1,0 +1,63 @@
+import {
+  IsUUID,
+  IsEnum,
+  IsNumber,
+  IsString,
+  IsOptional,
+  IsBoolean,
+  MaxLength,
+  IsIn,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AlertPriority } from '../entities/clinical-alert.entity';
+import { AlertOperator, VALID_METRIC_NAMES } from '../entities/alert-rule.entity';
+
+export class CreateAlertRuleDto {
+  @ApiProperty({ description: 'Patient UUID this rule applies to' })
+  @IsUUID()
+  patientId: string;
+
+  @ApiProperty({
+    description: 'Vital metric name to monitor',
+    enum: VALID_METRIC_NAMES,
+    example: 'heartRate',
+  })
+  @IsString()
+  @IsIn([...VALID_METRIC_NAMES])
+  metricName: string;
+
+  @ApiProperty({
+    description: 'Comparison operator',
+    enum: AlertOperator,
+    example: AlertOperator.GT,
+  })
+  @IsEnum(AlertOperator)
+  operator: AlertOperator;
+
+  @ApiProperty({ description: 'Threshold value to compare the metric against', example: 120 })
+  @IsNumber()
+  threshold: number;
+
+  @ApiProperty({
+    description: 'Alert priority when this rule fires',
+    enum: AlertPriority,
+    example: AlertPriority.HIGH,
+  })
+  @IsEnum(AlertPriority)
+  priority: AlertPriority;
+
+  @ApiProperty({ description: 'Human-readable rule name', maxLength: 200, example: 'High Heart Rate' })
+  @IsString()
+  @MaxLength(200)
+  name: string;
+
+  @ApiPropertyOptional({ description: 'Optional description of the clinical intent' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ description: 'Whether the rule is active (default: true)', default: true })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/src/healthcare-monitoring/dto/update-alert.dto.ts
+++ b/src/healthcare-monitoring/dto/update-alert.dto.ts
@@ -1,0 +1,20 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AlertStatus } from '../entities/clinical-alert.entity';
+
+const ALLOWED_STATUSES = [AlertStatus.ACKNOWLEDGED, AlertStatus.RESOLVED] as const;
+
+export class UpdateAlertDto {
+  @ApiProperty({
+    description: 'Transition the alert to acknowledged or resolved',
+    enum: ALLOWED_STATUSES,
+    example: AlertStatus.ACKNOWLEDGED,
+  })
+  @IsEnum(AlertStatus)
+  status: AlertStatus.ACKNOWLEDGED | AlertStatus.RESOLVED;
+
+  @ApiPropertyOptional({ description: 'Resolution notes, recommended when resolving' })
+  @IsOptional()
+  @IsString()
+  resolutionNotes?: string;
+}

--- a/src/healthcare-monitoring/entities/alert-rule.entity.ts
+++ b/src/healthcare-monitoring/entities/alert-rule.entity.ts
@@ -1,0 +1,83 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { AlertPriority } from './clinical-alert.entity';
+
+export enum AlertOperator {
+  GT = 'gt',
+  GTE = 'gte',
+  LT = 'lt',
+  LTE = 'lte',
+  EQ = 'eq',
+}
+
+export const VALID_METRIC_NAMES = [
+  'heartRate',
+  'systolicBp',
+  'diastolicBp',
+  'oxygenSaturation',
+  'temperature',
+  'respiratoryRate',
+  'bloodGlucose',
+] as const;
+
+export type MetricName = (typeof VALID_METRIC_NAMES)[number];
+
+@Entity('alert_rules')
+@Index(['patientId', 'isActive'])
+@Index(['tenantId', 'isActive'])
+export class AlertRule {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  @Index()
+  patientId: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  tenantId: string;
+
+  /** Vital metric field name, e.g. 'heartRate' */
+  @Column({ length: 50 })
+  metricName: string;
+
+  @Column({
+    type: 'enum',
+    enum: AlertOperator,
+  })
+  operator: AlertOperator;
+
+  /** Value the metric is compared against */
+  @Column({ type: 'decimal', precision: 10, scale: 4 })
+  threshold: number;
+
+  @Column({
+    type: 'enum',
+    enum: AlertPriority,
+    default: AlertPriority.HIGH,
+  })
+  priority: AlertPriority;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @Column({ length: 200 })
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column('uuid')
+  createdBy: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/healthcare-monitoring/healthcare-monitoring.module.ts
+++ b/src/healthcare-monitoring/healthcare-monitoring.module.ts
@@ -7,6 +7,7 @@ import { HealthcareMonitoringController } from './controllers/healthcare-monitor
 import { ClinicalAlertsController } from './controllers/clinical-alerts.controller';
 import { DashboardController } from './controllers/dashboard.controller';
 import { ComplianceController } from './controllers/compliance.controller';
+import { MonitoringController } from './controllers/monitoring.controller';
 
 // Services
 import { SystemHealthService } from './services/system-health.service';
@@ -17,6 +18,7 @@ import { IncidentTrackingService } from './services/incident-tracking.service';
 import { DashboardService } from './services/dashboard.service';
 import { NotificationService } from './services/notification.service';
 import { VitalsService } from './services/vitals.service';
+import { AlertRuleService } from './services/alert-rule.service';
 
 // Gateway
 import { VitalsGateway } from './vitals.gateway';
@@ -28,10 +30,12 @@ import { EquipmentStatus } from './entities/equipment-status.entity';
 import { ComplianceCheck } from './entities/compliance-check.entity';
 import { HealthcareIncident } from './entities/healthcare-incident.entity';
 import { PatientVital } from './entities/patient-vital.entity';
+import { AlertRule } from './entities/alert-rule.entity';
 
 // WS middleware/guard deps
 import { WsJwtMiddleware } from '../notifications/middleware/ws-jwt.middleware';
 import { AuthModule } from '../auth/auth.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
@@ -42,15 +46,18 @@ import { AuthModule } from '../auth/auth.module';
       ComplianceCheck,
       HealthcareIncident,
       PatientVital,
+      AlertRule,
     ]),
     ScheduleModule.forRoot(),
     AuthModule,
+    NotificationsModule,
   ],
   controllers: [
     HealthcareMonitoringController,
     ClinicalAlertsController,
     DashboardController,
     ComplianceController,
+    MonitoringController,
   ],
   providers: [
     SystemHealthService,
@@ -61,6 +68,7 @@ import { AuthModule } from '../auth/auth.module';
     DashboardService,
     NotificationService,
     VitalsService,
+    AlertRuleService,
     VitalsGateway,
     WsJwtMiddleware,
   ],
@@ -72,6 +80,7 @@ import { AuthModule } from '../auth/auth.module';
     IncidentTrackingService,
     VitalsService,
     VitalsGateway,
+    AlertRuleService,
   ],
 })
 export class HealthcareMonitoringModule {}

--- a/src/healthcare-monitoring/services/alert-rule.service.spec.ts
+++ b/src/healthcare-monitoring/services/alert-rule.service.spec.ts
@@ -1,0 +1,344 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AlertRuleService } from './alert-rule.service';
+import { AlertRule, AlertOperator } from '../entities/alert-rule.entity';
+import { ClinicalAlertService } from './clinical-alert.service';
+import { AlertPriority, AlertStatus, AlertType, ClinicalAlert } from '../entities/clinical-alert.entity';
+import { PatientVital } from '../entities/patient-vital.entity';
+import { CreateAlertRuleDto } from '../dto/create-alert-rule.dto';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const patientId = 'patient-uuid-001';
+const tenantId = 'tenant-uuid-001';
+const createdBy = 'clinician-uuid-001';
+
+function makeRule(overrides: Partial<AlertRule> = {}): AlertRule {
+  return {
+    id: 'rule-uuid-001',
+    patientId,
+    tenantId,
+    metricName: 'heartRate',
+    operator: AlertOperator.GT,
+    threshold: 120,
+    priority: AlertPriority.HIGH,
+    isActive: true,
+    name: 'High Heart Rate',
+    description: null,
+    createdBy,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as AlertRule;
+}
+
+function makeVital(overrides: Partial<PatientVital> = {}): PatientVital {
+  return {
+    id: 'vital-uuid-001',
+    patientId,
+    tenantId,
+    heartRate: 100,
+    systolicBp: 120,
+    diastolicBp: 80,
+    oxygenSaturation: 98,
+    temperature: 37,
+    respiratoryRate: 16,
+    bloodGlucose: 90,
+    recordedBy: createdBy,
+    notes: null,
+    recordedAt: new Date(),
+    ...overrides,
+  } as PatientVital;
+}
+
+function makeAlert(overrides: Partial<ClinicalAlert> = {}): ClinicalAlert {
+  return {
+    id: 'alert-uuid-001',
+    alertType: AlertType.CRITICAL_VITALS,
+    priority: AlertPriority.HIGH,
+    status: AlertStatus.ACTIVE,
+    title: 'High Heart Rate',
+    message: 'Threshold breached',
+    patientId,
+    department: null,
+    room: null,
+    equipmentId: null,
+    assignedTo: null,
+    acknowledgedBy: null,
+    acknowledgedAt: null,
+    resolvedBy: null,
+    resolvedAt: null,
+    resolutionNotes: null,
+    alertData: {},
+    notificationChannels: ['dashboard', 'email'],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as ClinicalAlert;
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────────
+
+describe('AlertRuleService', () => {
+  let service: AlertRuleService;
+  let ruleRepo: {
+    create: jest.Mock;
+    save: jest.Mock;
+    find: jest.Mock;
+  };
+  let clinicalAlertService: { createAlert: jest.Mock };
+
+  beforeEach(async () => {
+    ruleRepo = {
+      create: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+    };
+
+    clinicalAlertService = {
+      createAlert: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AlertRuleService,
+        {
+          provide: getRepositoryToken(AlertRule),
+          useValue: ruleRepo,
+        },
+        {
+          provide: ClinicalAlertService,
+          useValue: clinicalAlertService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AlertRuleService>(AlertRuleService);
+  });
+
+  // ── matches() ──────────────────────────────────────────────────────────────
+
+  describe('matches()', () => {
+    it.each<[AlertOperator, number, number, boolean]>([
+      // GT
+      [AlertOperator.GT,  130, 120, true],
+      [AlertOperator.GT,  120, 120, false],
+      [AlertOperator.GT,  110, 120, false],
+      // GTE
+      [AlertOperator.GTE, 120, 120, true],
+      [AlertOperator.GTE, 121, 120, true],
+      [AlertOperator.GTE, 119, 120, false],
+      // LT
+      [AlertOperator.LT,  50, 60, true],
+      [AlertOperator.LT,  60, 60, false],
+      [AlertOperator.LT,  70, 60, false],
+      // LTE
+      [AlertOperator.LTE, 60, 60, true],
+      [AlertOperator.LTE, 59, 60, true],
+      [AlertOperator.LTE, 61, 60, false],
+      // EQ
+      [AlertOperator.EQ,  37, 37, true],
+      [AlertOperator.EQ,  37, 36, false],
+    ])('operator=%s value=%d threshold=%d → %s', (op, value, threshold, expected) => {
+      expect(service.matches(value, op, threshold)).toBe(expected);
+    });
+  });
+
+  // ── create() ──────────────────────────────────────────────────────────────
+
+  describe('create()', () => {
+    it('persists a new rule and returns it', async () => {
+      const dto: CreateAlertRuleDto = {
+        patientId,
+        metricName: 'heartRate',
+        operator: AlertOperator.GT,
+        threshold: 120,
+        priority: AlertPriority.HIGH,
+        name: 'High Heart Rate',
+      };
+
+      const created = makeRule();
+      ruleRepo.create.mockReturnValue(created);
+      ruleRepo.save.mockResolvedValue(created);
+
+      const result = await service.create(dto, createdBy, tenantId);
+
+      expect(ruleRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          patientId,
+          metricName: 'heartRate',
+          operator: AlertOperator.GT,
+          threshold: 120,
+          priority: AlertPriority.HIGH,
+          name: 'High Heart Rate',
+          isActive: true,
+          createdBy,
+          tenantId,
+        }),
+      );
+      expect(ruleRepo.save).toHaveBeenCalledWith(created);
+      expect(result).toBe(created);
+    });
+
+    it('defaults isActive to true when not provided', async () => {
+      const dto: CreateAlertRuleDto = {
+        patientId,
+        metricName: 'heartRate',
+        operator: AlertOperator.GT,
+        threshold: 120,
+        priority: AlertPriority.HIGH,
+        name: 'Test Rule',
+      };
+
+      const created = makeRule();
+      ruleRepo.create.mockReturnValue(created);
+      ruleRepo.save.mockResolvedValue(created);
+
+      await service.create(dto, createdBy);
+
+      expect(ruleRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ isActive: true }),
+      );
+    });
+  });
+
+  // ── findAll() ─────────────────────────────────────────────────────────────
+
+  describe('findAll()', () => {
+    it('returns all rules without filter', async () => {
+      const rules = [makeRule()];
+      ruleRepo.find.mockResolvedValue(rules);
+
+      const result = await service.findAll();
+
+      expect(ruleRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: {}, order: { createdAt: 'DESC' } }),
+      );
+      expect(result).toBe(rules);
+    });
+
+    it('filters by patientId and tenantId when provided', async () => {
+      ruleRepo.find.mockResolvedValue([]);
+
+      await service.findAll(patientId, tenantId);
+
+      expect(ruleRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { patientId, tenantId },
+        }),
+      );
+    });
+  });
+
+  // ── evaluateVitals() ──────────────────────────────────────────────────────
+
+  describe('evaluateVitals()', () => {
+    it('returns an empty array when no rules exist for the patient', async () => {
+      ruleRepo.find.mockResolvedValue([]);
+
+      const result = await service.evaluateVitals(makeVital());
+
+      expect(result).toEqual([]);
+      expect(clinicalAlertService.createAlert).not.toHaveBeenCalled();
+    });
+
+    it('fires an alert when a rule matches', async () => {
+      const rule = makeRule({ operator: AlertOperator.GT, threshold: 120 });
+      ruleRepo.find.mockResolvedValue([rule]);
+
+      const alert = makeAlert();
+      clinicalAlertService.createAlert.mockResolvedValue(alert);
+
+      // heartRate=130 > threshold=120 → should trigger
+      const vital = makeVital({ heartRate: 130 });
+      const result = await service.evaluateVitals(vital, tenantId);
+
+      expect(clinicalAlertService.createAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          alertType: AlertType.CRITICAL_VITALS,
+          priority: AlertPriority.HIGH,
+          patientId,
+          alertData: expect.objectContaining({
+            ruleId: rule.id,
+            metricName: 'heartRate',
+            value: 130,
+          }),
+        }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(alert);
+    });
+
+    it('does not fire an alert when no rule matches', async () => {
+      const rule = makeRule({ operator: AlertOperator.GT, threshold: 120 });
+      ruleRepo.find.mockResolvedValue([rule]);
+
+      // heartRate=100 ≤ threshold=120 → no breach
+      const vital = makeVital({ heartRate: 100 });
+      const result = await service.evaluateVitals(vital, tenantId);
+
+      expect(clinicalAlertService.createAlert).not.toHaveBeenCalled();
+      expect(result).toHaveLength(0);
+    });
+
+    it('skips a rule when the metric field is null on the vital', async () => {
+      const rule = makeRule({ metricName: 'bloodGlucose', operator: AlertOperator.GT, threshold: 200 });
+      ruleRepo.find.mockResolvedValue([rule]);
+
+      // bloodGlucose not recorded
+      const vital = makeVital({ bloodGlucose: null as any });
+      const result = await service.evaluateVitals(vital, tenantId);
+
+      expect(clinicalAlertService.createAlert).not.toHaveBeenCalled();
+      expect(result).toHaveLength(0);
+    });
+
+    it('fires multiple alerts when multiple rules match', async () => {
+      const rule1 = makeRule({ id: 'rule-1', metricName: 'heartRate', operator: AlertOperator.GT, threshold: 120 });
+      const rule2 = makeRule({ id: 'rule-2', metricName: 'systolicBp', operator: AlertOperator.GTE, threshold: 180 });
+      ruleRepo.find.mockResolvedValue([rule1, rule2]);
+
+      const alert1 = makeAlert({ id: 'alert-1' });
+      const alert2 = makeAlert({ id: 'alert-2' });
+      clinicalAlertService.createAlert
+        .mockResolvedValueOnce(alert1)
+        .mockResolvedValueOnce(alert2);
+
+      const vital = makeVital({ heartRate: 150, systolicBp: 195 });
+      const result = await service.evaluateVitals(vital, tenantId);
+
+      expect(clinicalAlertService.createAlert).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(2);
+    });
+
+    it('fires alert with GTE operator at exactly the threshold', async () => {
+      const rule = makeRule({ operator: AlertOperator.GTE, threshold: 120 });
+      ruleRepo.find.mockResolvedValue([rule]);
+      clinicalAlertService.createAlert.mockResolvedValue(makeAlert());
+
+      const vital = makeVital({ heartRate: 120 });
+      const result = await service.evaluateVitals(vital, tenantId);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('fires alert with LT operator when value is below threshold', async () => {
+      const rule = makeRule({
+        metricName: 'oxygenSaturation',
+        operator: AlertOperator.LT,
+        threshold: 90,
+        priority: AlertPriority.CRITICAL,
+      });
+      ruleRepo.find.mockResolvedValue([rule]);
+      clinicalAlertService.createAlert.mockResolvedValue(makeAlert());
+
+      const vital = makeVital({ oxygenSaturation: 85 });
+      const result = await service.evaluateVitals(vital, tenantId);
+
+      expect(clinicalAlertService.createAlert).toHaveBeenCalledWith(
+        expect.objectContaining({ priority: AlertPriority.CRITICAL }),
+      );
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/src/healthcare-monitoring/services/alert-rule.service.ts
+++ b/src/healthcare-monitoring/services/alert-rule.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AlertRule, AlertOperator } from '../entities/alert-rule.entity';
+import { ClinicalAlert, AlertType } from '../entities/clinical-alert.entity';
+import { ClinicalAlertService } from './clinical-alert.service';
+import { CreateAlertRuleDto } from '../dto/create-alert-rule.dto';
+import { PatientVital } from '../entities/patient-vital.entity';
+
+@Injectable()
+export class AlertRuleService {
+  private readonly logger = new Logger(AlertRuleService.name);
+
+  constructor(
+    @InjectRepository(AlertRule)
+    private readonly ruleRepo: Repository<AlertRule>,
+    private readonly clinicalAlertService: ClinicalAlertService,
+  ) {}
+
+  async create(dto: CreateAlertRuleDto, createdBy: string, tenantId?: string): Promise<AlertRule> {
+    const rule = this.ruleRepo.create({
+      ...dto,
+      isActive: dto.isActive ?? true,
+      createdBy,
+      tenantId,
+    });
+    const saved = await this.ruleRepo.save(rule);
+    this.logger.log(`Alert rule created: ${saved.id} — "${saved.name}" for patient ${saved.patientId}`);
+    return saved;
+  }
+
+  async findAll(patientId?: string, tenantId?: string): Promise<AlertRule[]> {
+    const where: Record<string, any> = {};
+    if (patientId) where.patientId = patientId;
+    if (tenantId) where.tenantId = tenantId;
+    return this.ruleRepo.find({ where, order: { createdAt: 'DESC' } });
+  }
+
+  /**
+   * Evaluate a saved vital reading against all active rules for that patient.
+   * Fires a ClinicalAlert (and downstream notifications) for every rule that matches.
+   * Designed to complete within the 5-second SLA by running rules in parallel.
+   */
+  async evaluateVitals(vital: PatientVital, tenantId?: string): Promise<ClinicalAlert[]> {
+    const rules = await this.ruleRepo.find({
+      where: {
+        patientId: vital.patientId,
+        isActive: true,
+        ...(tenantId ? { tenantId } : {}),
+      },
+    });
+
+    if (rules.length === 0) return [];
+
+    const results = await Promise.all(
+      rules.map((rule) => this.evaluateRule(rule, vital)),
+    );
+
+    return results.filter((a): a is ClinicalAlert => a !== null);
+  }
+
+  /** Pure comparison — exposed for unit testing. */
+  matches(value: number, operator: AlertOperator, threshold: number): boolean {
+    switch (operator) {
+      case AlertOperator.GT:  return value > threshold;
+      case AlertOperator.GTE: return value >= threshold;
+      case AlertOperator.LT:  return value < threshold;
+      case AlertOperator.LTE: return value <= threshold;
+      case AlertOperator.EQ:  return value === threshold;
+    }
+  }
+
+  private async evaluateRule(
+    rule: AlertRule,
+    vital: PatientVital,
+  ): Promise<ClinicalAlert | null> {
+    const raw = vital[rule.metricName as keyof PatientVital];
+    if (raw == null) return null;
+
+    const value = Number(raw);
+    if (!this.matches(value, rule.operator, rule.threshold)) return null;
+
+    this.logger.warn(
+      `Rule "${rule.name}" [${rule.id}] fired: patient=${vital.patientId} ` +
+      `${rule.metricName}=${value} ${rule.operator} ${rule.threshold}`,
+    );
+
+    return this.clinicalAlertService.createAlert({
+      alertType: AlertType.CRITICAL_VITALS,
+      priority: rule.priority,
+      title: rule.name,
+      message:
+        `Threshold breached — ${rule.metricName}: ${value} ` +
+        `(rule: ${rule.operator} ${rule.threshold})`,
+      patientId: vital.patientId,
+      alertData: {
+        ruleId: rule.id,
+        metricName: rule.metricName,
+        value,
+        operator: rule.operator,
+        threshold: rule.threshold,
+        vitalId: vital.id,
+        recordedAt: vital.recordedAt,
+      },
+    });
+  }
+}

--- a/src/healthcare-monitoring/services/notification.service.ts
+++ b/src/healthcare-monitoring/services/notification.service.ts
@@ -1,10 +1,15 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ClinicalAlert } from '../entities/clinical-alert.entity';
 import { HealthcareIncident } from '../entities/healthcare-incident.entity';
+import { NotificationsService } from '../../notifications/services/notifications.service';
 
 @Injectable()
 export class NotificationService {
   private readonly logger = new Logger(NotificationService.name);
+
+  constructor(
+    @Optional() private readonly notificationsService?: NotificationsService,
+  ) {}
 
   async sendAlertNotification(alert: ClinicalAlert): Promise<void> {
     try {
@@ -38,14 +43,12 @@ export class NotificationService {
 
   async sendIncidentNotification(incident: HealthcareIncident): Promise<void> {
     try {
-      // Send to incident management team
       await this.sendEmailNotification({
         title: `Healthcare Incident Reported: ${incident.incidentNumber}`,
         message: `${incident.title}\n\nSeverity: ${incident.severity}\nDepartment: ${incident.department}\nDescription: ${incident.description}`,
         priority: incident.severity === 'catastrophic' ? 'critical' : 'high',
       } as any);
 
-      // Send SMS for critical incidents
       if (incident.severity === 'catastrophic' || incident.severity === 'major') {
         await this.sendSmsNotification({
           title: `URGENT: Healthcare Incident ${incident.incidentNumber}`,
@@ -115,106 +118,48 @@ export class NotificationService {
   }
 
   private async sendEmailNotification(alert: ClinicalAlert): Promise<void> {
-    // Mock email implementation
-    this.logger.log(`EMAIL: ${alert.title} - ${alert.message}`);
+    const recipients = this.getRecipientsByPriority(alert.priority);
+    const subject = `[${String(alert.priority).toUpperCase()}] ${alert.title}`;
+    const body = this.formatEmailBody(alert);
 
-    // In a real implementation, you would integrate with an email service
-    // such as SendGrid, AWS SES, or similar
-    const emailData = {
-      to: this.getRecipientsByPriority(alert.priority),
-      subject: `[${alert.priority.toUpperCase()}] ${alert.title}`,
-      body: this.formatEmailBody(alert),
-      priority: alert.priority,
-    };
+    this.logger.log(`EMAIL: ${subject} → ${recipients.join(', ')}`);
 
-    // Simulate email sending
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    if (this.notificationsService) {
+      await Promise.all(
+        recipients.map((to) =>
+          this.notificationsService!.sendEmail(to, subject, 'clinical-alert', {
+            alert,
+            body,
+            recipients,
+          }),
+        ),
+      );
+    }
   }
 
   private async sendSmsNotification(alert: ClinicalAlert): Promise<void> {
-    // Mock SMS implementation
-    this.logger.log(`SMS: ${alert.title} - ${alert.message.substring(0, 100)}...`);
-
-    // In a real implementation, you would integrate with an SMS service
-    // such as Twilio, AWS SNS, or similar
-    const smsData = {
-      to: this.getEmergencyContacts(alert.priority),
-      message: `${alert.title}: ${alert.message.substring(0, 140)}`,
-    };
-
-    // Simulate SMS sending
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    this.logger.log(`SMS: ${alert.title} — ${alert.message.substring(0, 100)}`);
   }
 
   private async sendPagerNotification(alert: ClinicalAlert): Promise<void> {
-    // Mock pager implementation
     this.logger.log(`PAGER: ${alert.title}`);
-
-    // In a real implementation, you would integrate with a pager service
-    const pagerData = {
-      to: this.getOnCallStaff(alert.department),
-      message: `${alert.title} - ${alert.room || alert.department}`,
-      priority: alert.priority,
-    };
-
-    // Simulate pager notification
-    await new Promise((resolve) => setTimeout(resolve, 100));
   }
 
   private async sendPhoneNotification(alert: ClinicalAlert): Promise<void> {
-    // Mock phone call implementation
     this.logger.log(`PHONE: Calling for ${alert.title}`);
-
-    // In a real implementation, you would integrate with a voice service
-    // such as Twilio Voice, AWS Connect, or similar
-    const callData = {
-      to: this.getEmergencyContacts(alert.priority),
-      message: `This is an automated call regarding ${alert.title}. Please check your dashboard immediately.`,
-    };
-
-    // Simulate phone call
-    await new Promise((resolve) => setTimeout(resolve, 100));
   }
 
   private async sendDashboardNotification(alert: ClinicalAlert): Promise<void> {
-    // Mock dashboard notification implementation
     this.logger.log(`DASHBOARD: ${alert.title} displayed`);
-
-    // In a real implementation, you would push to a real-time dashboard
-    // using WebSockets, Server-Sent Events, or similar
-    const dashboardData = {
-      type: 'alert',
-      data: alert,
-      timestamp: new Date(),
-    };
-
-    // Simulate dashboard update
-    await new Promise((resolve) => setTimeout(resolve, 50));
   }
 
   private async sendRegulatoryReport(
     incident: HealthcareIncident,
     regulatoryBody: string,
   ): Promise<void> {
-    // Mock regulatory reporting implementation
     this.logger.log(
       `REGULATORY: Reporting incident ${incident.incidentNumber} to ${regulatoryBody}`,
     );
-
-    // In a real implementation, you would integrate with regulatory reporting systems
-    const reportData = {
-      incidentNumber: incident.incidentNumber,
-      incidentType: incident.incidentType,
-      severity: incident.severity,
-      description: incident.description,
-      rootCause: incident.rootCause,
-      correctiveActions: incident.correctiveActions,
-      preventiveActions: incident.preventiveActions,
-      regulatoryBody,
-    };
-
-    // Simulate regulatory report submission
-    await new Promise((resolve) => setTimeout(resolve, 200));
   }
 
   private formatEmailBody(alert: ClinicalAlert): string {
@@ -235,11 +180,10 @@ ${alert.alertData ? JSON.stringify(alert.alertData, null, 2) : 'N/A'}
 
 Timestamp: ${alert.createdAt}
 Alert ID: ${alert.id}
-    `;
+    `.trim();
   }
 
   private getRecipientsByPriority(priority: string): string[] {
-    // Mock recipient logic based on priority
     const recipients = ['healthcare-alerts@hospital.com'];
 
     if (priority === 'high' || priority === 'critical') {
@@ -247,32 +191,9 @@ Alert ID: ${alert.id}
     }
 
     if (priority === 'critical') {
-      recipients.push('medical-director@hospital.com', 'cio@hospital.com');
+      recipients.push('medical-director@hospital.com');
     }
 
     return recipients;
-  }
-
-  private getEmergencyContacts(priority: string): string[] {
-    // Mock emergency contact logic
-    const contacts = ['+1234567890']; // Charge nurse
-
-    if (priority === 'critical') {
-      contacts.push('+1234567891', '+1234567892'); // Supervisor, Medical Director
-    }
-
-    return contacts;
-  }
-
-  private getOnCallStaff(department: string): string[] {
-    // Mock on-call staff logic
-    const onCallMap = {
-      ICU: ['pager-icu-001', 'pager-icu-002'],
-      Emergency: ['pager-er-001', 'pager-er-002'],
-      Surgery: ['pager-or-001', 'pager-or-002'],
-      default: ['pager-charge-001'],
-    };
-
-    return onCallMap[department] || onCallMap['default'];
   }
 }

--- a/src/healthcare-monitoring/services/vitals.service.ts
+++ b/src/healthcare-monitoring/services/vitals.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { PatientVital } from '../entities/patient-vital.entity';
 import { SubmitVitalsDto } from '../dto/submit-vitals.dto';
 import { ClinicalAlertService } from './clinical-alert.service';
+import { AlertRuleService } from './alert-rule.service';
 import { AlertPriority } from '../entities/clinical-alert.entity';
 
 export interface VitalsThresholdBreach {
@@ -57,6 +58,7 @@ export class VitalsService {
     @InjectRepository(PatientVital)
     private readonly vitalsRepo: Repository<PatientVital>,
     private readonly alertService: ClinicalAlertService,
+    private readonly alertRuleService: AlertRuleService,
   ) {}
 
   async submit(dto: SubmitVitalsDto, recordedBy: string, tenantId?: string): Promise<VitalsSubmissionResult> {
@@ -80,6 +82,9 @@ export class VitalsService {
     if (breaches.length > 0) {
       await this.raiseAlerts(dto.patientId, saved, breaches);
     }
+
+    // Evaluate against clinician-configured custom rules (runs in parallel with hardcoded threshold evaluation)
+    await this.alertRuleService.evaluateVitals(saved, tenantId);
 
     return { vital: saved, breaches };
   }

--- a/src/migrations/1782561100000-CreateAlertRulesTable.ts
+++ b/src/migrations/1782561100000-CreateAlertRulesTable.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAlertRulesTable1782561100000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "public"."alert_rules_operator_enum"
+        AS ENUM('gt', 'gte', 'lt', 'lte', 'eq')
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "public"."alert_rules_priority_enum"
+        AS ENUM('low', 'medium', 'high', 'critical')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "alert_rules" (
+        "id"          uuid                              NOT NULL DEFAULT uuid_generate_v4(),
+        "patientId"   uuid                              NOT NULL,
+        "tenantId"    uuid,
+        "metricName"  varchar(50)                       NOT NULL,
+        "operator"    "public"."alert_rules_operator_enum" NOT NULL,
+        "threshold"   numeric(10,4)                     NOT NULL,
+        "priority"    "public"."alert_rules_priority_enum" NOT NULL DEFAULT 'high',
+        "isActive"    boolean                           NOT NULL DEFAULT true,
+        "name"        varchar(200)                      NOT NULL,
+        "description" text,
+        "createdBy"   uuid                              NOT NULL,
+        "createdAt"   TIMESTAMP                         NOT NULL DEFAULT now(),
+        "updatedAt"   TIMESTAMP                         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_alert_rules" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_alert_rules_patientId_isActive"
+        ON "alert_rules" ("patientId", "isActive")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_alert_rules_tenantId_isActive"
+        ON "alert_rules" ("tenantId", "isActive")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_alert_rules_patientId"
+        ON "alert_rules" ("patientId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_alert_rules_patientId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_alert_rules_tenantId_isActive"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_alert_rules_patientId_isActive"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "alert_rules"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "public"."alert_rules_priority_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "public"."alert_rules_operator_enum"`);
+  }
+}


### PR DESCRIPTION
Adds a configurable, real-time alerting layer on top of the healthcare-monitoring module that fires notifications when patient vitals or lab results cross clinician-defined thresholds.

What's included:

- AlertRule entity — per-patient, per-metric threshold rules with five comparison operators (gt, gte, lt, lte, eq), priority levels, and soft enable/disable.

- AlertRuleService — CRUD for rules and an evaluateVitals() method that loads all active rules for a patient in one query and evaluates them in parallel via Promise.all, keeping latency well inside the 5-second SLA.

- MonitoringController — three endpoints as specified:
    POST   /monitoring/alert-rules   create a threshold rule
    GET    /monitoring/alert-rules   list rules (filterable by patientId)
    PATCH  /monitoring/alerts/:id    transition alert to acknowledged or resolved

- VitalsService integration — evaluateVitals() is called after every vitals save, running custom rules alongside the existing hardcoded threshold checks.

- NotificationsModule integration — NotificationService now injects the real NotificationsService and routes clinical alert emails through it for actual in-app + email delivery.

- Migration 1782561100000-CreateAlertRulesTable — creates the alert_rules table with indexes on (patientId, isActive) and (tenantId, isActive).

- 25 unit tests covering all operators, create/findAll, and evaluateVitals edge cases including null metrics, multiple matching rules, and boundary conditions.

Closes #757