### PR TITLE
fix(billing,stellar): close payment race conditions and dead-letter r…

### DIFF
--- a/src/billing/entities/payment.entity.ts
+++ b/src/billing/entities/payment.entity.ts
@@ -70,7 +70,7 @@ export class Payment {
   @Column({ type: 'varchar', length: 50, nullable: true })
   checkNumber: string;
 
-  @Column({ type: 'varchar', length: 100, nullable: true })
+  @Column({ type: 'varchar', length: 100, nullable: true, unique: true })
   transactionId: string;
 
   @Column({ type: 'varchar', length: 50, nullable: true })

--- a/src/billing/services/payment.service.ts
+++ b/src/billing/services/payment.service.ts
@@ -44,6 +44,22 @@ export class PaymentService {
       );
     }
 
+    // Idempotency: a client-supplied transactionId identifies a single
+    // logical payment attempt (e.g. a gateway charge). If a payment already
+    // exists for it, return that payment instead of creating a second
+    // Payment row and a second deduction from billing.balance.
+    if (createDto.transactionId) {
+      const existingPayment = await this.paymentRepository.findOne({
+        where: { transactionId: createDto.transactionId },
+      });
+      if (existingPayment) {
+        this.logger.warn(
+          `Duplicate payment request for transactionId=${createDto.transactionId}; returning existing payment ${existingPayment.id}`,
+        );
+        return existingPayment;
+      }
+    }
+
     const paymentNumber = `PAY-${Date.now()}-${uuidv4().substring(0, 4).toUpperCase()}`;
 
     const payment = this.paymentRepository.create({
@@ -68,11 +84,33 @@ export class PaymentService {
       notes: createDto.notes,
     });
 
-    await this.paymentRepository.save(payment);
+    try {
+      await this.paymentRepository.save(payment);
+    } catch (error) {
+      // A concurrent request carrying the same client-supplied transactionId
+      // may have won the race to insert first. The unique constraint on
+      // transactionId (see migration AddUniqueConstraintToPaymentTransactionId)
+      // turns that race into "return the existing payment" instead of a
+      // duplicate deduction against billing.balance.
+      if (createDto.transactionId && this.isDuplicateKeyError(error)) {
+        const existingPayment = await this.paymentRepository.findOne({
+          where: { transactionId: createDto.transactionId },
+        });
+        if (existingPayment) {
+          return existingPayment;
+        }
+      }
+      throw error;
+    }
 
     const processedPayment = await this.processPayment(payment.id);
 
     return processedPayment;
+  }
+
+  private isDuplicateKeyError(error: unknown): boolean {
+    const code = (error as { code?: string } | undefined)?.code;
+    return code === '23505';
   }
 
   async processPayment(paymentId: string): Promise<Payment> {
@@ -103,32 +141,48 @@ export class PaymentService {
         }
       }
 
-      const billing = await this.billingRepository.findOne({
-        where: { id: payment.billingId },
-        relations: ['lineItems', 'payments'],
-      });
+      // Lock the billing row for the duration of the balance mutation so
+      // concurrent payments against the same billing record serialize
+      // instead of both reading a stale balance and both applying their
+      // deduction. The balance is re-validated under the lock — rather than
+      // clamping a negative result to zero — so a payment that no longer
+      // fits (because a concurrent payment already consumed the balance) is
+      // rejected instead of silently driving the balance negative.
+      await this.billingRepository.manager.transaction(async (manager) => {
+        const billing = await manager
+          .createQueryBuilder(Billing, 'billing')
+          .setLock('pessimistic_write')
+          .where('billing.id = :id', { id: payment.billingId })
+          .getOne();
 
-      if (billing) {
-        billing.totalPayments = Number(billing.totalPayments) + Number(payment.amount);
-        billing.balance = Number(billing.balance) - Number(payment.amount);
+        if (!billing) {
+          return;
+        }
+
+        const paymentAmount = Number(payment.amount);
+        const currentBalance = Number(billing.balance);
+
+        if (paymentAmount > currentBalance) {
+          throw new BadRequestException(
+            `Payment amount ($${paymentAmount}) exceeds outstanding balance ($${currentBalance})`,
+          );
+        }
+
+        billing.totalPayments = Number(billing.totalPayments) + paymentAmount;
+        billing.balance = currentBalance - paymentAmount;
 
         if (payment.isInsurancePayment) {
           billing.insuranceResponsibility =
-            Number(billing.insuranceResponsibility || 0) - Number(payment.amount);
+            Number(billing.insuranceResponsibility || 0) - paymentAmount;
         } else {
           billing.patientResponsibility =
-            Number(billing.patientResponsibility || 0) - Number(payment.amount);
+            Number(billing.patientResponsibility || 0) - paymentAmount;
         }
 
-        if (billing.balance <= 0) {
-          billing.status = 'paid';
-          billing.balance = 0;
-        } else {
-          billing.status = 'partial';
-        }
+        billing.status = billing.balance <= 0 ? 'paid' : 'partial';
 
-        await this.billingRepository.save(billing);
-      }
+        await manager.save(Billing, billing);
+      });
 
       payment.status = PaymentStatus.COMPLETED;
       payment.postedDate = new Date();

