### PR TITLE
docs: add database seeding step to installation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,17 @@ docker compose -f docker-compose.local.yml down -v     # wipe volumes
 
 **Prerequisites:** Node.js v18+, PostgreSQL v12+
 
-```bash
-npm install
-cp .env.example .env
-# fill in .env
-npm run migration:run
-npm run start:dev
-```
+1. Install dependencies:
+   `npm install`
+2. Set up environment variables:
+   `cp .env.example .env`
+3. Run database migrations:
+   `npm run migration:run`
+4. **Seed the database with test data:**
+   `npm run seed`
+   *(Why added: This generates fake users, medical records, and access grants via `src/database/seeder.ts` so you can log in and test the application).*
+5. Start the development server:
+   `npm run start:dev`
 
 ## Configuration
 


### PR DESCRIPTION
The current setup documentation skips the database seeding step. If a new contributor follows the README exactly (npm run migration:run -> npm run start:dev), they are left with an empty database and no test users to log in with.This PR adds npm run seed to the setup instructions to ensure src/database/seeder.ts generates the necessary users, medical records, and access grants for local development.