### PR TITLE
EHR import: map CCD/C-CDA sections to internal record types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,8 @@
         "sqlite3": "^5.1.7",
         "typeorm": "^0.3.28",
         "typescript-eslint": "^8.56.1",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "xml2js": "^0.6.2"
       },
       "devDependencies": {
         "@faker-js/faker": "^9.3.0",
@@ -123,6 +124,7 @@
         "@types/speakeasy": "^2.0.10",
         "@types/supertest": "^6.0.2",
         "@types/uuid": "^9.0.7",
+        "@types/xml2js": "^0.4.14",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
@@ -9770,6 +9772,16 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23391,6 +23403,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -26332,6 +26353,28 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xss": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,8 @@
     "sqlite3": "^5.1.7",
     "typeorm": "^0.3.28",
     "typescript-eslint": "^8.56.1",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.3.0",
@@ -198,6 +199,7 @@
     "@types/speakeasy": "^2.0.10",
     "@types/supertest": "^6.0.2",
     "@types/uuid": "^9.0.7",
+    "@types/xml2js": "^0.4.14",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/src/ehr-import/import.spec.ts
+++ b/src/ehr-import/import.spec.ts
@@ -6,6 +6,7 @@ import { ImportService } from './import.service';
 import { ImportJob, ImportJobStatus, ImportFormat } from './entities/import-job.entity';
 import { ImportError } from './entities/import-error.entity';
 import { Record as RecordEntity } from '../records/entities/record.entity';
+import { RecordType } from '../records/dto/create-record.dto';
 import { Hl7Parser } from './parsers/hl7.parser';
 import { CcdParser } from './parsers/ccd.parser';
 import { CsvParser } from './parsers/csv.parser';
@@ -35,9 +36,11 @@ function buildMocks() {
       if (!j) throw new Error('Not found');
       return Promise.resolve(j);
     }),
