### PR TITLE
GDPR: aggregate DSAR export into FHIR bundle with signed download link

### DIFF
--- a/src/fhir/utils/signed-url.util.ts
+++ b/src/fhir/utils/signed-url.util.ts
@@ -28,20 +28,33 @@ export function generateSignedUrl(
 }
 
 /**
+ * Generate a time-limited, HMAC-SHA256-signed download URL for a GDPR DSAR
+ * export bundle. Reuses the same signing scheme (path:expiresAt HMAC) as the
+ * FHIR bulk-export signed URLs.
+ */
+export function generateGdprExportSignedUrl(requestId: string): string {
+  const expiresAt = Math.floor(Date.now() / 1000) + SIGNED_URL_TTL_S;
+  const path = `/gdpr/export-files/${requestId}/dsar-bundle.json`;
+  const payload = `${path}:${expiresAt}`;
+  const sig = crypto.createHmac('sha256', SIGNING_SECRET).update(payload).digest('hex');
+  return `${path}?expires=${expiresAt}&sig=${sig}`;
+}
+
+/**
  * Verify a signed export URL.
  * Returns true when the signature is valid and the URL has not expired.
  */
 export function verifySignedUrl(url: string): boolean {
   try {
     const parsed = new URL(url, 'http://localhost');
-    const sig     = parsed.searchParams.get('sig');
+    const sig = parsed.searchParams.get('sig');
     const expires = parsed.searchParams.get('expires');
     if (!sig || !expires) return false;
 
     const expiresAt = parseInt(expires, 10);
     if (Date.now() / 1000 > expiresAt) return false;
 
-    const path    = parsed.pathname;
+    const path = parsed.pathname;
     const payload = `${path}:${expiresAt}`;
     const expected = crypto.createHmac('sha256', SIGNING_SECRET).update(payload).digest('hex');
 

--- a/src/gdpr/controllers/gdpr.controller.ts
+++ b/src/gdpr/controllers/gdpr.controller.ts
@@ -14,7 +14,7 @@ import { CreateErasureRequestDto } from '../dto/create-erasure-request.dto';
 export class GdprController {
   constructor(private readonly gdprService: GdprService) {}
 
-  @Post('data-export-request')
+  @Post(['data-export-request', 'export-request'])
   @HttpCode(HttpStatus.ACCEPTED)
   @RateLimit(5, 60)
   @ApiOperation({ summary: 'Request a full export of user data' })

--- a/src/gdpr/gdpr.module.ts
+++ b/src/gdpr/gdpr.module.ts
@@ -21,6 +21,10 @@ import { MedicalRecord } from '../medical-records/entities/medical-record.entity
 import { AccessGrant } from '../access-control/entities/access-grant.entity';
 import { AuditLogEntity } from '../common/audit/audit-log.entity';
 import { GdprComplianceLog } from './entities/gdpr-compliance-log.entity';
+import { Billing } from '../billing/entities/billing.entity';
+import { LabOrder } from '../laboratory/entities/lab-order.entity';
+import { Specimen } from '../laboratory/entities/specimen.entity';
+import { LabResult } from '../laboratory/entities/lab-result.entity';
 
 @Module({
   imports: [
@@ -33,6 +37,10 @@ import { GdprComplianceLog } from './entities/gdpr-compliance-log.entity';
       AccessGrant,
       AuditLogEntity,
       GdprComplianceLog,
+      Billing,
+      LabOrder,
+      Specimen,
+      LabResult,
     ]),
     BullModule.registerQueue({
       name: 'gdpr',

--- a/src/gdpr/processors/gdpr.processor.ts
+++ b/src/gdpr/processors/gdpr.processor.ts
@@ -25,6 +25,9 @@ import { IpfsService } from '../../records/services/ipfs.service';
 import { NotificationsService } from '../../notifications/services/notifications.service';
 import { DeletionRegistryService } from '../services/deletion-registry.service';
 import { DataRetentionService } from '../../data-retention/data-retention.service';
+import { Billing } from '../../billing/entities/billing.entity';
+import { generateGdprExportSignedUrl } from '../../fhir/utils/signed-url.util';
+import { FhirMapper } from '../../fhir/mappers/fhir.mapper';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -45,6 +48,10 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
     private readonly auditLogRepository: Repository<AuditLogEntity>,
     @InjectRepository(GdprComplianceLog)
     private readonly complianceLogRepository: Repository<GdprComplianceLog>,
+    @InjectRepository(Billing) private readonly billingRepository: Repository<Billing>,
+    @InjectRepository(LabOrder) private readonly labOrderRepository: Repository<LabOrder>,
+    @InjectRepository(Specimen) private readonly specimenRepository: Repository<Specimen>,
+    @InjectRepository(LabResult) private readonly labResultRepository: Repository<LabResult>,
     private readonly ipfsService: IpfsService,
     private readonly notificationsService: NotificationsService,
     private readonly deletionRegistry: DeletionRegistryService,
@@ -93,7 +100,8 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
 
     this.deletionRegistry.register({
       moduleName: 'records',
-      previewForUser: async (userId, manager) => manager.count(Record, { where: { patientId: userId } }),
+      previewForUser: async (userId, manager) =>
+        manager.count(Record, { where: { patientId: userId } }),
       deleteForUser: async (userId, manager) => {
         await manager.delete(Record, { patientId: userId });
       },
@@ -125,7 +133,11 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
         await manager.update(
           AccessGrant,
           { patientId: userId, status: GrantStatus.ACTIVE },
-          { status: GrantStatus.REVOKED, revokedAt: new Date(), revocationReason: 'GDPR Right to Erasure' },
+          {
+            status: GrantStatus.REVOKED,
+            revokedAt: new Date(),
+            revocationReason: 'GDPR Right to Erasure',
+          },
         );
       },
     });
@@ -235,21 +247,56 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
         where: { patientId: data.userId },
       });
       const auditLogEntity = await this.auditLogRepository.find({ where: { userId: data.userId } });
+      const billingRecords = await this.billingRepository.find({
+        where: { patientId: data.userId },
+      });
+      const labOrders = await this.labOrderRepository.find({ where: { patientId: data.userId } });
+      const specimens = await this.specimenRepository.find({ where: { patientId: data.userId } });
+      const orderRefs = labOrders.flatMap((o) => [o.id, (o as any).orderNumber].filter(Boolean));
+      const labResults = orderRefs.length
+        ? await this.labResultRepository.find({ where: { orderId: In(orderRefs) } })
+        : [];
 
-      const exportData = {
-        profile: user,
-        patient,
-        records,
-        medicalRecords,
-        accessGrants,
-        auditLogEntity, // Audit logs might contain Stellar transaction hashes
+      const toBasicResource = (moduleName: string, id: string, source: unknown) => ({
+        resource: {
+          resourceType: 'Basic',
+          id,
+          code: { text: moduleName },
+          extension: [
+            {
+              url: 'https://healthystellar.com/fhir/StructureDefinition/dsar-source-data',
+              valueString: JSON.stringify(source),
+            },
+          ],
+        },
+      });
+
+      const entry = [
+        ...(patient ? [{ resource: FhirMapper.toPatient(patient) }] : []),
+        ...medicalRecords.map((r) => ({ resource: FhirMapper.toDocumentReference(r) })),
+        ...records.map((r) => toBasicResource('records', r.id, r)),
+        ...accessGrants.map((g) => toBasicResource('access-grants', g.id, g)),
+        ...auditLogEntity.map((a) => toBasicResource('audit-logs', a.id, a)), // Audit logs might contain Stellar transaction hashes
+        ...billingRecords.map((b) => toBasicResource('billing', b.id, b)),
+        ...labOrders.map((o) => toBasicResource('laboratory-orders', o.id, o)),
+        ...specimens.map((s) => toBasicResource('laboratory-specimens', s.id, s)),
+        ...labResults.map((r) => toBasicResource('laboratory-results', r.id, r)),
+      ];
+
+      const bundle = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        timestamp: new Date().toISOString(),
+        entry,
       };
 
       const tmpDir = os.tmpdir();
       const fileName = `gdpr-export-${data.userId}-${Date.now()}.json`;
       const filePath = path.join(tmpDir, fileName);
 
-      fs.writeFileSync(filePath, JSON.stringify(exportData, null, 2));
+      fs.writeFileSync(filePath, JSON.stringify(bundle, null, 2));
+
+      const signedUrl = generateGdprExportSignedUrl(data.requestId);
 
       // Simulate sending email via NotificationsService
       if (user?.email) {
@@ -259,20 +306,20 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
             user.email,
             'Your GDPR Data Export',
             'ExportReady',
-            { link: `https://api.healthystellar.com/downloads/${fileName}` },
+            { link: signedUrl },
           );
         } else if ((this.notificationsService as any).sendPatientEmailNotification) {
           await (this.notificationsService as any).sendPatientEmailNotification(
             data.userId,
             'Your GDPR Data Export',
-            `Your export is ready at: https://api.healthystellar.com/downloads/${fileName}`,
+            `Your export is ready at: ${signedUrl}`,
           );
         }
       }
 
       await this.gdprRequestRepository.update(data.requestId, {
         status: GdprRequestStatus.COMPLETED,
-        fileUrl: filePath,
+        fileUrl: signedUrl,
         completedAt: new Date(),
       });
     } catch (e) {
@@ -296,7 +343,10 @@ export class GdprProcessor extends WorkerHost implements OnModuleInit {
       status: GdprRequestStatus.IN_PROGRESS,
     });
 
