### PR TITLE
Notifications: digest mode for non-critical access-event emails

### DIFF
--- a/src/email-notification-service-for-critical-access-events/.env.example
+++ b/src/email-notification-service-for-critical-access-events/.env.example
@@ -24,3 +24,6 @@ REDIS_PASSWORD=
 
 # Security
 UNSUBSCRIBE_SECRET=change-this-to-a-long-random-secret
+
+# Digest delivery (batches non-critical access-event emails; cron expression)
+EMAIL_DIGEST_CRON=*/30 * * * *

--- a/src/email-notification-service-for-critical-access-events/email-digest-scheduler.service.ts
+++ b/src/email-notification-service-for-critical-access-events/email-digest-scheduler.service.ts
@@ -1,0 +1,71 @@
+// src/queue/email-digest-scheduler.service.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Job, Queue } from 'bullmq';
+import { EMAIL_DIGEST_QUEUE } from './email-queue.module';
+import { MailService, DigestSummary } from './mail.service';
+import { EmailLookupService } from './email-lookup.service';
+import { EmailJobData, EmailJobType } from './email-queue.producer';
+
+/**
+ * Batches queued non-critical access-event emails into a single periodic
+ * digest per patient. Interval is configurable via EMAIL_DIGEST_CRON (a
+ * standard cron expression); defaults to every 30 minutes.
+ */
+@Injectable()
+export class EmailDigestSchedulerService {
+  private readonly logger = new Logger(EmailDigestSchedulerService.name);
+
+  constructor(
+    @InjectQueue(EMAIL_DIGEST_QUEUE) private readonly digestQueue: Queue,
+    private readonly mailService: MailService,
+    private readonly lookup: EmailLookupService,
+  ) {}
+
+  @Cron(process.env.EMAIL_DIGEST_CRON || CronExpression.EVERY_30_MINUTES)
+  async handleDigest(): Promise<void> {
+    const jobs: Job<EmailJobData>[] = await this.digestQueue.getJobs(['waiting', 'delayed']);
+    if (!jobs.length) return;
+
+    const jobsByPatient = new Map<string, Job<EmailJobData>[]>();
+    for (const job of jobs) {
+      const patientId = job.data.patientId;
+      const existing = jobsByPatient.get(patientId) ?? [];
+      existing.push(job);
+      jobsByPatient.set(patientId, existing);
+    }
+
+    for (const [patientId, patientJobs] of jobsByPatient) {
+      try {
+        const summary = this.summarize(patientJobs);
+        const patient = await this.lookup.findPatient(patientId);
+        await this.mailService.sendDigestEmail(patient, summary);
+        await Promise.all(patientJobs.map((job) => job.remove()));
+      } catch (error) {
+        this.logger.error(
+          `Failed to send digest for patient ${patientId}: ${(error as Error).message}`,
+        );
+      }
+    }
+  }
+
+  private summarize(jobs: Job<EmailJobData>[]): DigestSummary {
+    const counts: Record<string, number> = {
+      [EmailJobType.ACCESS_GRANTED]: 0,
+      [EmailJobType.ACCESS_REVOKED]: 0,
+      [EmailJobType.RECORD_UPLOADED]: 0,
+    };
+
+    for (const job of jobs) {
+      counts[job.data.type] = (counts[job.data.type] ?? 0) + 1;
+    }
+
+    return {
+      accessGrantedCount: counts[EmailJobType.ACCESS_GRANTED],
+      accessRevokedCount: counts[EmailJobType.ACCESS_REVOKED],
+      recordUploadedCount: counts[EmailJobType.RECORD_UPLOADED],
+      totalEvents: jobs.length,
+    };
+  }
+}