-    create: jest.fn().mockImplementation((data) =>
-      Object.assign(new ImportJob(), { id: `job-${++jobIdCounter}`, ...data }),
-    ),
+    create: jest
+      .fn()
+      .mockImplementation((data) =>
+        Object.assign(new ImportJob(), { id: `job-${++jobIdCounter}`, ...data }),
+      ),
     save: jest.fn().mockImplementation((job) => {
       savedJobs.push(job);
       return Promise.resolve(job);
@@ -50,12 +53,12 @@ function buildMocks() {
   };
 
   const errorRepo = {
-    find: jest.fn().mockImplementation(({ where: { jobId } }) =>
-      Promise.resolve(savedErrors.filter((e) => e.jobId === jobId)),
-    ),
-    create: jest.fn().mockImplementation((data) =>
-      Object.assign(new ImportError(), data),
-    ),
+    find: jest
+      .fn()
+      .mockImplementation(({ where: { jobId } }) =>
+        Promise.resolve(savedErrors.filter((e) => e.jobId === jobId)),
+      ),
+    create: jest.fn().mockImplementation((data) => Object.assign(new ImportError(), data)),
     save: jest.fn().mockImplementation((e) => {
       savedErrors.push(e);
       return Promise.resolve(e);
@@ -63,9 +66,7 @@ function buildMocks() {
   };
 
   const recordRepo = {
-    create: jest.fn().mockImplementation((data) =>
-      Object.assign(new RecordEntity(), data),
-    ),
+    create: jest.fn().mockImplementation((data) => Object.assign(new RecordEntity(), data)),
     save: jest.fn().mockImplementation((r) => {
       savedRecords.push(r);
       return Promise.resolve(r);
@@ -121,7 +122,7 @@ describe('ImportService — HL7 format', () => {
     const { jobId } = await svc.enqueue(hl7Buffer, 'sample.hl7');
     await waitForJob(mocks, jobId);
 
-    const job = mocks.savedJobs.find((j) => j.id === jobId)!;
+    const job = mocks.savedJobs.find((j) => j.id === jobId);
     expect(job.status).toBe(ImportJobStatus.COMPLETED);
     expect(job.succeeded).toBeGreaterThan(0);
     expect(job.failed).toBe(0);
@@ -136,7 +137,7 @@ describe('ImportService — HL7 format', () => {
     const svc = await buildService(mocks);
     const { jobId } = await svc.enqueue(hl7Buffer, 'data.hl7');
     await waitForJob(mocks, jobId);
-    const job = mocks.savedJobs.find((j) => j.id === jobId)!;
+    const job = mocks.savedJobs.find((j) => j.id === jobId);
     expect(job.format).toBe(ImportFormat.HL7);
   });
 });
@@ -149,9 +150,10 @@ describe('ImportService — CCD format', () => {
     const { jobId } = await svc.enqueue(ccdBuffer, 'sample.ccd');
     await waitForJob(mocks, jobId);
 
-    const job = mocks.savedJobs.find((j) => j.id === jobId)!;
+    const job = mocks.savedJobs.find((j) => j.id === jobId);
     expect(job.status).toBe(ImportJobStatus.COMPLETED);
-    expect(job.succeeded).toBe(1);
+    // One record per CCD section: Problems, Medications, Allergies, Results
+    expect(job.succeeded).toBe(4);
     expect(mocks.savedRecords[0].patientId).toBe('PAT-002');
   });
 
@@ -160,7 +162,7 @@ describe('ImportService — CCD format', () => {
     const svc = await buildService(mocks);
     const { jobId } = await svc.enqueue(ccdBuffer, 'record.ccd');
     await waitForJob(mocks, jobId);
-    const job = mocks.savedJobs.find((j) => j.id === jobId)!;
+    const job = mocks.savedJobs.find((j) => j.id === jobId);
     expect(job.format).toBe(ImportFormat.CCD);
   });
 });
@@ -173,7 +175,7 @@ describe('ImportService — CSV format', () => {
     const { jobId } = await svc.enqueue(csvBuffer, 'sample.csv');
     await waitForJob(mocks, jobId);
 
-    const job = mocks.savedJobs.find((j) => j.id === jobId)!;
+    const job = mocks.savedJobs.find((j) => j.id === jobId);
     expect(job.status).toBe(ImportJobStatus.COMPLETED);
     expect(job.total).toBe(3); // 3 data rows in fixture
     expect(job.succeeded).toBe(3);
@@ -187,7 +189,7 @@ describe('ImportService — CSV format', () => {
     const svc = await buildService(mocks);
     const { jobId } = await svc.enqueue(csvBuffer, 'patients.csv');
     await waitForJob(mocks, jobId);
-    const job = mocks.savedJobs.find((j) => j.id === jobId)!;
+    const job = mocks.savedJobs.find((j) => j.id === jobId);
     expect(job.format).toBe(ImportFormat.CSV);
   });
 });
@@ -201,9 +203,7 @@ describe('ImportService — idempotency', () => {
     await waitForJob(mocks, first.jobId);
 
     // Second upload: findOne returns the completed job
-    mocks.jobRepo.findOne.mockResolvedValue(
-      mocks.savedJobs.find((j) => j.id === first.jobId),
-    );
+    mocks.jobRepo.findOne.mockResolvedValue(mocks.savedJobs.find((j) => j.id === first.jobId));
 
     const second = await svc.enqueue(csvBuffer, 'sample.csv');
     expect(second.jobId).toBe(first.jobId);
@@ -220,7 +220,7 @@ describe('ImportService — dry-run mode', () => {
     const { jobId } = await svc.enqueue(csvBuffer, 'sample.csv', true);
     await waitForJob(mocks, jobId);
 
-    const job = mocks.savedJobs.find((j) => j.id === jobId)!;
+    const job = mocks.savedJobs.find((j) => j.id === jobId);
     expect(job.dryRun).toBe(true);
     expect(job.status).toBe(ImportJobStatus.COMPLETED);
     expect(job.succeeded).toBe(3);
@@ -236,14 +236,12 @@ describe('ImportService — error logging', () => {
     const svc = await buildService(mocks);
 
     // Make IPFS fail on the first call only
-    mocks.ipfs.upload
-      .mockRejectedValueOnce(new Error('IPFS timeout'))
-      .mockResolvedValue('QmOk');
+    mocks.ipfs.upload.mockRejectedValueOnce(new Error('IPFS timeout')).mockResolvedValue('QmOk');
 
     const { jobId } = await svc.enqueue(csvBuffer, 'sample.csv');
     await waitForJob(mocks, jobId);
 
-    const job = mocks.savedJobs.find((j) => j.id === jobId)!;
+    const job = mocks.savedJobs.find((j) => j.id === jobId);
     expect(job.failed).toBe(1);
     expect(job.succeeded).toBe(2);
     expect(mocks.savedErrors).toHaveLength(1);
@@ -301,8 +299,32 @@ describe('CcdParser', () => {
   it('extracts patientId PAT-002 from sample CCD', async () => {
     const parser = new CcdParser();
     const results = await parser.parse(ccdBuffer.toString());
-    expect(results).toHaveLength(1);
     expect(results[0].patientId).toBe('PAT-002');
+  });
+
+  it('maps each CCD section (problems, medications, allergies, results) to a record', async () => {
+    const parser = new CcdParser();
+    const results = await parser.parse(ccdBuffer.toString());
+
+    expect(results).toHaveLength(4);
+    expect(results.every((r) => r.patientId === 'PAT-002')).toBe(true);
+
+    expect(results[0].description).toContain('Problems');
+    expect(results[0].recordType).toBe(RecordType.MEDICAL_REPORT);
+
+    expect(results[1].description).toContain('Medications');
+    expect(results[1].recordType).toBe(RecordType.PRESCRIPTION);
+
+    expect(results[2].description).toContain('Allergies');
+    expect(results[2].recordType).toBe(RecordType.MEDICAL_REPORT);
+
+    expect(results[3].description).toContain('Results');
+    expect(results[3].recordType).toBe(RecordType.LAB_RESULT);
+  });
+
+  it('throws a validation error for a malformed CCD document', async () => {
+    const parser = new CcdParser();
+    await expect(parser.parse('<NotClinicalDocument></NotClinicalDocument>')).rejects.toThrow();
   });
 });
 
@@ -319,7 +341,11 @@ describe('CsvParser', () => {
   it('respects custom column mapping', () => {
     const parser = new CsvParser();
     const csv = 'pid,type,notes\nP1,LAB_RESULT,test note';
-    const results = parser.parse(csv, { patientId: 'pid', recordType: 'type', description: 'notes' });
+    const results = parser.parse(csv, {
+      patientId: 'pid',
+      recordType: 'type',
+      description: 'notes',
+    });
     expect(results[0].patientId).toBe('P1');
     expect(results[0].description).toBe('test note');
   });

--- a/src/ehr-import/parsers/ccd.parser.ts
+++ b/src/ehr-import/parsers/ccd.parser.ts
@@ -1,13 +1,29 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { parseStringPromise } from 'xml2js';
 import { ParsedRecord } from './parsed-record.interface';
 import { RecordType } from '../../records/dto/create-record.dto';
 
+/** Maps a CCD section title to the closest internal RecordType. */
+function classifySection(title: string): RecordType {
+  const normalized = title.toLowerCase();
+  if (normalized.includes('medication')) return RecordType.PRESCRIPTION;
+  if (normalized.includes('result') || normalized.includes('lab')) return RecordType.LAB_RESULT;
+  if (normalized.includes('imag') || normalized.includes('radiolog')) return RecordType.IMAGING;
+  if (normalized.includes('problem') || normalized.includes('allerg'))
+    return RecordType.MEDICAL_REPORT;
+  return RecordType.MEDICAL_REPORT;
+}
+
 @Injectable()
 export class CcdParser {
-  /** Parse a CCD XML document into ParsedRecord[]. */
+  /** Parse a CCD/C-CDA XML document into one ParsedRecord per clinical section. */
   async parse(xml: string): Promise<ParsedRecord[]> {
-    const doc = await parseStringPromise(xml, { explicitArray: false });
+    let doc: any;
+    try {
+      doc = await parseStringPromise(xml, { explicitArray: false });
+    } catch (err: any) {
+      throw new BadRequestException(`Malformed CCD XML: ${err.message}`);
+    }
 
     // Navigate CCDA structure: ClinicalDocument > recordTarget > patientRole
     const root =
@@ -17,23 +33,62 @@ export class CcdParser {
       doc;
 
     const patientRole =
-      root?.recordTarget?.patientRole ??
-      root?.['cda:recordTarget']?.['cda:patientRole'];
+      root?.recordTarget?.patientRole ?? root?.['cda:recordTarget']?.['cda:patientRole'];
+
+    if (!root || !patientRole) {
+      throw new BadRequestException(
+        'Malformed CCD document: missing ClinicalDocument/recordTarget/patientRole',
+      );
+    }
 
     const patientId: string =
-      patientRole?.id?.['$']?.extension ??
-      patientRole?.id?.extension ??
-      'unknown';
+      patientRole?.id?.['$']?.extension ?? patientRole?.id?.extension ?? 'unknown';
 
-    const title: string = root?.title?._ ?? root?.title ?? 'CCD Document';
+    const documentTitle: string = root?.title?._ ?? root?.title ?? 'CCD Document';
 
-    return [
-      {
+    const rawSections =
+      root?.component?.structuredBody?.component ??
+      root?.['cda:component']?.['cda:structuredBody']?.['cda:component'];
+
+    const sections: any[] = !rawSections
+      ? []
+      : Array.isArray(rawSections)
+        ? rawSections
+        : [rawSections];
+
+    if (sections.length === 0) {
+      // No structured sections — fall back to a single document-level record
+      // rather than failing the whole import outright.
+      return [
+        {
+          patientId,
+          recordType: RecordType.MEDICAL_REPORT,
+          description: String(documentTitle),
+          rawPayload: xml,
+        },
+      ];
+    }
+
+    const records: ParsedRecord[] = [];
+    for (const component of sections) {
+      const section = component?.section ?? component?.['cda:section'];
+      if (!section) continue; // unsupported/empty section — skip rather than fail the import
+
+      const sectionTitle: string = section?.title?._ ?? section?.title ?? 'Section';
+      const sectionText: string = section?.text?._ ?? section?.text ?? '';
+
+      records.push({
         patientId,
-        recordType: RecordType.MEDICAL_REPORT,
-        description: String(title),
+        recordType: classifySection(String(sectionTitle)),
+        description: `${sectionTitle}: ${sectionText}`.trim(),
         rawPayload: xml,
-      },
-    ];
+      });
+    }
+
+    if (records.length === 0) {
+      throw new BadRequestException('CCD document contained no supported clinical sections');
+    }
+
+    return records;
   }
 }

--- a/test/fixtures/import/sample.ccd
+++ b/test/fixtures/import/sample.ccd
@@ -18,6 +18,24 @@
           <text>Hypertension, Type 2 Diabetes</text>
         </section>
       </component>
+      <component>
+        <section>
+          <title>Medications</title>
+          <text>Metformin 500mg twice daily, Lisinopril 10mg once daily</text>
+        </section>
+      </component>
+      <component>
+        <section>
+          <title>Allergies</title>
+          <text>Penicillin - anaphylaxis</text>
+        </section>
+      </component>
+      <component>
+        <section>
+          <title>Results</title>
+          <text>HbA1c 7.2%, Basic Metabolic Panel within normal limits</text>
+        </section>
+      </component>
     </structuredBody>
   </component>
 </ClinicalDocument>


### PR DESCRIPTION
## Summary
The HL7 v2 parser, the CCD ingestion endpoint (multipart upload with content-type detection by extension/content-sniffing), and a `CcdParser` all already existed on `main`. The gap was that `CcdParser` collapsed an entire CCD document into a single generic `MEDICAL_REPORT` record instead of mapping individual clinical sections, and there was no validation/error reporting for malformed documents.

- `CcdParser` now walks `structuredBody` sections (problems, medications, allergies, results, ...) and emits one `ParsedRecord` per section, classified to the closest `RecordType` (`PRESCRIPTION` for medications, `LAB_RESULT` for results/labs, `IMAGING` for imaging, `MEDICAL_REPORT` otherwise)
- Malformed documents (missing `ClinicalDocument`/`recordTarget`/`patientRole`, or zero supported sections) now raise a clear validation error; unsupported/empty individual sections are skipped rather than failing the whole import
- Extended `test/fixtures/import/sample.ccd` with Medications, Allergies, and Results sections and updated the `CcdParser`/`ImportService` CCD tests to cover multi-section mapping end-to-end
- Added `xml2js` / `@types/xml2js` to `package.json` — `CcdParser` already imported `xml2js` before this change, but it was missing from the dependency manifest, so the module could never actually resolve in a clean install

Closes #849

## Validation performed
- `npx tsc --noEmit` — no new type errors
- `npx eslint --fix` on changed files — remaining findings are pre-existing `no-unsafe-*` patterns already present in this file (untyped `xml2js` output), proportionally consistent with the file's existing baseline
- Verified `CcdParser` directly against the updated fixture via a standalone script: correctly extracts 4 records (Problems→MEDICAL_REPORT, Medications→PRESCRIPTION, Allergies→MEDICAL_REPORT, Results→LAB_RESULT), all with `patientId: PAT-002`, and confirmed it throws on a malformed document
- Could not run `src/ehr-import/import.spec.ts` / `import.service.spec.ts` via Jest in this environment: both fail to load due to a **pre-existing, unrelated** issue — `src/ehr-import/services/temp-storage.service.ts` imports `@aws-sdk/client-s3`, which is not declared anywhere in `package.json` (verified this predates this PR). This blocks the whole `ImportService` test suite regardless of this change and should be fixed separately.