### PR TITLE
Add GDPR erasure request pipeline

### DIFF
--- a/src/gdpr/controllers/gdpr.controller.ts
+++ b/src/gdpr/controllers/gdpr.controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Post, Get, UseGuards, Req, HttpCode, HttpStatus } from '@nestjs/common';
+import { Body, Controller, Post, Get, UseGuards, Req, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { GdprService } from '../services/gdpr.service';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { AuditLog } from '../../common/audit/audit-log.decorator';
 import { ThrottlerBehindProxyGuard } from '../../common/throttler/throttler-behind-proxy.guard';
 import { RateLimit } from '../../common/throttler/throttler.decorator';
+import { CreateErasureRequestDto } from '../dto/create-erasure-request.dto';
 
 @ApiTags('GDPR Data Subject Rights')
 @Controller('gdpr')
@@ -25,16 +26,16 @@ export class GdprController {
     return this.gdprService.createExportRequest(userId);
   }
 
-  @Post('erasure-request')
+  @Post(['erasure-request', 'erasure-requests'])
   @HttpCode(HttpStatus.ACCEPTED)
   @RateLimit(3, 60)
   @ApiOperation({ summary: 'Submit a right-to-erasure request' })
   @ApiResponse({ status: 202, description: 'Erasure request queued' })
   @ApiResponse({ status: 409, description: 'A pending or in-progress request already exists' })
   @AuditLog('GDPR_ERASURE_REQUEST', 'GdprRequest')
-  async requestErasure(@Req() req) {
+  async requestErasure(@Req() req, @Body() dto?: CreateErasureRequestDto) {
     const userId = req.user.id;
-    return this.gdprService.createErasureRequest(userId);
+    return this.gdprService.createErasureRequest(userId, dto);
   }
 
   @Get('requests')

--- a/src/gdpr/dto/create-erasure-request.dto.ts
+++ b/src/gdpr/dto/create-erasure-request.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class CreateErasureRequestDto {
+  @IsUUID()
+  @IsNotEmpty()
+  patientId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  requestorIdentity: string;
+
+  @IsOptional()
+  @IsString()
+  tenantId?: string;
+}

--- a/src/gdpr/entities/gdpr-compliance-log.entity.ts
+++ b/src/gdpr/entities/gdpr-compliance-log.entity.ts
@@ -1,0 +1,29 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('gdpr_compliance_logs')
+@Index(['requestId', 'createdAt'])
+export class GdprComplianceLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  requestId: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  patientId: string;
+
+  @Column({ nullable: true })
+  tenantId: string;
+
+  @Column({ nullable: true })
+  operator: string;
+
+  @Column({ nullable: true })
+  scope: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  details: Record<string, any>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/gdpr/entities/gdpr-request.entity.ts
+++ b/src/gdpr/entities/gdpr-request.entity.ts
@@ -28,6 +28,16 @@ export class GdprRequest {
   @Index()
   userId: string;
 
+  @Column({ type: 'uuid', nullable: true })
+  @Index()
+  patientId: string;
+
+  @Column({ nullable: true })
+  requestorIdentity: string;
+
+  @Column({ nullable: true })
+  tenantId: string;
+
   @Column({
     type: 'enum',
     enum: GdprRequestType,

--- a/src/gdpr/gdpr.module.ts
+++ b/src/gdpr/gdpr.module.ts
@@ -13,12 +13,14 @@ import { MedicalRecordsModule } from '../medical-records/medical-records.module'
 import { AccessControlModule } from '../access-control/access-control.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { DataRetentionModule } from '../data-retention/data-retention.module';
 import { User } from '../auth/entities/user.entity';
 import { Patient } from '../patients/entities/patient.entity';
 import { Record } from '../records/entities/record.entity';
 import { MedicalRecord } from '../medical-records/entities/medical-record.entity';
 import { AccessGrant } from '../access-control/entities/access-grant.entity';
 import { AuditLogEntity } from '../common/audit/audit-log.entity';
+import { GdprComplianceLog } from './entities/gdpr-compliance-log.entity';
 
 @Module({
   imports: [
@@ -30,6 +32,7 @@ import { AuditLogEntity } from '../common/audit/audit-log.entity';
       MedicalRecord,
       AccessGrant,
       AuditLogEntity,
+      GdprComplianceLog,
     ]),
     BullModule.registerQueue({
       name: 'gdpr',
@@ -41,6 +44,7 @@ import { AuditLogEntity } from '../common/audit/audit-log.entity';
     AccessControlModule,
     NotificationsModule,
     StellarModule,
+    DataRetentionModule,
   ],
   controllers: [GdprController],
   providers: [GdprService, GdprProcessor, DeletionRegistryService],

--- a/src/gdpr/processors/gdpr.processor.ts
+++ b/src/gdpr/processors/gdpr.processor.ts
@@ -3,7 +3,9 @@ import { Logger, OnModuleInit } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
+import { createHash } from 'crypto';
 import { GdprRequest, GdprRequestStatus } from '../entities/gdpr-request.entity';
+import { GdprComplianceLog } from '../entities/gdpr-compliance-log.entity';
 import { User } from '../../auth/entities/user.entity';
 import { Patient } from '../../patients/entities/patient.entity';
 import { Record } from '../../records/entities/record.entity';
@@ -22,6 +24,7 @@ import { ConsultationNote } from '../../appointments/entities/consultation-note.
 import { IpfsService } from '../../records/services/ipfs.service';
 import { NotificationsService } from '../../notifications/services/notifications.service';
 import { DeletionRegistryService } from '../services/deletion-registry.service';
+import { DataRetentionService } from '../../data-retention/data-retention.service';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -40,9 +43,12 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
     @InjectRepository(AccessGrant) private readonly accessGrantRepository: Repository<AccessGrant>,
     @InjectRepository(AuditLogEntity)
     private readonly auditLogRepository: Repository<AuditLogEntity>,
+    @InjectRepository(GdprComplianceLog)
+    private readonly complianceLogRepository: Repository<GdprComplianceLog>,
     private readonly ipfsService: IpfsService,
     private readonly notificationsService: NotificationsService,
     private readonly deletionRegistry: DeletionRegistryService,
+    private readonly dataRetentionService: DataRetentionService,
   ) {
     super();
   }
@@ -54,13 +60,13 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
       deleteForUser: async (userId, manager) => {
         const user = await manager.findOne(User, { where: { id: userId } });
         if (user) {
-          user.firstName = '[DELETED]';
-          user.lastName = '[DELETED]';
-          user.displayName = '[DELETED]';
-          user.email = `deleted-${userId}@anonymized.local`;
-          user.phone = '[DELETED]';
-          user.npi = '[DELETED]';
-          user.licenseNumber = '[DELETED]';
+          user.firstName = this.hashPlaceholder(user.firstName ?? 'first', userId);
+          user.lastName = this.hashPlaceholder(user.lastName ?? 'last', userId);
+          user.displayName = this.hashPlaceholder(user.displayName ?? 'display', userId);
+          user.email = this.hashEmail(userId, user.email);
+          user.phone = this.hashPlaceholder(user.phone ?? 'phone', userId);
+          user.npi = this.hashPlaceholder(user.npi ?? 'npi', userId);
+          user.licenseNumber = this.hashPlaceholder(user.licenseNumber ?? 'license', userId);
           await manager.save(User, user);
         }
       },
@@ -72,14 +78,14 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
       deleteForUser: async (userId, manager) => {
         const patient = await manager.findOne(Patient, { where: { id: userId } });
         if (patient) {
-          patient.firstName = '[DELETED]';
-          patient.lastName = '[DELETED]';
-          patient.middleName = '[DELETED]';
-          patient.email = '[DELETED]';
-          patient.phone = '[DELETED]';
-          patient.address = '[DELETED]';
+          patient.firstName = this.hashPlaceholder(patient.firstName ?? 'first', userId);
+          patient.lastName = this.hashPlaceholder(patient.lastName ?? 'last', userId);
+          patient.middleName = this.hashPlaceholder(patient.middleName ?? 'middle', userId);
+          patient.email = this.hashEmail(userId, patient.email);
+          patient.phone = this.hashPlaceholder(patient.phone ?? 'phone', userId);
+          patient.address = this.hashPlaceholder(JSON.stringify(patient.address ?? {}), userId);
           patient.dateOfBirth = '1900-01-01';
-          patient.nationalId = null;
+          patient.nationalId = this.hashPlaceholder(patient.nationalId ?? 'national-id', userId);
           await manager.save(Patient, patient);
         }
       },
@@ -189,6 +195,15 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
     });
   }
 
+  private hashPlaceholder(value: string, seed: string): string {
+    return `hash:${createHash('sha256').update(`${seed}:${value}`).digest('hex').slice(0, 16)}`;
+  }
+
+  private hashEmail(userId: string, email?: string): string {
+    const normalized = email ?? `user-${userId}`;
+    return `deleted+${createHash('sha256').update(`${userId}:${normalized}`).digest('hex').slice(0, 16)}@anonymized.local`;
+  }
+
   async process(job: Job<any, any, string>): Promise<any> {
     this.logger.log(`Processing GDPR job ${job.id} of type ${job.name}`);
 
@@ -269,13 +284,37 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
     }
   }
 
-  private async handleErasure(data: { requestId: string; userId: string }) {
+  private async handleErasure(data: {
+    requestId: string;
+    userId: string;
+    patientId?: string;
+    requestorIdentity?: string;
+    tenantId?: string;
+  }) {
     this.logger.log(`Erasing data for user ${data.userId}`);
     await this.gdprRequestRepository.update(data.requestId, {
       status: GdprRequestStatus.IN_PROGRESS,
     });
 
+    const policy = this.dataRetentionService?.getEffectivePolicy(data.tenantId ?? null, 'medical_records');
+    const action = policy?.action ?? 'anonymize';
+
     try {
+      await this.complianceLogRepository.save(
+        this.complianceLogRepository.create({
+          requestId: data.requestId,
+          patientId: data.patientId,
+          tenantId: data.tenantId,
+          operator: data.requestorIdentity,
+          scope: `gdpr-erasure:${action}`,
+          details: {
+            action: 'ERASURE_STARTED',
+            tenantId: data.tenantId,
+            requestorIdentity: data.requestorIdentity,
+            retentionAction: action,
+          },
+        }),
+      );
       // Captured before the cascade anonymises/deletes the user record, so we can
       // still notify the data subject once erasure completes.
       const dataSubjectUser = await this.userRepository.findOne({ where: { id: data.userId } });
@@ -315,6 +354,22 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
 
       // 3. Run all registered deletion handlers in a single transaction
       await this.deletionRegistry.deleteAllForUser(data.userId);
+
+      await this.complianceLogRepository.save(
+        this.complianceLogRepository.create({
+          requestId: data.requestId,
+          patientId: data.patientId,
+          tenantId: data.tenantId,
+          operator: data.requestorIdentity,
+          scope: `gdpr-erasure:${action}`,
+          details: {
+            action: 'ERASURE_COMPLETED',
+            tenantId: data.tenantId,
+            requestorIdentity: data.requestorIdentity,
+            retentionAction: action,
+          },
+        }),
+      );
 
       // 4. Notify Data Protection Officer
       try {

--- a/src/gdpr/services/gdpr.service.ts
+++ b/src/gdpr/services/gdpr.service.ts
@@ -4,7 +4,9 @@ import { Repository, In } from 'typeorm';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bullmq';
 import { GdprRequest, GdprRequestType, GdprRequestStatus } from '../entities/gdpr-request.entity';
+import { GdprComplianceLog } from '../entities/gdpr-compliance-log.entity';
 import { DeletionPreviewEntry, DeletionRegistryService } from './deletion-registry.service';
+import { CreateErasureRequestDto } from '../dto/create-erasure-request.dto';
 
 @Injectable()
 export class GdprService {
@@ -13,6 +15,8 @@ export class GdprService {
   constructor(
     @InjectRepository(GdprRequest)
     private readonly gdprRequestRepository: Repository<GdprRequest>,
+    @InjectRepository(GdprComplianceLog)
+    private readonly complianceLogRepository: Repository<GdprComplianceLog>,
     @InjectQueue('gdpr') private gdprQueue: Queue,
     private readonly deletionRegistry: DeletionRegistryService,
   ) {}
@@ -55,7 +59,10 @@ export class GdprService {
     return request;
   }
 
-  async createErasureRequest(userId: string): Promise<GdprRequest> {
+  async createErasureRequest(
+    userId: string,
+    dto: CreateErasureRequestDto = {} as CreateErasureRequestDto,
+  ): Promise<GdprRequest> {
     const existingRequest = await this.gdprRequestRepository.findOne({
       where: {
         userId,
@@ -72,16 +79,36 @@ export class GdprService {
 
     const request = this.gdprRequestRepository.create({
       userId,
+      patientId: dto.patientId,
+      requestorIdentity: dto.requestorIdentity,
+      tenantId: dto.tenantId,
       type: GdprRequestType.ERASURE,
       status: GdprRequestStatus.PENDING,
     });
 
     await this.gdprRequestRepository.save(request);
 
-    // Add to BullMQ
+    await this.complianceLogRepository.save(
+      this.complianceLogRepository.create({
+        requestId: request.id,
+        patientId: dto.patientId,
+        tenantId: dto.tenantId,
+        operator: dto.requestorIdentity,
+        scope: 'gdpr-erasure-request',
+        details: {
+          action: 'ERASURE_REQUESTED',
+          requestorIdentity: dto.requestorIdentity,
+          tenantId: dto.tenantId,
+        },
+      }),
+    );
+
     await this.gdprQueue.add('erase-data', {
       requestId: request.id,
       userId,
+      patientId: dto.patientId,
+      requestorIdentity: dto.requestorIdentity,
+      tenantId: dto.tenantId,
     });
 
     this.logger.log(`Erasure request ${request.id} queued for user ${userId}`);

--- a/src/gdpr/tests/gdpr.controller.spec.ts
+++ b/src/gdpr/tests/gdpr.controller.spec.ts
@@ -3,7 +3,9 @@ import { GdprController } from '../controllers/gdpr.controller';
 import { GdprService } from '../services/gdpr.service';
 import { ExecutionContext } from '@nestjs/common';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ThrottlerBehindProxyGuard } from '../../common/throttler/throttler-behind-proxy.guard';
 import { GdprRequestType, GdprRequestStatus } from '../entities/gdpr-request.entity';
+import { CreateErasureRequestDto } from '../dto/create-erasure-request.dto';
 
 describe('GdprController', () => {
   let controller: GdprController;
@@ -37,6 +39,10 @@ describe('GdprController', () => {
       .useValue({
         canActivate: (context: ExecutionContext) => true,
       })
+      .overrideGuard(ThrottlerBehindProxyGuard)
+      .useValue({
+        canActivate: (context: ExecutionContext) => true,
+      })
       .compile();
 
     controller = module.get<GdprController>(GdprController);
@@ -59,8 +65,12 @@ describe('GdprController', () => {
   describe('requestErasure', () => {
     it('should call gdprService.createErasureRequest', async () => {
       const req = { user: { id: 'user1' } };
-      const res = await controller.requestErasure(req);
-      expect(mockGdprService.createErasureRequest).toHaveBeenCalledWith('user1');
+      const payload: CreateErasureRequestDto = {
+        patientId: 'patient-1',
+        requestorIdentity: 'operator-1',
+      };
+      const res = await controller.requestErasure(req, payload);
+      expect(mockGdprService.createErasureRequest).toHaveBeenCalledWith('user1', payload);
       expect(res.id).toEqual('2');
     });
   });

--- a/src/gdpr/tests/gdpr.processor.spec.ts
+++ b/src/gdpr/tests/gdpr.processor.spec.ts
@@ -1,3 +1,15 @@
+jest.mock('../../medical-records/entities/medical-record.entity', () => ({
+  MedicalRecord: class MedicalRecord {},
+}));
+
+jest.mock('../../data-retention/data-retention.service', () => ({
+  DataRetentionService: class DataRetentionService {
+    getEffectivePolicy() {
+      return { retentionYears: 7, action: 'anonymize' };
+    }
+  },
+}));
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { GdprProcessor } from '../processors/gdpr.processor';
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -11,6 +23,9 @@ import { AuditLogEntity } from '../../common/audit/audit-log.entity';
 import { IpfsService } from '../../records/services/ipfs.service';
 import { NotificationsService } from '../../notifications/services/notifications.service';
 import { Job } from 'bullmq';
+import { DeletionRegistryService } from '../services/deletion-registry.service';
+import { DataRetentionService } from '../../data-retention/data-retention.service';
+import { GdprComplianceLog } from '../entities/gdpr-compliance-log.entity';
 
 describe('GdprProcessor', () => {
   let processor: GdprProcessor;
@@ -20,6 +35,7 @@ describe('GdprProcessor', () => {
     find: jest.fn().mockResolvedValue([]),
     findOne: jest.fn().mockResolvedValue(null),
     save: jest.fn().mockResolvedValue({}),
+    create: jest.fn().mockImplementation((dto) => dto),
   };
 
   const mockIpfsService = {
@@ -42,8 +58,18 @@ describe('GdprProcessor', () => {
         { provide: getRepositoryToken(MedicalRecord), useValue: mockRepo },
         { provide: getRepositoryToken(AccessGrant), useValue: mockRepo },
         { provide: getRepositoryToken(AuditLogEntity), useValue: mockRepo },
+        { provide: getRepositoryToken(GdprComplianceLog), useValue: mockRepo },
         { provide: IpfsService, useValue: mockIpfsService },
         { provide: NotificationsService, useValue: mockNotificationsService },
+        { provide: DataRetentionService, useValue: { getEffectivePolicy: jest.fn().mockReturnValue({ retentionYears: 7, action: 'anonymize' }) } },
+        {
+          provide: DeletionRegistryService,
+          useValue: {
+            register: jest.fn(),
+            previewForUser: jest.fn().mockResolvedValue([]),
+            deleteAllForUser: jest.fn().mockResolvedValue(undefined),
+          },
+        },
       ],
     }).compile();
 
@@ -86,6 +112,62 @@ describe('GdprProcessor', () => {
       expect(mockRepo.update).toHaveBeenCalledWith(
         'req2',
         expect.objectContaining({ status: GdprRequestStatus.COMPLETED }),
+      );
+    });
+
+    it('anonymizes user and patient fields via the registered erasure handlers', async () => {
+      const registry: any = {
+        handlers: [],
+        register: jest.fn((handler: any) => registry.handlers.push(handler)),
+        previewForUser: jest.fn().mockResolvedValue([]),
+        deleteAllForUser: jest.fn().mockResolvedValue(undefined),
+      };
+      const manager = {
+        findOne: jest.fn().mockImplementation((entity) => {
+          if (entity === User) {
+            return { id: 'user-1', firstName: 'Jane', lastName: 'Doe', displayName: 'Jane', email: 'jane@example.com', phone: '123', npi: 'npi', licenseNumber: 'lic' };
+          }
+          if (entity === Patient) {
+            return { id: 'user-1', firstName: 'Jane', lastName: 'Doe', middleName: 'M', email: 'jane@example.com', phone: '123', address: '1 Main', dateOfBirth: '1990-01-01', nationalId: '123' };
+          }
+          return null;
+        }),
+        save: jest.fn().mockResolvedValue(true),
+      };
+
+      const module = await Test.createTestingModule({
+        providers: [
+          GdprProcessor,
+          { provide: getRepositoryToken(GdprRequest), useValue: mockRepo },
+          { provide: getRepositoryToken(User), useValue: mockRepo },
+          { provide: getRepositoryToken(Patient), useValue: mockRepo },
+          { provide: getRepositoryToken(Record), useValue: mockRepo },
+          { provide: getRepositoryToken(MedicalRecord), useValue: mockRepo },
+          { provide: getRepositoryToken(AccessGrant), useValue: mockRepo },
+          { provide: getRepositoryToken(AuditLogEntity), useValue: mockRepo },
+          { provide: getRepositoryToken(GdprComplianceLog), useValue: mockRepo },
+          { provide: IpfsService, useValue: mockIpfsService },
+          { provide: NotificationsService, useValue: mockNotificationsService },
+          { provide: DataRetentionService, useValue: { getEffectivePolicy: jest.fn().mockReturnValue({ retentionYears: 7, action: 'anonymize' }) } },
+          { provide: DeletionRegistryService, useValue: registry },
+        ],
+      }).compile();
+
+      const processorWithRegistry = module.get<GdprProcessor>(GdprProcessor);
+      processorWithRegistry.onModuleInit();
+
+      const handler = (registry as any).handlers?.find((entry: any) => entry.moduleName === 'users');
+      await handler.deleteForUser('user-1', manager as any);
+      expect(manager.save).toHaveBeenCalledWith(
+        User,
+        expect.objectContaining({ email: expect.stringContaining('@anonymized.local') }),
+      );
+
+      const patientHandler = (registry as any).handlers?.find((entry: any) => entry.moduleName === 'patients');
+      await patientHandler.deleteForUser('user-1', manager as any);
+      expect(manager.save).toHaveBeenCalledWith(
+        Patient,
+        expect.objectContaining({ firstName: expect.stringContaining('hash:') }),
       );
     });
   });

--- a/src/gdpr/tests/gdpr.service.spec.ts
+++ b/src/gdpr/tests/gdpr.service.spec.ts
@@ -2,8 +2,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { GdprService } from '../services/gdpr.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { GdprRequest, GdprRequestType, GdprRequestStatus } from '../entities/gdpr-request.entity';
+import { GdprComplianceLog } from '../entities/gdpr-compliance-log.entity';
 import { getQueueToken } from '@nestjs/bull';
 import { ConflictException } from '@nestjs/common';
+import { DeletionRegistryService } from '../services/deletion-registry.service';
+import { CreateErasureRequestDto } from '../dto/create-erasure-request.dto';
 
 describe('GdprService', () => {
   let service: GdprService;
@@ -19,7 +22,20 @@ describe('GdprService', () => {
     add: jest.fn().mockResolvedValue(true),
   };
 
+  const mockComplianceLogRepo = {
+    create: jest.fn().mockImplementation((dto) => ({ id: 'log-1', ...dto })),
+    save: jest.fn().mockResolvedValue(true),
+  };
+
+  const mockDeletionRegistry = {
+    previewForUser: jest.fn().mockResolvedValue([]),
+    deleteAllForUser: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(async () => {
+    jest.clearAllMocks();
+    mockGdprRequestRepo.findOne.mockResolvedValue(null);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GdprService,
@@ -30,6 +46,14 @@ describe('GdprService', () => {
         {
           provide: getQueueToken('gdpr'),
           useValue: mockGdprQueue,
+        },
+        {
+          provide: getRepositoryToken(GdprComplianceLog),
+          useValue: mockComplianceLogRepo,
+        },
+        {
+          provide: DeletionRegistryService,
+          useValue: mockDeletionRegistry,
         },
       ],
     }).compile();
@@ -79,14 +103,24 @@ describe('GdprService', () => {
 
   describe('createErasureRequest', () => {
     it('should create an erasure request and add to queue', async () => {
-      const req = await service.createErasureRequest('user1');
+      const payload: CreateErasureRequestDto = {
+        patientId: 'patient-1',
+        requestorIdentity: 'operator-1',
+        tenantId: 'tenant-1',
+      };
+
+      const req = await service.createErasureRequest('user1', payload);
       expect(req).toBeDefined();
       expect(req.type).toBe(GdprRequestType.ERASURE);
       expect(req.status).toBe(GdprRequestStatus.PENDING);
       expect(mockGdprRequestRepo.save).toHaveBeenCalled();
+      expect(mockComplianceLogRepo.save).toHaveBeenCalled();
       expect(mockGdprQueue.add).toHaveBeenCalledWith('erase-data', {
         requestId: req.id,
         userId: 'user1',
+        patientId: 'patient-1',
+        requestorIdentity: 'operator-1',
+        tenantId: 'tenant-1',
       });
     });
 


### PR DESCRIPTION
# Implement GDPR erasure request pipeline

## Summary
This PR adds an end-to-end GDPR Article 17 erasure-request flow to the backend.

### What changed
- Added a new erasure request endpoint for submitting GDPR deletion/anonymization requests
- Queued erasure jobs asynchronously for processing outside the request lifecycle
- Implemented anonymization/deletion handling for personal data related to patient/user records
- Added compliance logging for erasure actions with request scope and operator context
- Extended the existing GDPR module to support the new request lifecycle and tenant-aware payload handling

### Why
This enables the system to accept and process erasure requests in a structured, auditable way and aligns the backend with GDPR right-to-erasure requirements.

### Verification
The following tests were run successfully:
- pnpm exec jest --selectProjects unit --runInBand --runTestsByPath gdpr.service.spec.ts gdpr.controller.spec.ts gdpr.processor.spec.ts

Closes: #754