--- a/src/email-notification-service-for-critical-access-events/email-lookup.service.ts
+++ b/src/email-notification-service-for-critical-access-events/email-lookup.service.ts
@@ -6,6 +6,7 @@ import { User } from '../auth/entities/user.entity';
 import { MedicalRecord as MedicalRecordEntity } from '../medical-records/entities/medical-record.entity';
 import { AuditLogEntity } from '../common/audit/audit-log.entity';
 import { Patient, Provider, MedicalRecord, SuspiciousAccessEvent } from './mail.service';
+import { EmailDeliveryMode } from '../patients/dto/update-notification-preferences.dto';
 
 @Injectable()
 export class EmailLookupService {
@@ -62,6 +63,16 @@ export class EmailLookupService {
     };
   }
 
+  /** Whether the patient has opted into digest delivery for non-critical access-event emails. */
+  async prefersDigestDelivery(patientId: string): Promise<boolean> {
+    const patient = await this.patientRepository.findOne({
+      where: { id: patientId },
+      select: ['id', 'notificationPreferences'],
+    });
+
+    return patient?.notificationPreferences?.emailDeliveryMode === EmailDeliveryMode.DIGEST;
+  }
+
   /**
    * Fetch suspicious-access event details from the audit log.
    * The accessEventId is the AuditLogEntity primary key.
@@ -73,10 +84,9 @@ export class EmailLookupService {
     });
     if (!log) throw new NotFoundException(`AccessEvent ${id} not found`);
 
-    const accessorName =
-      log.user
-        ? `${log.user.firstName ?? ''} ${log.user.lastName ?? ''}`.trim() || log.user.email
-        : (log.details?.accessorName as string | undefined) ?? 'Unknown';
+    const accessorName = log.user
+      ? `${log.user.firstName ?? ''} ${log.user.lastName ?? ''}`.trim() || log.user.email
+      : ((log.details?.accessorName as string | undefined) ?? 'Unknown');
 
     return {
       accessedAt: log.timestamp ?? log.createdAt,

--- a/src/email-notification-service-for-critical-access-events/email-queue.consumer.spec.ts
+++ b/src/email-notification-service-for-critical-access-events/email-queue.consumer.spec.ts
@@ -1,0 +1,98 @@
+import { EmailQueueConsumer } from './email-queue.consumer';
+import { MailService } from './mail.service';
+import { EmailLookupService } from './email-lookup.service';
+import { EmailJobType } from './email-queue.producer';
+
+describe('EmailQueueConsumer', () => {
+  let consumer: EmailQueueConsumer;
+  let mailService: jest.Mocked<MailService>;
+  let lookup: jest.Mocked<EmailLookupService>;
+  let digestQueue: { add: jest.Mock };
+
+  beforeEach(() => {
+    mailService = {
+      sendAccessGrantedEmail: jest.fn().mockResolvedValue(undefined),
+      sendAccessRevokedEmail: jest.fn().mockResolvedValue(undefined),
+      sendRecordUploadedEmail: jest.fn().mockResolvedValue(undefined),
+      sendSuspiciousAccessEmail: jest.fn().mockResolvedValue(undefined),
+      sendDigestEmail: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    lookup = {
+      findPatient: jest
+        .fn()
+        .mockResolvedValue({ id: 'patient-1', email: 'p@example.com', name: 'Pat' }),
+      findProvider: jest
+        .fn()
+        .mockResolvedValue({ id: 'prov-1', name: 'Dr. Who', email: 'dr@example.com' }),
+      findRecord: jest.fn().mockResolvedValue({ id: 'rec-1', title: 'Lab Result' }),
+      findAccessEvent: jest.fn().mockResolvedValue({
+        accessedAt: new Date(),
+        ipAddress: '1.2.3.4',
+        accessorName: 'Someone',
+      }),
+      prefersDigestDelivery: jest.fn(),
+    } as any;
+
+    digestQueue = { add: jest.fn().mockResolvedValue(undefined) };
+
+    consumer = new EmailQueueConsumer(mailService, lookup, digestQueue as any);
+  });
+
+  it('always sends suspicious-access (critical) emails immediately, even when the patient prefers digest delivery', async () => {
+    lookup.prefersDigestDelivery.mockResolvedValue(true);
+
+    const job = {
+      id: '1',
+      name: EmailJobType.SUSPICIOUS_ACCESS,
+      attemptsMade: 0,
+      data: {
+        type: EmailJobType.SUSPICIOUS_ACCESS,
+        patientId: 'patient-1',
+        accessEventId: 'evt-1',
+      },
+    } as any;
+
+    await consumer.process(job);
+
+    expect(mailService.sendSuspiciousAccessEmail).toHaveBeenCalled();
+    expect(digestQueue.add).not.toHaveBeenCalled();
+  });
+
+  it('queues non-critical access-granted emails for digest delivery when the patient prefers digest mode', async () => {
+    lookup.prefersDigestDelivery.mockResolvedValue(true);
+
+    const job = {
+      id: '2',
+      name: EmailJobType.ACCESS_GRANTED,
+      attemptsMade: 0,
+      data: {
+        type: EmailJobType.ACCESS_GRANTED,
+        patientId: 'patient-1',
+        granteeId: 'prov-1',
+        recordId: 'rec-1',
+      },
+    } as any;
+
+    await consumer.process(job);
+
+    expect(digestQueue.add).toHaveBeenCalledWith(EmailJobType.ACCESS_GRANTED, job.data);
+    expect(mailService.sendAccessGrantedEmail).not.toHaveBeenCalled();
+  });
+
+  it('sends non-critical emails immediately when the patient prefers immediate delivery', async () => {
+    lookup.prefersDigestDelivery.mockResolvedValue(false);
+
+    const job = {
+      id: '3',
+      name: EmailJobType.RECORD_UPLOADED,
+      attemptsMade: 0,
+      data: { type: EmailJobType.RECORD_UPLOADED, patientId: 'patient-1', recordId: 'rec-1' },
+    } as any;
+
+    await consumer.process(job);
+
+    expect(mailService.sendRecordUploadedEmail).toHaveBeenCalled();
+    expect(digestQueue.add).not.toHaveBeenCalled();
+  });
+});

--- a/src/email-notification-service-for-critical-access-events/email-queue.consumer.ts
+++ b/src/email-notification-service-for-critical-access-events/email-queue.consumer.ts
@@ -1,14 +1,19 @@
 // src/queue/email-queue.consumer.ts
-import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
+import { Processor, WorkerHost, OnWorkerEvent, InjectQueue } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
-import { Job } from 'bullmq';
-import { EMAIL_QUEUE } from './email-queue.module';
+import { Job, Queue } from 'bullmq';
+import { EMAIL_QUEUE, EMAIL_DIGEST_QUEUE } from './email-queue.module';
 import { MailService } from './mail.service';
 import { EmailLookupService } from './email-lookup.service';
-import {
-  EmailJobData,
-  EmailJobType,
-} from './email-queue.producer';
+import { EmailJobData, EmailJobType } from './email-queue.producer';
+
+// Non-critical event types are eligible for digest batching. Suspicious-access
+// alerts are always critical and must always send immediately.
+const DIGESTIBLE_JOB_TYPES: ReadonlySet<EmailJobType> = new Set([
+  EmailJobType.ACCESS_GRANTED,
+  EmailJobType.ACCESS_REVOKED,
+  EmailJobType.RECORD_UPLOADED,
+]);
 
 @Processor(EMAIL_QUEUE, { concurrency: 5 })
 export class EmailQueueConsumer extends WorkerHost {
@@ -17,12 +22,24 @@ export class EmailQueueConsumer extends WorkerHost {
   constructor(
     private readonly mailService: MailService,
     private readonly lookup: EmailLookupService,
+    @InjectQueue(EMAIL_DIGEST_QUEUE) private readonly digestQueue: Queue,
   ) {
     super();
   }
 
   async process(job: Job<EmailJobData>): Promise<void> {
     this.logger.log(`Processing job ${job.id} [${job.name}] attempt ${job.attemptsMade + 1}`);
+
+    if (
+      DIGESTIBLE_JOB_TYPES.has(job.data.type) &&
+      (await this.lookup.prefersDigestDelivery(job.data.patientId))
+    ) {
+      await this.digestQueue.add(job.data.type, job.data);
+      this.logger.log(
+        `Queued ${job.data.type} for digest delivery to patient ${job.data.patientId}`,
+      );
+      return;
+    }
 
     switch (job.data.type) {
       case EmailJobType.ACCESS_GRANTED: {

--- a/src/email-notification-service-for-critical-access-events/email-queue.module.ts
+++ b/src/email-notification-service-for-critical-access-events/email-queue.module.ts
@@ -2,10 +2,12 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EmailQueueProducer } from './email-queue.producer';
 import { EmailQueueConsumer } from './email-queue.consumer';
 import { EmailLookupService } from './email-lookup.service';
+import { EmailDigestSchedulerService } from './email-digest-scheduler.service';
 import { MailModule } from '../mail/mail.module';
 import { Patient } from '../patients/entities/patient.entity';
 import { User } from '../auth/entities/user.entity';
@@ -13,9 +15,11 @@ import { MedicalRecord } from '../medical-records/entities/medical-record.entity
 import { AuditLogEntity } from '../common/audit/audit-log.entity';
 
 export const EMAIL_QUEUE = 'email-notifications';
+export const EMAIL_DIGEST_QUEUE = 'email-notifications-digest';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
     BullModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -27,22 +31,38 @@ export const EMAIL_QUEUE = 'email-notifications';
         },
       }),
     }),
-    BullModule.registerQueue({
-      name: EMAIL_QUEUE,
-      defaultJobOptions: {
-        attempts: 3,
-        backoff: {
-          type: 'exponential',
-          delay: 2000, // 2s → 4s → 8s
+    BullModule.registerQueue(
+      {
+        name: EMAIL_QUEUE,
+        defaultJobOptions: {
+          attempts: 3,
+          backoff: {
+            type: 'exponential',
+            delay: 2000, // 2s → 4s → 8s
+          },
+          removeOnComplete: 100,
+          removeOnFail: 50,
         },
-        removeOnComplete: 100,
-        removeOnFail: 50,
       },
-    }),
+      {
+        // Holds non-critical events for patients on digest delivery until the
+        // scheduler batches and sends them; never processed job-by-job.
+        name: EMAIL_DIGEST_QUEUE,
+        defaultJobOptions: {
+          removeOnComplete: true,
+          removeOnFail: 50,
+        },
+      },
+    ),
     TypeOrmModule.forFeature([Patient, User, MedicalRecord, AuditLogEntity]),
     MailModule,
   ],
-  providers: [EmailQueueProducer, EmailQueueConsumer, EmailLookupService],
+  providers: [
+    EmailQueueProducer,
+    EmailQueueConsumer,
+    EmailLookupService,
+    EmailDigestSchedulerService,
+  ],
   exports: [EmailQueueProducer],
 })
 export class EmailQueueModule {}

--- a/src/email-notification-service-for-critical-access-events/mail.service.ts
+++ b/src/email-notification-service-for-critical-access-events/mail.service.ts
@@ -33,6 +33,13 @@ export interface SuspiciousAccessEvent {
   accessorName: string;
 }
 
+export interface DigestSummary {
+  accessGrantedCount: number;
+  accessRevokedCount: number;
+  recordUploadedCount: number;
+  totalEvents: number;
+}
+
 @Injectable()
 export class MailService {
   private readonly logger = new Logger(MailService.name);
@@ -68,7 +75,7 @@ export class MailService {
     patient: Patient,
     grantee: Provider,
     record: MedicalRecord,
-    language: string = 'en'
+    language: string = 'en',
   ): Promise<void> {
     const template = `access-granted/access-granted.${language}`;
     const subject = `Access Granted: ${grantee.name} can now view your records`;
@@ -105,7 +112,7 @@ export class MailService {
     patient: Patient,
     revokee: Provider,
     record: MedicalRecord,
-    language: string = 'en'
+    language: string = 'en',
   ): Promise<void> {
     const subject = `Access Revoked: ${revokee.name} no longer has access to your records`;
 
@@ -135,7 +142,7 @@ export class MailService {
     patient: Patient,
     record: MedicalRecord,
     uploadedBy?: Provider,
-    language: string = 'en'
+    language: string = 'en',
   ): Promise<void> {
     const subject = `New Record Available: ${record.title}`;
 
@@ -163,10 +170,37 @@ export class MailService {
     });
   }
 
+  async sendDigestEmail(
+    patient: Patient,
+    summary: DigestSummary,
+    language: string = 'en',
+  ): Promise<void> {
+    const subject = `Your Health Record Activity Summary (${summary.totalEvents} update${summary.totalEvents === 1 ? '' : 's'})`;
+
+    if (this.isTestEnv) {
+      this.logger.log(`[TEST] Would send '${subject}' to ${patient.email}`, { patient, summary });
+      return;
+    }
+
+    await this.circuitBreaker.execute('mail', async () => {
+      await this.mailerService.sendMail({
+        to: patient.email,
+        subject,
+        template: `digest/digest.${language}`,
+        context: {
+          patientName: patient.name,
+          ...summary,
+          unsubscribeUrl: this.buildUnsubscribeUrl(patient),
+          appUrl: this.appUrl,
+        },
+      });
+    });
+  }
+
   async sendSuspiciousAccessEmail(
     patient: Patient,
     event: SuspiciousAccessEvent,
-    language: string = 'en'
+    language: string = 'en',
   ): Promise<void> {
     const subject = '⚠️ Suspicious Access Detected on Your Health Records';
 

--- a/src/email-notification-service-for-critical-access-events/templates/digest/digest.en.hbs
+++ b/src/email-notification-service-for-critical-access-events/templates/digest/digest.en.hbs
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Activity Summary</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f5f7fa; margin: 0; padding: 0; }
+    .wrapper { max-width: 600px; margin: 40px auto; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,.08); }
+    .header { background: #0ea5e9; padding: 32px; text-align: center; }
+    .header h1 { color: #fff; margin: 0; font-size: 22px; font-weight: 600; }
+    .body { padding: 32px; color: #374151; line-height: 1.6; }
+    .card { background: #f0f9ff; border-left: 4px solid #0ea5e9; border-radius: 4px; padding: 16px; margin: 24px 0; }
+    .card p { margin: 4px 0; font-size: 14px; }
+    .card strong { color: #0369a1; }
+    .footer { background: #f9fafb; padding: 24px; text-align: center; font-size: 12px; color: #6b7280; }
+    .footer a { color: #6b7280; }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="header">
+      <h1>📋 Your Activity Summary</h1>
+    </div>
+    <div class="body">
+      <p>Hi <strong>{{patientName}}</strong>,</p>
+      <p>Here is a summary of {{totalEvents}} recent activity update(s) on your health records:</p>
+
+      <div class="card">
+        {{#if accessGrantedCount}}
+        <p><strong>Access granted:</strong> {{accessGrantedCount}}</p>
+        {{/if}}
+        {{#if accessRevokedCount}}
+        <p><strong>Access revoked:</strong> {{accessRevokedCount}}</p>
+        {{/if}}
+        {{#if recordUploadedCount}}
+        <p><strong>New records uploaded:</strong> {{recordUploadedCount}}</p>
+        {{/if}}
+      </div>
+
+      <p style="text-align:center; margin-top: 32px;">
+        <a href="{{appUrl}}/access" style="background:#0ea5e9;color:#fff;padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:600;">
+          View Full Activity
+        </a>
+      </p>
+    </div>
+    <div class="footer">
+      <p>You are receiving this digest because your notification preference is set to "digest" delivery.</p>
+      <p><a href="{{unsubscribeUrl}}">Unsubscribe from email notifications</a></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/patients/dto/update-notification-preferences.dto.ts
+++ b/src/patients/dto/update-notification-preferences.dto.ts
@@ -7,6 +7,11 @@ export enum NotificationChannel {
   SMS = 'SMS',
 }
 
+export enum EmailDeliveryMode {
+  IMMEDIATE = 'IMMEDIATE',
+  DIGEST = 'DIGEST',
+}
+
 export class UpdateNotificationPreferencesDto {
   @ApiPropertyOptional()
   @IsOptional()
@@ -34,4 +39,13 @@ export class UpdateNotificationPreferencesDto {
   @ArrayUnique()
   @IsEnum(NotificationChannel, { each: true })
   channels?: NotificationChannel[];
+
+  @ApiPropertyOptional({
+    enum: EmailDeliveryMode,
+    description:
+      'Delivery mode for non-critical access-event emails. Critical events always send immediately.',
+  })
+  @IsOptional()
+  @IsEnum(EmailDeliveryMode)
+  emailDeliveryMode?: EmailDeliveryMode;
 }

--- a/src/patients/types/notification-preferences.type.ts
+++ b/src/patients/types/notification-preferences.type.ts
@@ -1,4 +1,4 @@
-import { NotificationChannel } from '../dto/update-notification-preferences.dto';
+import { EmailDeliveryMode, NotificationChannel } from '../dto/update-notification-preferences.dto';
 
 export interface NotificationPreferences {
   newRecord: boolean;
@@ -6,6 +6,8 @@ export interface NotificationPreferences {
   accessRevoked: boolean;
   appointmentReminder: boolean;
   channels: NotificationChannel[];
+  /** Delivery mode for non-critical access-event emails. Critical events always send immediately. */
+  emailDeliveryMode?: EmailDeliveryMode;
 }
 
 export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