-    const policy = this.dataRetentionService?.getEffectivePolicy(data.tenantId ?? null, 'medical_records');
+    const policy = this.dataRetentionService?.getEffectivePolicy(
+      data.tenantId ?? null,
+      'medical_records',
+    );
     const action = policy?.action ?? 'anonymize';
 
     try {

--- a/src/gdpr/tests/gdpr.processor.spec.ts
+++ b/src/gdpr/tests/gdpr.processor.spec.ts
@@ -26,6 +26,11 @@ import { Job } from 'bullmq';
 import { DeletionRegistryService } from '../services/deletion-registry.service';
 import { DataRetentionService } from '../../data-retention/data-retention.service';
 import { GdprComplianceLog } from '../entities/gdpr-compliance-log.entity';
+import { Billing } from '../../billing/entities/billing.entity';
+import { LabOrder } from '../../laboratory/entities/lab-order.entity';
+import * as fs from 'fs';
+import { Specimen } from '../../laboratory/entities/specimen.entity';
+import { LabResult } from '../../laboratory/entities/lab-result.entity';
 
 describe('GdprProcessor', () => {
   let processor: GdprProcessor;
@@ -59,9 +64,20 @@ describe('GdprProcessor', () => {
         { provide: getRepositoryToken(AccessGrant), useValue: mockRepo },
         { provide: getRepositoryToken(AuditLogEntity), useValue: mockRepo },
         { provide: getRepositoryToken(GdprComplianceLog), useValue: mockRepo },
+        { provide: getRepositoryToken(Billing), useValue: mockRepo },
+        { provide: getRepositoryToken(LabOrder), useValue: mockRepo },
+        { provide: getRepositoryToken(Specimen), useValue: mockRepo },
+        { provide: getRepositoryToken(LabResult), useValue: mockRepo },
         { provide: IpfsService, useValue: mockIpfsService },
         { provide: NotificationsService, useValue: mockNotificationsService },
-        { provide: DataRetentionService, useValue: { getEffectivePolicy: jest.fn().mockReturnValue({ retentionYears: 7, action: 'anonymize' }) } },
+        {
+          provide: DataRetentionService,
+          useValue: {
+            getEffectivePolicy: jest
+              .fn()
+              .mockReturnValue({ retentionYears: 7, action: 'anonymize' }),
+          },
+        },
         {
           provide: DeletionRegistryService,
           useValue: {
@@ -96,6 +112,110 @@ describe('GdprProcessor', () => {
         expect.objectContaining({ status: GdprRequestStatus.COMPLETED }),
       );
     });
+
+    it('aggregates records from medical-records, billing, and laboratory into a FHIR bundle with a signed download link', async () => {
+      const writeFileSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          GdprProcessor,
+          { provide: getRepositoryToken(GdprRequest), useValue: mockRepo },
+          { provide: getRepositoryToken(User), useValue: mockRepo },
+          { provide: getRepositoryToken(Patient), useValue: mockRepo },
+          { provide: getRepositoryToken(Record), useValue: mockRepo },
+          {
+            provide: getRepositoryToken(MedicalRecord),
+            useValue: {
+              ...mockRepo,
+              find: jest.fn().mockResolvedValue([{ id: 'mr-1', patientId: 'user1' }]),
+            },
+          },
+          { provide: getRepositoryToken(AccessGrant), useValue: mockRepo },
+          { provide: getRepositoryToken(AuditLogEntity), useValue: mockRepo },
+          { provide: getRepositoryToken(GdprComplianceLog), useValue: mockRepo },
+          {
+            provide: getRepositoryToken(Billing),
+            useValue: {
+              ...mockRepo,
+              find: jest.fn().mockResolvedValue([{ id: 'bill-1', patientId: 'user1' }]),
+            },
+          },
+          {
+            provide: getRepositoryToken(LabOrder),
+            useValue: {
+              ...mockRepo,
+              find: jest
+                .fn()
+                .mockResolvedValue([
+                  { id: 'lab-order-1', patientId: 'user1', orderNumber: 'LO-1' },
+                ]),
+            },
+          },
+          { provide: getRepositoryToken(Specimen), useValue: mockRepo },
+          {
+            provide: getRepositoryToken(LabResult),
+            useValue: {
+              ...mockRepo,
+              find: jest.fn().mockResolvedValue([{ id: 'lab-result-1', orderId: 'lab-order-1' }]),
+            },
+          },
+          { provide: IpfsService, useValue: mockIpfsService },
+          { provide: NotificationsService, useValue: mockNotificationsService },
+          {
+            provide: DataRetentionService,
+            useValue: {
+              getEffectivePolicy: jest
+                .fn()
+                .mockReturnValue({ retentionYears: 7, action: 'anonymize' }),
+            },
+          },
+          {
+            provide: DeletionRegistryService,
+            useValue: {
+              register: jest.fn(),
+              previewForUser: jest.fn().mockResolvedValue([]),
+              deleteAllForUser: jest.fn().mockResolvedValue(undefined),
+            },
+          },
+        ],
+      }).compile();
+
+      const multiModuleProcessor = module.get<GdprProcessor>(GdprProcessor);
+      const job = {
+        name: 'export-data',
+        data: { requestId: 'req-multi', userId: 'user1' },
+        id: 'multi',
+      } as any;
+
+      await multiModuleProcessor.process(job);
+
+      const [, writtenContent] = writeFileSpy.mock.calls[0];
+      const bundle = JSON.parse(writtenContent as string);
+      expect(bundle.resourceType).toBe('Bundle');
+      const moduleNames = bundle.entry.map((e: any) =>
+        e.resource.resourceType === 'Basic' ? e.resource.code.text : e.resource.resourceType,
+      );
+      expect(moduleNames).toEqual(
+        expect.arrayContaining([
+          'DocumentReference',
+          'billing',
+          'laboratory-orders',
+          'laboratory-results',
+        ]),
+      );
+
+      expect(mockRepo.update).toHaveBeenCalledWith(
+        'req-multi',
+        expect.objectContaining({
+          status: GdprRequestStatus.COMPLETED,
+          fileUrl: expect.stringMatching(
+            /^\/gdpr\/export-files\/req-multi\/dsar-bundle\.json\?expires=\d+&sig=[a-f0-9]+$/,
+          ),
+        }),
+      );
+
+      writeFileSpy.mockRestore();
+    });
   });
 
   describe('handleErasure', () => {
@@ -125,10 +245,29 @@ describe('GdprProcessor', () => {
       const manager = {
         findOne: jest.fn().mockImplementation((entity) => {
           if (entity === User) {
-            return { id: 'user-1', firstName: 'Jane', lastName: 'Doe', displayName: 'Jane', email: 'jane@example.com', phone: '123', npi: 'npi', licenseNumber: 'lic' };
+            return {
+              id: 'user-1',
+              firstName: 'Jane',
+              lastName: 'Doe',
+              displayName: 'Jane',
+              email: 'jane@example.com',
+              phone: '123',
+              npi: 'npi',
+              licenseNumber: 'lic',
+            };
           }
           if (entity === Patient) {
-            return { id: 'user-1', firstName: 'Jane', lastName: 'Doe', middleName: 'M', email: 'jane@example.com', phone: '123', address: '1 Main', dateOfBirth: '1990-01-01', nationalId: '123' };
+            return {
+              id: 'user-1',
+              firstName: 'Jane',
+              lastName: 'Doe',
+              middleName: 'M',
+              email: 'jane@example.com',
+              phone: '123',
+              address: '1 Main',
+              dateOfBirth: '1990-01-01',
+              nationalId: '123',
+            };
           }
           return null;
         }),
@@ -146,9 +285,20 @@ describe('GdprProcessor', () => {
           { provide: getRepositoryToken(AccessGrant), useValue: mockRepo },
           { provide: getRepositoryToken(AuditLogEntity), useValue: mockRepo },
           { provide: getRepositoryToken(GdprComplianceLog), useValue: mockRepo },
+          { provide: getRepositoryToken(Billing), useValue: mockRepo },
+          { provide: getRepositoryToken(LabOrder), useValue: mockRepo },
+          { provide: getRepositoryToken(Specimen), useValue: mockRepo },
+          { provide: getRepositoryToken(LabResult), useValue: mockRepo },
           { provide: IpfsService, useValue: mockIpfsService },
           { provide: NotificationsService, useValue: mockNotificationsService },
-          { provide: DataRetentionService, useValue: { getEffectivePolicy: jest.fn().mockReturnValue({ retentionYears: 7, action: 'anonymize' }) } },
+          {
+            provide: DataRetentionService,
+            useValue: {
+              getEffectivePolicy: jest
+                .fn()
+                .mockReturnValue({ retentionYears: 7, action: 'anonymize' }),
+            },
+          },
           { provide: DeletionRegistryService, useValue: registry },
         ],
       }).compile();
@@ -156,14 +306,16 @@ describe('GdprProcessor', () => {
       const processorWithRegistry = module.get<GdprProcessor>(GdprProcessor);
       processorWithRegistry.onModuleInit();
 
-      const handler = (registry as any).handlers?.find((entry: any) => entry.moduleName === 'users');
+      const handler = registry.handlers?.find((entry: any) => entry.moduleName === 'users');
       await handler.deleteForUser('user-1', manager as any);
       expect(manager.save).toHaveBeenCalledWith(
         User,
         expect.objectContaining({ email: expect.stringContaining('@anonymized.local') }),
       );
 
-      const patientHandler = (registry as any).handlers?.find((entry: any) => entry.moduleName === 'patients');
+      const patientHandler = registry.handlers?.find(
+        (entry: any) => entry.moduleName === 'patients',
+      );
       await patientHandler.deleteForUser('user-1', manager as any);
       expect(manager.save).toHaveBeenCalledWith(
         Patient,


### PR DESCRIPTION
## Summary
- Adds `POST /gdpr/export-request` as an alias for the existing DSAR export endpoint
- Extends the export job (`GdprProcessor.handleExport`) to also aggregate billing and laboratory records alongside medical-records/records/access-grants/audit-logs
- Packages the aggregated data as a FHIR `Bundle` (Patient/DocumentReference mapped via the existing `FhirMapper`, other modules as `Basic` resources)
- Delivers the export via a time-limited HMAC-signed URL, reusing the signing scheme from the FHIR bulk-export `signed-url.util.ts`
- Audit logging for the DSAR export already existed via the `@AuditLog('GDPR_EXPORT_REQUEST', ...)` decorator on the controller — no change needed there

Closes #851

## Validation performed
- `npx tsc --noEmit` — no new type errors introduced
- `npx eslint --fix` on all changed files — remaining warnings are pre-existing patterns consistent with the rest of this file (e.g. `any`-typed notification service calls)
- `npx jest src/gdpr` — `gdpr.service.spec.ts` and `gdpr.controller.spec.ts` pass. `gdpr.processor.spec.ts` fails to load in this environment due to a **pre-existing, unrelated** issue: `src/billing/entities/*.js` are stale compiled artifacts committed alongside the `.ts` sources, and Jest's `moduleFileExtensions: ['js','json','ts']` resolves the broken `.js` copy instead of the `.ts` source. This is not caused by this PR — the identical failure reproduces on `main` for `src/billing/services/billing.service.spec.ts`, a file this PR never touches. Recommend a separate cleanup PR to remove the stray compiled `.js` files from `src/billing/entities/`.

## Note
`main` (via the Healthy-Stellar/Healthy-Stellar-backend fork) had no local test infra pre-installed; dependencies were installed fresh to validate.