--- a/src/migrations/1783100000000-AddUniqueConstraintToPaymentTransactionId.ts
+++ b/src/migrations/1783100000000-AddUniqueConstraintToPaymentTransactionId.ts
@@ -1,0 +1,78 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { createIndexConcurrently } from '../common/utils/migration-safety.util';
+
+/**
+ * Migration: Unique constraint on payments.transactionId
+ *
+ * Why this migration
+ * -------------------
+ * PaymentService.create() previously had no server-side protection against
+ * duplicate/double-processed payments: `transactionId` was optional and
+ * un-indexed, so a client retry after a timeout (or a duplicate webhook
+ * delivery) could insert a second Payment row and deduct twice from
+ * `billing.balance`. PaymentService now checks for an existing payment by
+ * transactionId before inserting, but that check-then-insert is itself
+ * race-prone under concurrent requests — the unique index is the
+ * authoritative guard, with the application-level check turning the
+ * resulting unique-violation into a clean "return the existing payment"
+ * instead of a 500.
+ *
+ * `transactionId` is nullable, and Postgres unique indexes treat NULLs as
+ * distinct from one another, so rows without a transactionId are unaffected.
+ *
+ * Idempotency: guarded by table/column existence checks so the migration is
+ * safe to re-run against a partially-applied schema. If duplicate
+ * transactionId values already exist (e.g. seeded/test data), the unique
+ * index creation is skipped with a warning rather than failing the deploy —
+ * operators can reconcile duplicates and re-run.
+ */
+export class AddUniqueConstraintToPaymentTransactionId1783100000000
+  implements MigrationInterface
+{
+  name = 'AddUniqueConstraintToPaymentTransactionId1783100000000';
+
+  private readonly indexName = 'UQ_payments_transactionId';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasTable('payments'))) {
+      return;
+    }
+    if (!(await queryRunner.hasColumn('payments', 'transactionId'))) {
+      return;
+    }
+
+    const duplicates: Array<{ count: string }> = await queryRunner.query(
+      `SELECT COUNT(*) AS count FROM (
+         SELECT "transactionId"
+         FROM "payments"
+         WHERE "transactionId" IS NOT NULL
+         GROUP BY "transactionId"
+         HAVING COUNT(*) > 1
+       ) dups`,
+    );
+
+    if (Number(duplicates[0]?.count ?? 0) > 0) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Migration ${this.name} skipped: duplicate "transactionId" values exist in "payments". ` +
+          `Reconcile duplicates and re-run this migration.`,
+      );
+      return;
+    }
+
+    await createIndexConcurrently(
+      queryRunner,
+      this.indexName,
+      'payments',
+      ['transactionId'],
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasTable('payments'))) {
+      return;
+    }
+    await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${this.indexName}"`);
+  }
+}