@@ -14,4 +16,5 @@ export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
   accessRevoked: true,
   appointmentReminder: true,
   channels: [NotificationChannel.WEBSOCKET],
+  emailDeliveryMode: EmailDeliveryMode.IMMEDIATE,
 };


### PR DESCRIPTION
## Summary
- Adds a per-patient `emailDeliveryMode` preference (`IMMEDIATE` | `DIGEST`) to notification preferences
- `EmailQueueConsumer` routes non-critical events (access-granted, access-revoked, record-uploaded) to a digest queue when the patient prefers digest delivery; suspicious-access (critical) always sends immediately, regardless of preference
- New `EmailDigestSchedulerService`: a `@Cron` job (interval configurable via `EMAIL_DIGEST_CRON`, default every 30 minutes) that batches queued digest-queue jobs per patient into a single summary email grouped by event type, then clears the processed jobs
- New digest email template + `MailService.sendDigestEmail`
- Unit test asserting critical (suspicious-access) events are never batched, even for patients on digest mode

Closes #850

## Validation performed
- `npx tsc --noEmit` — no new type errors introduced
- `npx eslint --fix` on all changed files — remaining findings are pre-existing `no-unsafe-*` patterns already present throughout this module (untyped Bull/Mailer APIs), consistent with the file's existing baseline
- `npx jest src/email-notification-service-for-critical-access-events` — the new `email-queue.consumer.spec.ts` fails to load in this environment due to a **pre-existing, unrelated** issue: `src/medical-records/entities/*.js` are stale compiled artifacts committed alongside the `.ts` sources (same class of problem as the stray `.js` files under `src/billing/entities/`), and Jest's `moduleFileExtensions: ['js','json','ts']` resolves the broken `.js` copy instead of the `.ts` source. `EmailLookupService` already imported `MedicalRecord` before this change, so any test exercising it would hit this regardless of this PR. Recommend a follow-up cleanup PR to remove the stray compiled `.js` files from entity directories repo-wide.