### PR TITLE
[Critical] SecretRotationController has zero authentication or authorization guards

### DIFF
--- a/src/auth/controllers/secret-rotation.controller.spec.ts
+++ b/src/auth/controllers/secret-rotation.controller.spec.ts
@@ -1,0 +1,13 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { AdminGuard } from '../guards/admin.guard';
+import { JwtAuthGuard } from '../guards/jwt-auth.guard';
+import { SecretRotationController } from './secret-rotation.controller';
+
+describe('SecretRotationController', () => {
+  it('requires an authenticated admin for every route', () => {
+    expect(Reflect.getMetadata(GUARDS_METADATA, SecretRotationController)).toEqual([
+      JwtAuthGuard,
+      AdminGuard,
+    ]);
+  });
+});

--- a/src/auth/controllers/secret-rotation.controller.ts
+++ b/src/auth/controllers/secret-rotation.controller.ts
@@ -1,10 +1,13 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiBody, ApiParam } from '@nestjs/swagger';
 import { SecretRotationService } from '../services/secret-rotation.service';
+import { JwtAuthGuard } from '../guards/jwt-auth.guard';
+import { AdminGuard } from '../guards/admin.guard';
 
 @ApiTags('Admin - Secret Rotation')
 @ApiBearerAuth()
 @Controller('admin/secret-rotation')
+@UseGuards(JwtAuthGuard, AdminGuard)
 export class SecretRotationController {
   constructor(private readonly secretRotation: SecretRotationService) {}
 


### PR DESCRIPTION
The vulnerable controller is protected with [@UseGuards(JwtAuthGuard, AdminGuard)](vscode-file://vscode-app/c:/Users/H/AppData/Local/Programs/Microsoft%20VS%20Code/8a7abeba6e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Unauthenticated requests can no longer reach any secret-rotation route.
Non-admin authenticated users are rejected.
Both JWT rotation routes are covered because the guards are applied at controller scope:
[POST /admin/secret-rotation/rotate/jwt](vscode-file://vscode-app/c:/Users/H/AppData/Local/Programs/Microsoft%20VS%20Code/8a7abeba6e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[POST /admin/secret-rotation/jwt/rotate](vscode-file://vscode-app/c:/Users/H/AppData/Local/Programs/Microsoft%20VS%20Code/8a7abeba6e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Database rotation and status access are protected as well.
A regression test verifies that the controller retains both guards

Closes #790 