### PR TITLE
#783 docs:generate script has a broken import path, preventing OpenAP…

### DIFF
--- a/src/swaggeropenapi-documentation-with-full-schema-coverage/export-openapi.ts
+++ b/src/swaggeropenapi-documentation-with-full-schema-coverage/export-openapi.ts
@@ -11,7 +11,7 @@ import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { writeFileSync, mkdirSync } from 'fs';
 import { resolve } from 'path';
-import { AppModule } from '../src/app.module';
+import { AppModule } from '../app.module';
 
 async function exportOpenApi() {
   console.log('⚙️  Bootstrapping app (no HTTP listener)…');


### PR DESCRIPTION
### Findings

* The OpenAPI exporter is located at:
  `src/swaggeropenapi-documentation-with-full-schema-coverage/export-openapi.ts`
* It originally imported `AppModule` using:

  ```ts
  import { AppModule } from '../src/app.module';
  ```
* Because the exporter is already inside the `src` directory, this incorrectly resolved to:
  `src/src/app.module.ts`
* The correct application module is located at:
  `src/app.module.ts`
* This incorrect import prevented the OpenAPI generation command from loading `AppModule`, causing `docs/openapi.json` to potentially remain outdated.

### Fix Applied

* Updated the import statement to:

  ```ts
  import { AppModule } from '../app.module';
  ```
* This correctly resolves the module from:
  `src/swaggeropenapi-documentation-with-full-schema-coverage/`
  to:
  `src/app.module.ts`

### Fix Features

* Corrected the broken relative import path.
* Enabled the OpenAPI exporter to successfully locate `AppModule`.
* Allowed `npm run docs:generate` to proceed without the module-resolution error.
* Did **not** change application behavior, routes, schemas, or API logic.
* Added **no** new dependencies.
* Created **no** new files.
* Modified **only one** existing file.

CLOSE #783 