### PR TITLE
docs: document missing environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ NODE_ENV=development
 # HTTP port the server listens on.
 PORT=3000
 
+# Alternate port variable read by tenant-provisioning workflow.
+APP_PORT=3000
+
 # Human-readable application name (used in logs and emails).
 APP_NAME=Healthy Stellar
 
@@ -57,6 +60,8 @@ DB_NAME=healthy_stellar_dev
 
 # SSL (HIPAA requirement in production — set DB_SSL_ENABLED=true).
 DB_SSL_ENABLED=false
+# Legacy SSL toggle read by query-performance profiling module.
+DB_SSL=false
 # Paths to SSL certificates (leave blank for local dev).
 DB_SSL_CA=
 DB_SSL_CERT=
@@ -67,6 +72,8 @@ DB_SSL_KEY=
 # Development: min=2 max=10 | Staging: min=5 max=20 | Production: min=10 max=50
 DB_POOL_MIN=2
 DB_POOL_MAX=10
+# Legacy pool-size knob read by query-performance profiling module.
+DB_POOL_SIZE=10
 DB_CONNECTION_TIMEOUT_MS=2000
 DB_IDLE_TIMEOUT_MS=30000
 # Pool utilisation threshold (0.0–1.0). Requests are rejected above this level.
@@ -97,6 +104,55 @@ REQUEST_TIMEOUT_MS=30000
 # DB_REPLICA_NAME=
 # DB_REPLICA_POOL_MIN=1
 # DB_REPLICA_POOL_MAX=5
+
+
+# =============================================================================
+# Data Residency — Regional Database, Stellar, and IPFS Endpoints
+# =============================================================================
+# Default region for tenant / patient data placement.
+# Values: eu | us | apac | africa
+DEFAULT_REGION=eu
+
+# EU region.
+DB_TYPE_EU=postgres
+DB_HOST_EU=
+DB_PORT_EU=5432
+DB_NAME_EU=healthy_stellar_eu
+# Either EU_DB_URL or DB_URL_EU can be used by the data-residency config.
+EU_DB_URL=
+DB_URL_EU=
+STELLAR_HORIZON_EU_URL=https://horizon.eu.stellar.org
+IPFS_NODES_EU=https://ipfs-eu-1.infura.io:5001
+
+# US region.
+DB_TYPE_US=postgres
+DB_HOST_US=
+DB_PORT_US=5432
+DB_NAME_US=healthy_stellar_us
+US_DB_URL=
+DB_URL_US=
+STELLAR_HORIZON_US_URL=https://horizon.us.stellar.org
+IPFS_NODES_US=https://ipfs-us-1.infura.io:5001
+
+# APAC region.
+DB_TYPE_APAC=postgres
+DB_HOST_APAC=
+DB_PORT_APAC=5432
+DB_NAME_APAC=healthy_stellar_apac
+APAC_DB_URL=
+DB_URL_APAC=
+STELLAR_HORIZON_APAC_URL=https://horizon.apac.stellar.org
+IPFS_NODES_APAC=https://ipfs-apac-1.infura.io:5001
+
+# Africa region.
+DB_TYPE_AFRICA=postgres
+DB_HOST_AFRICA=
+DB_PORT_AFRICA=5432
+DB_NAME_AFRICA=healthy_stellar_africa
+AFRICA_DB_URL=
+DB_URL_AFRICA=
+STELLAR_HORIZON_AFRICA_URL=https://horizon.africa.stellar.org
+IPFS_NODES_AFRICA=https://ipfs-africa-1.infura.io:5001
 
 
 # =============================================================================
@@ -213,6 +269,10 @@ RATE_LIMIT_MAX=100
 GRAPHQL_MAX_SUBSCRIPTIONS_PER_USER=10
 GRAPHQL_MAX_SUBSCRIPTIONS_PER_TENANT=100
 
+# GraphQL query DoS guardrails.
+GRAPHQL_MAX_QUERY_DEPTH=7
+GRAPHQL_QUERY_COMPLEXITY_THRESHOLD=150
+
 
 # =============================================================================
 # Email (SMTP)
@@ -225,6 +285,11 @@ MAIL_USER=your_email@example.com
 # REQUIRED for email delivery
 MAIL_PASSWORD=your_email_password
 MAIL_FROM=noreply@healthystellar.com
+
+# Optional outbound billing / notification controls.
+ENABLE_EMAIL_NOTIFICATIONS=false
+BILLING_NOTIFICATIONS_EMAIL=billing@healthystellar.com
+CHARGE_NURSE_ALERT_EMAIL=charge-nurse@healthystellar.com
 
 
 # =============================================================================
@@ -384,6 +449,15 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
 # Sampling rate (0.0–1.0). Use 1.0 for dev, 0.1 for production.
 OTEL_SAMPLING_RATE=1.0
 