--- a/src/stellar/services/stellar-payment-verification.service.ts
+++ b/src/stellar/services/stellar-payment-verification.service.ts
@@ -70,70 +70,134 @@ export class StellarPaymentVerificationService {
     txHash: string,
     tenantId?: string,
   ): Promise<PaymentVerificationResult> {
-    // ── 1. Idempotency check ──────────────────────────────────────────────────
+    // ── 1. Idempotency check + atomic claim ─────────────────────────────────
+    // A plain SELECT-then-later-write leaves a window where two concurrent
+    // calls for the same txHash (e.g. a webhook retry racing the original
+    // delivery) both observe "no existing record", both hit Horizon, and
+    // both emit PAYMENT_CONFIRMED_EVENT. `key` carries a unique index, so an
+    // INSERT reserving the row is an atomic claim: only one concurrent
+    // caller can win it, and everyone else is told to back off instead of
+    // proceeding to call Horizon and emit the event a second time.
     const idempotencyKey = `${IDEMPOTENCY_KEY_PREFIX}${txHash}`;
-    const existing = await this.idempotencyRepo.findOne({ where: { key: idempotencyKey } });
+    const claimed = await this.claimIdempotencyKey(idempotencyKey, txHash);
 
-    if (existing) {
-      this.logger.log(`[verifyPayment] Returning cached result for txHash=${txHash}`);
-      return {
-        ...(existing.body as PaymentVerificationResult),
-        status: PaymentVerificationStatus.DUPLICATE,
-      };
+    if (!claimed) {
+      const existing = await this.idempotencyRepo.findOne({ where: { key: idempotencyKey } });
+      if (
+        existing &&
+        (existing.body as PaymentVerificationResult)?.status !== PaymentVerificationStatus.PENDING
+      ) {
+        this.logger.log(`[verifyPayment] Returning cached result for txHash=${txHash}`);
+        return {
+          ...(existing.body as PaymentVerificationResult),
+          status: PaymentVerificationStatus.DUPLICATE,
+        };
+      }
+
+      // Another call currently owns verification of this txHash (or left it
+      // PENDING). Do not race it into a second Horizon lookup / event emit.
+      this.logger.log(`[verifyPayment] Verification already in progress for txHash=${txHash}`);
+      return { txHash, status: PaymentVerificationStatus.PENDING };
     }
 
-    // ── 2. Query Horizon API ──────────────────────────────────────────────────
-    let horizonData: any;
     try {
-      const url = `${this.horizonUrl}/transactions/${txHash}`;
-      const response = await firstValueFrom(this.httpService.get(url));
-      horizonData = response.data;
-    } catch (err: any) {
-      if (err?.response?.status === 404) {
-        this.logger.warn(`[verifyPayment] txHash=${txHash} not found on Horizon — treating as PENDING`);
-        return { txHash, status: PaymentVerificationStatus.PENDING };
+      // ── 2. Query Horizon API ────────────────────────────────────────────
+      let horizonData: any;
+      try {
+        const url = `${this.horizonUrl}/transactions/${txHash}`;
+        const response = await firstValueFrom(this.httpService.get(url));
+        horizonData = response.data;
+      } catch (err: any) {
+        if (err?.response?.status === 404) {
+          this.logger.warn(`[verifyPayment] txHash=${txHash} not found on Horizon — treating as PENDING`);
+          await this.releaseIdempotencyClaim(idempotencyKey);
+          return { txHash, status: PaymentVerificationStatus.PENDING };
+        }
+        this.logger.error(`[verifyPayment] Horizon API error for txHash=${txHash}: ${err.message}`);
+        await this.releaseIdempotencyClaim(idempotencyKey);
+        throw err;
       }
-      this.logger.error(`[verifyPayment] Horizon API error for txHash=${txHash}: ${err.message}`);
+
+      // ── 3. Classify transaction state ─────────────────────────────────────
+      const result = this.classifyTransaction(txHash, horizonData);
+
+      // ── 4. Persist idempotency record for confirmed/failed transactions ───
+      if (
+        result.status === PaymentVerificationStatus.CONFIRMED ||
+        result.status === PaymentVerificationStatus.FAILED ||
+        result.status === PaymentVerificationStatus.EXPIRED
+      ) {
+        await this.idempotencyRepo.update(
+          { key: idempotencyKey },
+          {
+            statusCode: 200,
+            body:       result as unknown as Record<string, any>,
+          },
+        );
+      } else {
+        // Still PENDING on-chain — release the claim so a legitimate later
+        // retry (poll) can re-check Horizon instead of being stuck behind
+        // a stale reservation forever.
+        await this.releaseIdempotencyClaim(idempotencyKey);
+      }
+
+      // ── 5. Emit domain event for confirmed payments ────────────────────────
+      if (result.status === PaymentVerificationStatus.CONFIRMED) {
+        const event: PaymentConfirmedEvent = {
+          txHash,
+          ledger:     result.ledger!,
+          confirmedAt: result.confirmedAt!,
+          tenantId,
+        };
+        this.eventEmitter.emit(PAYMENT_CONFIRMED_EVENT, event);
+        this.logger.log(`[verifyPayment] Emitted ${PAYMENT_CONFIRMED_EVENT} for txHash=${txHash}`);
+      }
+
+      return result;
+    } catch (err) {
+      // Don't leave a dangling claim behind on unexpected failures — a
+      // permanently-stuck PENDING placeholder would block all future
+      // verification attempts for this txHash.
+      await this.releaseIdempotencyClaim(idempotencyKey).catch(() => {});
       throw err;
     }
-
-    // ── 3. Classify transaction state ─────────────────────────────────────────
-    const result = this.classifyTransaction(txHash, horizonData);
-
-    // ── 4. Persist idempotency record for confirmed/failed transactions ───────
-    if (
-      result.status === PaymentVerificationStatus.CONFIRMED ||
-      result.status === PaymentVerificationStatus.FAILED ||
-      result.status === PaymentVerificationStatus.EXPIRED
-    ) {
-      await this.idempotencyRepo.upsert(
-        {
-          key:                idempotencyKey,
-          statusCode:         200,
-          body:               result as unknown as Record<string, any>,
-          headers:            {},
-          requestFingerprint: `POST:/webhooks/stellar:${txHash}`,
-        },
-        ['key'],
-      );
-    }
-
-    // ── 5. Emit domain event for confirmed payments ───────────────────────────
-    if (result.status === PaymentVerificationStatus.CONFIRMED) {
-      const event: PaymentConfirmedEvent = {
-        txHash,
-        ledger:     result.ledger!,
-        confirmedAt: result.confirmedAt!,
-        tenantId,
-      };
-      this.eventEmitter.emit(PAYMENT_CONFIRMED_EVENT, event);
-      this.logger.log(`[verifyPayment] Emitted ${PAYMENT_CONFIRMED_EVENT} for txHash=${txHash}`);
-    }
-
-    return result;
   }
 
   // ── Private helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Attempts to atomically reserve the idempotency row for this txHash.
+   * Returns `true` if this call won the claim, `false` if another call
+   * already holds (or previously completed) it.
+   */
+  private async claimIdempotencyKey(key: string, txHash: string): Promise<boolean> {
+    try {
+      await this.idempotencyRepo.insert({
+        key,
+        statusCode:         202,
+        body:               { txHash, status: PaymentVerificationStatus.PENDING },
+        headers:            {},
+        requestFingerprint: `POST:/webhooks/stellar:${txHash}`,
+      });
+      return true;
+    } catch (err: any) {
+      if (this.isDuplicateKeyError(err)) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  private async releaseIdempotencyClaim(key: string): Promise<void> {
+    await this.idempotencyRepo.delete({ key });
+  }
+
+  private isDuplicateKeyError(error: unknown): boolean {
+    const code =
+      (error as { code?: string; driverError?: { code?: string } } | undefined)?.code ??
+      (error as { driverError?: { code?: string } } | undefined)?.driverError?.code;
+    return code === '23505';
+  }
 
   private classifyTransaction(
     txHash: string,

--- a/src/stellar/services/stellar-transaction-queue.service.ts
+++ b/src/stellar/services/stellar-transaction-queue.service.ts
@@ -62,6 +62,10 @@ export class StellarTransactionQueueService implements OnModuleInit {
   private readonly transactionTTLMs: number;
   private retryTimer?: NodeJS.Timeout;
 
+  private readonly sorobanServer: StellarSdk.SorobanRpc.Server;
+  private readonly horizonServer: StellarSdk.Horizon.Server;
+  private readonly sourceKeypair?: StellarSdk.Keypair;
+
   constructor(
     private readonly configService: ConfigService,
     private readonly retryService: StellarTransactionRetryService,
@@ -79,6 +83,26 @@ export class StellarTransactionQueueService implements OnModuleInit {
       this.configService.get<string>('STELLAR_TRANSACTION_TTL_MS', '3600000'), // 1 hour
       10,
     );
+
+    const isMainnet = this.configService.get<string>('STELLAR_NETWORK', 'testnet') === 'mainnet';
+    const sorobanRpcUrl = isMainnet
+      ? 'https://soroban-rpc.mainnet.stellar.gateway.fm'
+      : 'https://soroban-testnet.stellar.org';
+    const horizonUrl = isMainnet
+      ? 'https://horizon.stellar.org'
+      : 'https://horizon-testnet.stellar.org';
+
+    this.sorobanServer = new StellarSdk.SorobanRpc.Server(sorobanRpcUrl, { allowHttp: false });
+    this.horizonServer = new StellarSdk.Horizon.Server(horizonUrl, { allowHttp: false });
+
+    const secretKey = this.configService.get<string>('STELLAR_SECRET_KEY');
+    if (secretKey) {
+      this.sourceKeypair = StellarSdk.Keypair.fromSecret(secretKey);
+    } else {
+      this.logger.warn(
+        'STELLAR_SECRET_KEY is not configured — queued transactions cannot be automatically resubmitted for retry',
+      );
+    }
 
     this.logger.log(
       `StellarTransactionQueueService initialized (maxSize: ${this.maxQueueSize}, retryInterval: ${this.retryIntervalMs}ms)`,
@@ -301,25 +325,40 @@ export class StellarTransactionQueueService implements OnModuleInit {
     );
 
     try {
-      // Note: This is a simplified retry - in production, you'd need to inject
-      // the actual Stellar servers and keypair
-      // For now, we just update the status and schedule next retry
+      if (!this.sourceKeypair) {
+        throw new Error(
+          'STELLAR_SECRET_KEY is not configured; cannot sign queued transaction for retry',
+        );
+      }
 
-      // Simulate retry logic
-      const nextRetryDelay = this.calculateNextRetryDelay(queuedTx.attempts);
-      queuedTx.nextRetryAt = new Date(Date.now() + nextRetryDelay);
+      const result = await this.retryService.submitWithRetry(
+        this.sorobanServer,
+        this.horizonServer,
+        transaction,
+        this.sourceKeypair,
+        context,
+      );
 
-      // In a real implementation, you would call the retry service here
-      // const result = await this.retryService.submitWithRetry(...);
-
-      // For now, mark as pending for next retry
-      if (queuedTx.attempts >= queuedTx.maxAttempts) {
+      if (result.success) {
+        queuedTx.status = TransactionStatus.COMPLETED;
+        queuedTx.lastError = undefined;
+        this.logger.log(
+          `[${context.operation}] Transaction ${id} resubmitted successfully: ${result.txHash} (attempt ${queuedTx.attempts})`,
+        );
+      } else if (queuedTx.attempts >= queuedTx.maxAttempts) {
         queuedTx.status = TransactionStatus.FAILED;
+        queuedTx.lastError = result.error;
         this.logger.error(
-          `[${context.operation}] Transaction ${id} failed after ${queuedTx.attempts} attempts`,
+          `[${context.operation}] Transaction ${id} failed after ${queuedTx.attempts} attempts: ${result.error}`,
         );
       } else {
         queuedTx.status = TransactionStatus.PENDING;
+        queuedTx.lastError = result.error;
+        const nextRetryDelay = this.calculateNextRetryDelay(queuedTx.attempts);
+        queuedTx.nextRetryAt = new Date(Date.now() + nextRetryDelay);
+        this.logger.warn(
+          `[${context.operation}] Transaction ${id} retry failed: ${result.error}. Next retry at ${queuedTx.nextRetryAt.toISOString()}`,
+        );
       }
     } catch (err: any) {
       queuedTx.lastError = err.message;


### PR DESCRIPTION
…etry stub

[Critical] Queued Stellar transaction retry logic is a stub — failed transactions are never actually resubmitted Fixes #799

[High] Race condition / lost update on `Billing.balance` during concurrent payments Fixes #800

[High] No idempotency/duplicate-payment protection in `PaymentService.create` Fixes #801

[High] TOCTOU race in Stellar payment-verification idempotency check Fixes #802