+# Optional OTLP exporter headers as a JSON object string.
+# Example: {"Authorization":"Bearer token"}
+OTEL_EXPORTER_OTLP_HEADERS=
+OTEL_EXPORTER_OTLP_TIMEOUT=10000
+
+# Optional host identifier included in logs, cache invalidation, and traces.
+# Usually provided by the platform in production.
+HOSTNAME=localhost
+
 
 # =============================================================================
 # Backup & Disaster Recovery
@@ -395,6 +469,9 @@ BACKUP_DIR=/backups
 BACKUP_RETENTION_DAYS=90
 # REQUIRED — used to encrypt backup archives at rest.
 BACKUP_ENCRYPTION_KEY=your_backup_encryption_key_here
+
+# Administrative email used by backup verification alerts.
+ADMIN_EMAIL=admin@healthystellar.io
 
 # Pre-migration backup settings.
 MIGRATION_BACKUP_ENABLED=true
@@ -414,6 +491,8 @@ MIGRATION_BACKUP_BLOCK_ON_FAILURE=true
 # Identity logged in the migration audit trail.
 # Falls back to GITHUB_ACTOR, then the OS USER environment variable.
 # MIGRATION_EXECUTOR=your_name
+# GITHUB_ACTOR=github-actions
+# USER=local-user
 
 # Slack notifications for migration events.
 # MIGRATION_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/your/webhook/url
@@ -430,6 +509,9 @@ MIGRATION_SLACK_ALL_ENVS=false
 SWAGGER_USER=admin
 SWAGGER_PASS=change_me_in_production
 
+# API base URL used by generated SDK helper scripts.
+MEDCHAIN_API_URL=http://localhost:3000/v1
+
 
 # =============================================================================
 # File Uploads
@@ -442,8 +524,17 @@ UPLOAD_PATH=./storage/uploads
 # =============================================================================
 # FHIR & Bulk Export
 # =============================================================================
+# Base URL used in SMART-on-FHIR fhirUser claims and OAuth metadata.
+FHIR_BASE_URL=http://localhost:3000
+
 # Rows fetched per batch during FHIR bulk export.
 BULK_EXPORT_BATCH_SIZE=500
+
+# REQUIRED in production — secret used to sign generated bulk-export download URLs.
+EXPORT_SIGNING_SECRET=your_export_signing_secret_here
+
+# Signed bulk-export URL lifetime in seconds.
+EXPORT_URL_TTL_S=3600
 
 # Data retention for medical records (legal minimum varies by jurisdiction).
 RECORD_RETENTION_YEARS=7
@@ -458,6 +549,9 @@ SNAPSHOT_RETENTION_COUNT=3
 # =============================================================================
 HIPAA_COMPLIANCE_ENABLED=true
 
+# Directory where compliance report artifacts are written.
+COMPLIANCE_REPORT_STORAGE_DIR=./storage/compliance-reports
+
 
 # =============================================================================
 # Optional Module Feature Flags
@@ -469,9 +563,32 @@ TELEMEDICINE_ENABLED=false
 # Telemedicine service base URL (required when TELEMEDICINE_ENABLED=true).
 TELEMEDICINE_BASE_URL=https://telemedicine.app
 
+# Telemedicine recording storage and signed playback/download URLs.
+TELEMEDICINE_RECORDING_STORAGE_DIR=./storage/telemedicine-recordings
+TELEMEDICINE_RECORDING_RETENTION_DAYS=90
+TELEMEDICINE_RECORDING_URL_TTL_S=900
+# REQUIRED in production — secret used to sign recording URLs.
+TELEMEDICINE_RECORDING_SIGNING_SECRET=your_telemedicine_recording_signing_secret_here
+
 # Surgical Management — surgical cases, operating rooms, outcomes.
 # Set to true to enable surgical management endpoints.
 SURGICAL_MANAGEMENT_ENABLED=false
+
+
+# =============================================================================
+# Billing & Invoicing
+# =============================================================================
+# Directory where generated invoice PDFs are stored.
+INVOICE_STORAGE_DIR=./storage/invoices
+
+# REQUIRED in production — secret used to sign generated invoice PDF URLs.
+INVOICE_SIGNING_SECRET=your_invoice_signing_secret_here
+
+# Signed invoice URL lifetime in seconds.
+INVOICE_URL_TTL_S=3600
+
+# Default invoice tax rate as a decimal fraction (0.0825 = 8.25%).
+INVOICE_TAX_RATE=0
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Updated `.env.example` to document environment variables currently referenced from `src/`
- Added missing config for data residency, GraphQL guards, FHIR exports, invoicing, telemedicine recordings, tracing, backups, migration metadata, and SDK helper scripts
- Included production-sensitive secrets as placeholders or commented examples where appropriate

## Verification
- Ran a script comparing `process.env.*` usage in `src/` against `.env.example`
- Result: `used 138 documented 230 missing 0`

close #786 