### PR TITLE
Data validation: configurable per-tenant custom field validation rules

### DIFF
--- a/src/data-validation-integrity/controllers/tenant-field-validation.controller.ts
+++ b/src/data-validation-integrity/controllers/tenant-field-validation.controller.ts
@@ -1,0 +1,41 @@
+import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { TenantFieldValidationService } from '../services/tenant-field-validation.service';
+import {
+  CreateTenantFieldValidationRuleDto,
+  UpdateTenantFieldValidationRuleDto,
+} from '../dto/tenant-field-validation-rule.dto';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+
+@ApiTags('Tenant Field Validation Rules')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+@Controller('admin/tenants/:tenantId/field-validation-rules')
+export class TenantFieldValidationController {
+  constructor(private readonly service: TenantFieldValidationService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List custom field validation rules for a tenant' })
+  list(@Param('tenantId') tenantId: string) {
+    return this.service.listRules(tenantId);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a custom field validation rule for a tenant' })
+  create(@Param('tenantId') tenantId: string, @Body() dto: CreateTenantFieldValidationRuleDto) {
+    return this.service.createRule(tenantId, dto);
+  }
+
+  @Patch(':ruleId')
+  @ApiOperation({ summary: 'Update a custom field validation rule for a tenant' })
+  update(
+    @Param('tenantId') tenantId: string,
+    @Param('ruleId') ruleId: string,
+    @Body() dto: UpdateTenantFieldValidationRuleDto,
+  ) {
+    return this.service.updateRule(tenantId, ruleId, dto);
+  }
+}

--- a/src/data-validation-integrity/dto/tenant-field-validation-rule.dto.ts
+++ b/src/data-validation-integrity/dto/tenant-field-validation-rule.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsEnum, IsOptional, IsString, MinLength } from 'class-validator';
+import { TenantFieldRuleType } from '../entities/tenant-field-validation-rule.entity';
+
+export class CreateTenantFieldValidationRuleDto {
+  @ApiProperty()
+  @IsString()
+  @MinLength(1)
+  fieldName: string;
+
+  @ApiPropertyOptional({ enum: TenantFieldRuleType, default: TenantFieldRuleType.STRING })
+  @IsOptional()
+  @IsEnum(TenantFieldRuleType)
+  type?: TenantFieldRuleType;
+
+  @ApiPropertyOptional({ description: 'Regex source (no delimiters), required when type is REGEX' })
+  @IsOptional()
+  @IsString()
+  pattern?: string;
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @IsBoolean()
+  required?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  errorMessage?: string;
+}
+
+export class UpdateTenantFieldValidationRuleDto {
+  @ApiPropertyOptional({ enum: TenantFieldRuleType })
+  @IsOptional()
+  @IsEnum(TenantFieldRuleType)
+  type?: TenantFieldRuleType;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  pattern?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  required?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  errorMessage?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/src/data-validation-integrity/entities/tenant-field-validation-rule.entity.ts
+++ b/src/data-validation-integrity/entities/tenant-field-validation-rule.entity.ts
@@ -1,0 +1,51 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum TenantFieldRuleType {
+  REGEX = 'REGEX',
+  NUMBER = 'NUMBER',
+  STRING = 'STRING',
+}
+
+@Entity('tenant_field_validation_rules')
+@Index(['tenantId', 'fieldName'], { unique: true })
+export class TenantFieldValidationRule {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ type: 'varchar' })
+  tenantId: string;
+
+  /** Name of the field this rule applies to within a DTO's customFields bag. */
+  @Column({ type: 'varchar' })
+  fieldName: string;
+
+  @Column({ type: 'enum', enum: TenantFieldRuleType, default: TenantFieldRuleType.STRING })
+  type: TenantFieldRuleType;
+
+  /** Regex source (no delimiters) used when type is REGEX. */
+  @Column({ type: 'varchar', nullable: true })
+  pattern: string | null;
+
+  @Column({ type: 'boolean', default: false })
+  required: boolean;
+
+  @Column({ type: 'varchar', nullable: true })
+  errorMessage: string | null;
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/data-validation-integrity/medical-validation.module.ts
+++ b/src/data-validation-integrity/medical-validation.module.ts
@@ -11,6 +11,7 @@ import {
   GovernanceComplianceLog,
   ReferenceDataUpdateLog,
 } from './entities/medical-validation.entities';
+import { TenantFieldValidationRule } from './entities/tenant-field-validation-rule.entity';
 
 // Services
 import { Icd10ValidationService } from './services/icd10-validation.service';
@@ -21,9 +22,11 @@ import { ClinicalDecisionSupportService } from './services/clinical-decision-sup
 import { ReferenceDataService } from './services/reference-data.service';
 import { DataGovernanceService } from './services/data-governance.service';
 import { MedicalMonitoringService } from '../medical-monitoring/medical-monitoring.service';
+import { TenantFieldValidationService } from './services/tenant-field-validation.service';
 
 // Controller
 import { MedicalValidationController } from './medical-validation.controller';
+import { TenantFieldValidationController } from './controllers/tenant-field-validation.controller';
 
 @Module({
   imports: [
@@ -35,9 +38,10 @@ import { MedicalValidationController } from './medical-validation.controller';
       GovernancePolicyEntity,
       GovernanceComplianceLog,
       ReferenceDataUpdateLog,
+      TenantFieldValidationRule,
     ]),
   ],
-  controllers: [MedicalValidationController],
+  controllers: [MedicalValidationController, TenantFieldValidationController],
   providers: [
     Icd10ValidationService,
     CptValidationService,
@@ -47,6 +51,7 @@ import { MedicalValidationController } from './medical-validation.controller';
     ReferenceDataService,
     DataGovernanceService,
     MedicalMonitoringService,
+    TenantFieldValidationService,
   ],
   exports: [
     Icd10ValidationService,
@@ -57,6 +62,7 @@ import { MedicalValidationController } from './medical-validation.controller';
     ReferenceDataService,
     DataGovernanceService,
     MedicalMonitoringService,
+    TenantFieldValidationService,
   ],
 })
 export class MedicalValidationModule {}

--- a/src/data-validation-integrity/services/tenant-field-validation.service.spec.ts
+++ b/src/data-validation-integrity/services/tenant-field-validation.service.spec.ts
@@ -1,0 +1,160 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TenantFieldValidationService } from './tenant-field-validation.service';
+import {
+  TenantFieldRuleType,
+  TenantFieldValidationRule,
+} from '../entities/tenant-field-validation-rule.entity';
+
+describe('TenantFieldValidationService', () => {
+  let service: TenantFieldValidationService;
+  let rules: TenantFieldValidationRule[];
+
+  const mockRepo = {
+    find: jest
+      .fn()
+      .mockImplementation(({ where }) =>
+        Promise.resolve(
+          rules.filter(
+            (r) =>
+              r.tenantId === where.tenantId &&
+              (where.isActive === undefined || r.isActive === where.isActive),
+          ),
+        ),
+      ),
+    findOne: jest
+      .fn()
+      .mockImplementation(({ where }) =>
+        Promise.resolve(
+          rules.find((r) => r.id === where.id && r.tenantId === where.tenantId) ?? null,
+        ),
+      ),
+    create: jest
+      .fn()
+      .mockImplementation((data) => ({ id: `rule-${rules.length + 1}`, isActive: true, ...data })),
+    save: jest.fn().mockImplementation((rule) => {
+      const idx = rules.findIndex((r) => r.id === rule.id);
+      if (idx >= 0) rules[idx] = rule;
+      else rules.push(rule);
+      return Promise.resolve(rule);
+    }),
+  };
+
+  beforeEach(async () => {
+    rules = [];
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TenantFieldValidationService,
+        { provide: getRepositoryToken(TenantFieldValidationRule), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get(TenantFieldValidationService);
+  });
+
+  describe('createRule', () => {
+    it('rejects a REGEX rule with no pattern', async () => {
+      await expect(
+        service.createRule('tenant-a', {
+          fieldName: 'insuranceNumber',
+          type: TenantFieldRuleType.REGEX,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a REGEX rule with an invalid pattern', async () => {
+      await expect(
+        service.createRule('tenant-a', {
+          fieldName: 'insuranceNumber',
+          type: TenantFieldRuleType.REGEX,
+          pattern: '(unterminated',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('accepts a valid REGEX rule', async () => {
+      const rule = await service.createRule('tenant-a', {
+        fieldName: 'insuranceNumber',
+        type: TenantFieldRuleType.REGEX,
+        pattern: '^INS-\\d{6}$',
+        required: true,
+      });
+      expect(rule.fieldName).toBe('insuranceNumber');
+    });
+  });
+
+  describe('validateFields — tenant rule precedence and fallback', () => {
+    it('applies the tenant rule when one exists for the field', async () => {
+      await service.createRule('tenant-a', {
+        fieldName: 'insuranceNumber',
+        type: TenantFieldRuleType.REGEX,
+        pattern: '^INS-\\d{6}$',
+        required: true,
+        errorMessage: 'Invalid insurance number format',
+      });
+
+      await expect(
+        service.validateFields('tenant-a', { insuranceNumber: 'not-a-match' }),
+      ).rejects.toThrow(BadRequestException);
+
+      await expect(
+        service.validateFields('tenant-a', { insuranceNumber: 'INS-123456' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('falls back to no custom validation when no tenant rule exists for the field', async () => {
+      await service.createRule('tenant-a', {
+        fieldName: 'insuranceNumber',
+        type: TenantFieldRuleType.REGEX,
+        pattern: '^INS-\\d{6}$',
+      });
+
+      // "localBenefitId" has no rule for tenant-a — should pass through untouched.
+      await expect(
+        service.validateFields('tenant-a', { localBenefitId: 'anything-goes' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("does not apply another tenant's rules", async () => {
+      await service.createRule('tenant-a', {
+        fieldName: 'insuranceNumber',
+        type: TenantFieldRuleType.REGEX,
+        pattern: '^INS-\\d{6}$',
+        required: true,
+      });
+
+      // tenant-b has no rules at all, so the same field is unconstrained.
+      await expect(
+        service.validateFields('tenant-b', { insuranceNumber: 'anything' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects missing required fields', async () => {
+      await service.createRule('tenant-a', {
+        fieldName: 'insuranceNumber',
+        required: true,
+      });
+
+      await expect(service.validateFields('tenant-a', {})).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('updateRule', () => {
+    it('throws NotFoundException for a rule belonging to a different tenant', async () => {
+      const rule = await service.createRule('tenant-a', { fieldName: 'insuranceNumber' });
+
+      await expect(service.updateRule('tenant-b', rule.id, { required: true })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('rejects switching an existing rule to REGEX without providing a pattern', async () => {
+      const rule = await service.createRule('tenant-a', { fieldName: 'insuranceNumber' });
+
+      await expect(
+        service.updateRule('tenant-a', rule.id, { type: TenantFieldRuleType.REGEX }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/src/data-validation-integrity/services/tenant-field-validation.service.ts
+++ b/src/data-validation-integrity/services/tenant-field-validation.service.ts
@@ -1,0 +1,128 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  TenantFieldRuleType,
+  TenantFieldValidationRule,
+} from '../entities/tenant-field-validation-rule.entity';
+import {
+  CreateTenantFieldValidationRuleDto,
+  UpdateTenantFieldValidationRuleDto,
+} from '../dto/tenant-field-validation-rule.dto';
+
+/**
+ * Loads and applies tenant-specific custom-field validation rules.
+ * Fields with no matching active rule for the tenant are left to whatever
+ * default validation the caller already applies (fallback behaviour).
+ */
+@Injectable()
+export class TenantFieldValidationService {
+  constructor(
+    @InjectRepository(TenantFieldValidationRule)
+    private readonly ruleRepo: Repository<TenantFieldValidationRule>,
+  ) {}
+
+  async listRules(tenantId: string): Promise<TenantFieldValidationRule[]> {
+    return this.ruleRepo.find({ where: { tenantId }, order: { fieldName: 'ASC' } });
+  }
+
+  async createRule(
+    tenantId: string,
+    dto: CreateTenantFieldValidationRuleDto,
+  ): Promise<TenantFieldValidationRule> {
+    this.assertValidRuleDefinition(dto.type ?? TenantFieldRuleType.STRING, dto.pattern);
+
+    const rule = this.ruleRepo.create({
+      tenantId,
+      fieldName: dto.fieldName,
+      type: dto.type ?? TenantFieldRuleType.STRING,
+      pattern: dto.pattern ?? null,
+      required: dto.required ?? false,
+      errorMessage: dto.errorMessage ?? null,
+    });
+
+    return this.ruleRepo.save(rule);
+  }
+
+  async updateRule(
+    tenantId: string,
+    ruleId: string,
+    dto: UpdateTenantFieldValidationRuleDto,
+  ): Promise<TenantFieldValidationRule> {
+    const rule = await this.ruleRepo.findOne({ where: { id: ruleId, tenantId } });
+    if (!rule) throw new NotFoundException('Validation rule not found for this tenant');
+
+    const nextType = dto.type ?? rule.type;
+    const nextPattern = dto.pattern !== undefined ? dto.pattern : rule.pattern;
+    this.assertValidRuleDefinition(nextType, nextPattern ?? undefined);
+
+    Object.assign(rule, {
+      type: nextType,
+      pattern: nextPattern ?? null,
+      required: dto.required ?? rule.required,
+      errorMessage: dto.errorMessage ?? rule.errorMessage,
+      isActive: dto.isActive ?? rule.isActive,
+    });
+
+    return this.ruleRepo.save(rule);
+  }
+
+  /**
+   * Validates a custom-fields bag against the tenant's active rules.
+   * Throws BadRequestException listing every violation. Fields without a
+   * matching active rule are not validated here (fallback to default).
+   */
+  async validateFields(tenantId: string, fields: Record<string, unknown>): Promise<void> {
+    const rules = await this.ruleRepo.find({ where: { tenantId, isActive: true } });
+    if (rules.length === 0) return;
+
+    const violations: string[] = [];
+    for (const rule of rules) {
+      const value = fields?.[rule.fieldName];
+      const isEmpty = value === undefined || value === null || value === '';
+
+      if (rule.required && isEmpty) {
+        violations.push(rule.errorMessage ?? `${rule.fieldName} is required`);
+        continue;
+      }
+
+      if (isEmpty) continue; // optional and not provided — nothing further to check
+
+      if (!this.matchesType(rule, value)) {
+        violations.push(rule.errorMessage ?? `${rule.fieldName} is invalid`);
+      }
+    }
+
+    if (violations.length > 0) {
+      throw new BadRequestException({ message: 'Custom field validation failed', violations });
+    }
+  }
+
+  private matchesType(rule: TenantFieldValidationRule, value: unknown): boolean {
+    switch (rule.type) {
+      case TenantFieldRuleType.NUMBER:
+        return (
+          typeof value === 'number' || (typeof value === 'string' && /^-?\d+(\.\d+)?$/.test(value))
+        );
+      case TenantFieldRuleType.REGEX:
+        return typeof value === 'string' && new RegExp(rule.pattern ?? '.*').test(value);
+      case TenantFieldRuleType.STRING:
+      default:
+        return typeof value === 'string';
+    }
+  }
+
+  /** Rejects rule definitions that could never validate anything correctly. */
+  private assertValidRuleDefinition(type: TenantFieldRuleType, pattern?: string): void {
+    if (type === TenantFieldRuleType.REGEX) {
+      if (!pattern) {
+        throw new BadRequestException('A REGEX rule requires a pattern');
+      }
+      try {
+        new RegExp(pattern);
+      } catch {
+        throw new BadRequestException(`Invalid regex pattern: ${pattern}`);
+      }
+    }
+  }
+}

--- a/src/migrations/1783200000000-CreateTenantFieldValidationRules.ts
+++ b/src/migrations/1783200000000-CreateTenantFieldValidationRules.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTenantFieldValidationRules1783200000000 implements MigrationInterface {
+  name = 'CreateTenantFieldValidationRules1783200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasTable('tenant_field_validation_rules'))) {
+      await queryRunner.query(`
+        CREATE TABLE "tenant_field_validation_rules" (
+          "id"            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+          "tenantId"      VARCHAR NOT NULL,
+          "fieldName"     VARCHAR NOT NULL,
+          "type"          VARCHAR NOT NULL DEFAULT 'STRING',
+          "pattern"       VARCHAR,
+          "required"      BOOLEAN NOT NULL DEFAULT false,
+          "errorMessage"  VARCHAR,
+          "isActive"      BOOLEAN NOT NULL DEFAULT true,
+          "createdAt"     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          "updatedAt"     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          CONSTRAINT "UQ_tenant_field_validation_rules_tenant_field" UNIQUE ("tenantId", "fieldName")
+        )
+      `);
+      await queryRunner.query(`
+        CREATE INDEX "IDX_tenant_field_validation_rules_tenant"
+          ON "tenant_field_validation_rules" ("tenantId")
+      `);
+    }
+
+    if (
+      (await queryRunner.hasTable('patients')) &&
+      !(await queryRunner.hasColumn('patients', 'customFields'))
+    ) {
+      await queryRunner.query(`
+        ALTER TABLE "patients" ADD COLUMN "customFields" JSON
+      `);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    if (
+      (await queryRunner.hasTable('patients')) &&
+      (await queryRunner.hasColumn('patients', 'customFields'))
+    ) {
+      await queryRunner.query(`ALTER TABLE "patients" DROP COLUMN "customFields"`);
+    }
+    await queryRunner.query(`DROP TABLE IF EXISTS "tenant_field_validation_rules"`);
+  }
+}

--- a/src/patients/dto/create-patient.dto.ts
+++ b/src/patients/dto/create-patient.dto.ts
@@ -6,6 +6,7 @@ import {
   IsEmail,
   IsArray,
   IsUUID,
+  IsObject,
   Length,
   MaxLength,
 } from 'class-validator';
@@ -95,4 +96,11 @@ export class CreatePatientDto {
   @IsOptional()
   @IsString()
   nationalIdType?: string; // Passport, SSN, NIN
+
+  // -----------------------------
+  // Tenant-specific extended attributes
+  // -----------------------------
+  @IsOptional()
+  @IsObject()
+  customFields?: Record<string, string>;
 }

--- a/src/patients/entities/patient.entity.ts
+++ b/src/patients/entities/patient.entity.ts
@@ -167,6 +167,10 @@ export class Patient {
   @Column('json', { nullable: true })
   emergencyContact?: Record<string, any>; // e.g. { name, phone, relationship }
 
+  /** Tenant-specific extended attributes (e.g. local insurance numbers, national ID formats). */
+  @Column('json', { nullable: true })
+  customFields?: Record<string, string>;
+
   /**
    * -----------------------------
    * Administrative / Workflow
@@ -197,8 +201,7 @@ export class Patient {
   @Column({
     type: 'jsonb',
     nullable: false,
-    default: () =>
-      `'${JSON.stringify(DEFAULT_NOTIFICATION_PREFERENCES)}'`,
+    default: () => `'${JSON.stringify(DEFAULT_NOTIFICATION_PREFERENCES)}'`,
   })
   notificationPreferences: NotificationPreferences;
 

--- a/src/patients/patients.module.ts
+++ b/src/patients/patients.module.ts
@@ -13,6 +13,7 @@ import { PatientProvidersController } from './controllers/patient-providers.cont
 import { PatientProvidersService } from './services/patient-providers.service';
 import { CommonModule } from '../common/common.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { MedicalValidationModule } from '../data-validation-integrity/medical-validation.module';
 
 @Module({
   imports: [
@@ -20,9 +21,16 @@ import { StellarModule } from '../stellar/stellar.module';
     AuthModule,
     CommonModule,
     StellarModule,
+    MedicalValidationModule,
   ],
   controllers: [PatientsController, PatientProvidersController],
-  providers: [PatientsService, PatientTimelineService, PatientPrivacyGuard, GeoRestrictionGuard, PatientProvidersService],
+  providers: [
+    PatientsService,
+    PatientTimelineService,
+    PatientPrivacyGuard,
+    GeoRestrictionGuard,
+    PatientProvidersService,
+  ],
   exports: [PatientsService, PatientTimelineService, GeoRestrictionGuard],
 })
 export class PatientModule {}

--- a/src/patients/patients.service.spec.ts
+++ b/src/patients/patients.service.spec.ts
@@ -1,16 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
-import {
-  ConflictException,
-  NotFoundException,
-  BadRequestException,
-} from '@nestjs/common';
+import { ConflictException, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PatientsService } from './patients.service';
 import { Patient } from './entities/patient.entity';
 import { AuditLogEntity } from '../common/audit/audit-log.entity';
 import { RedisLockService } from '../common/utils/redis-lock.service';
 import { StellarService } from '../stellar/services/stellar.service';
+import { TenantFieldValidationService } from '../data-validation-integrity/services/tenant-field-validation.service';
 import { aPatient } from '../../test/fixtures/test-data-builder';
 
 // ─── Blockchain mock (Stellar SDK is mocked globally in setup-unit.ts) ────────
@@ -62,6 +59,11 @@ const mockRedisLock = {
   releaseLock: jest.fn().mockResolvedValue(undefined),
 };
 
+// ─── Tenant field validation mock ────────────────────────────────────────────
+const mockTenantFieldValidationService = {
+  validateFields: jest.fn().mockResolvedValue(undefined),
+};
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 function makeValidDto(overrides: Record<string, any> = {}) {
   return {
@@ -84,6 +86,7 @@ describe('PatientsService', () => {
         { provide: DataSource, useValue: mockDataSource },
         { provide: RedisLockService, useValue: mockRedisLock },
         { provide: StellarService, useValue: { invokeContract: mockStellarInvokeContract } },
+        { provide: TenantFieldValidationService, useValue: mockTenantFieldValidationService },
       ],
     }).compile();
 
@@ -102,6 +105,7 @@ describe('PatientsService', () => {
     mockQR.commitTransaction.mockResolvedValue(undefined);
     mockQR.rollbackTransaction.mockResolvedValue(undefined);
     mockQR.release.mockResolvedValue(undefined);
+    mockTenantFieldValidationService.validateFields.mockResolvedValue(undefined);
     mockQR.manager.findOne.mockResolvedValue(null);
     mockQR.manager.update.mockResolvedValue(undefined);
     mockQR.manager.save.mockImplementation(async (_entity: any, data: any) => data);
@@ -117,7 +121,7 @@ describe('PatientsService', () => {
       const saved = { ...dto, id: 'uuid-1', mrn: 'MRN-001', isActive: true, isAdmitted: false };
 
       mockRepo.findOneBy.mockResolvedValue(null); // no MRN conflict
-      mockRepo.findOne.mockResolvedValue(null);   // no duplicate
+      mockRepo.findOne.mockResolvedValue(null); // no duplicate
       mockRepo.create.mockReturnValue(saved);
       mockRepo.save.mockResolvedValue(saved);
 
@@ -140,7 +144,12 @@ describe('PatientsService', () => {
     });
 
     it('flags similar names as likely duplicates when the fuzzy score is above threshold', async () => {
-      const dto = makeValidDto({ firstName: 'John', lastName: 'Smith', dateOfBirth: '1985-03-12', sex: 'male' as const });
+      const dto = makeValidDto({
+        firstName: 'John',
+        lastName: 'Smith',
+        dateOfBirth: '1985-03-12',
+        sex: 'male' as const,
+      });
 
       mockRepo.findOneBy.mockResolvedValue(null);
       mockRepo.findOne.mockResolvedValue(null);
@@ -231,7 +240,7 @@ describe('PatientsService', () => {
 
     it('authorized — updates mutable fields for the matching stellarAddress', async () => {
       const existing = aPatient().build();
-      (existing as any).stellarAddress = stellarAddress;
+      existing.stellarAddress = stellarAddress;
       const profileData = { phone: '555-9999', email: 'new@example.com' };
       const updated = { ...existing, ...profileData };
 
@@ -249,17 +258,17 @@ describe('PatientsService', () => {
     it('unauthorized — throws NotFoundException when stellarAddress has no match', async () => {
       mockRepo.findOne.mockResolvedValue(null);
 
-      await expect(
-        service.updateProfile('INVALID_STELLAR', { phone: '555-0000' }),
-      ).rejects.toThrow(NotFoundException);
+      await expect(service.updateProfile('INVALID_STELLAR', { phone: '555-0000' })).rejects.toThrow(
+        NotFoundException,
+      );
 
       expect(mockRepo.save).not.toHaveBeenCalled();
     });
 
     it('does not overwrite immutable fields (stellarAddress, nationalIdHash)', async () => {
       const existing = aPatient().build();
-      (existing as any).stellarAddress = stellarAddress;
-      (existing as any).nationalIdHash = 'original-hash';
+      existing.stellarAddress = stellarAddress;
+      existing.nationalIdHash = 'original-hash';
 
       mockRepo.findOne.mockResolvedValue(existing);
       mockRepo.save.mockImplementation(async (p: any) => p);
@@ -272,7 +281,7 @@ describe('PatientsService', () => {
 
     it('blockchain mock is never called during profile update', async () => {
       const existing = aPatient().build();
-      (existing as any).stellarAddress = stellarAddress;
+      existing.stellarAddress = stellarAddress;
 
       mockRepo.findOne.mockResolvedValue(existing);
       mockRepo.save.mockResolvedValue(existing);
@@ -326,9 +335,7 @@ describe('PatientsService', () => {
       const primary = aPatient().withId('primary-id').build();
       const secondary = aPatient().withId('secondary-id').build();
 
-      mockQR.manager.findOne
-        .mockResolvedValueOnce(primary)
-        .mockResolvedValueOnce(secondary);
+      mockQR.manager.findOne.mockResolvedValueOnce(primary).mockResolvedValueOnce(secondary);
       mockStellarInvokeContract.mockResolvedValue({ txHash: 'tx-hash' });
 
       const result = await service.adminMergePatients(
@@ -392,10 +399,7 @@ describe('PatientsService', () => {
       mockRedisLock.acquireLock.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
       await expect(
-        service.adminMergePatients(
-          { primaryAddress: 'a', secondaryAddress: 'b' },
-          'admin-id',
-        ),
+        service.adminMergePatients({ primaryAddress: 'a', secondaryAddress: 'b' }, 'admin-id'),
       ).rejects.toThrow(ConflictException);
 
       expect(mockRedisLock.releaseLock).toHaveBeenCalledTimes(2);
@@ -406,10 +410,7 @@ describe('PatientsService', () => {
       mockQR.manager.findOne.mockRejectedValueOnce(new Error('DB Error'));
 
       await expect(
-        service.adminMergePatients(
-          { primaryAddress: 'a', secondaryAddress: 'b' },
-          'admin-id',
-        ),
+        service.adminMergePatients({ primaryAddress: 'a', secondaryAddress: 'b' }, 'admin-id'),
       ).rejects.toThrow('DB Error');
 
       expect(mockQR.rollbackTransaction).toHaveBeenCalled();
@@ -419,9 +420,7 @@ describe('PatientsService', () => {
 
     it('throws BadRequestException when merging a patient with itself', async () => {
       const patient = aPatient().withId('same-id').build();
-      mockQR.manager.findOne
-        .mockResolvedValueOnce(patient)
-        .mockResolvedValueOnce(patient);
+      mockQR.manager.findOne.mockResolvedValueOnce(patient).mockResolvedValueOnce(patient);
 
       await expect(
         service.adminMergePatients(
@@ -434,9 +433,7 @@ describe('PatientsService', () => {
     });
 
     it('throws NotFoundException when one patient is missing', async () => {
-      mockQR.manager.findOne
-        .mockResolvedValueOnce(aPatient().build())
-        .mockResolvedValueOnce(null);
+      mockQR.manager.findOne.mockResolvedValueOnce(aPatient().build()).mockResolvedValueOnce(null);
 
       await expect(
         service.adminMergePatients(
@@ -464,7 +461,10 @@ describe('PatientsService', () => {
           action: 'PATIENT_MERGED',
           entity: 'Patient',
           entityId: 'primary-id',
-          details: expect.objectContaining({ primaryId: 'primary-id', secondaryId: 'secondary-id' }),
+          details: expect.objectContaining({
+            primaryId: 'primary-id',
+            secondaryId: 'secondary-id',
+          }),
         }),
       );
     });

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -23,6 +23,8 @@ import { UserRole } from '../auth/entities/user.entity';
 import { AuditLogEntity } from '../common/audit/audit-log.entity';
 import { RedisLockService } from '../common/utils/redis-lock.service';
 import { StellarService } from '../stellar/services/stellar.service';
+import { TenantFieldValidationService } from '../data-validation-integrity/services/tenant-field-validation.service';
+import { TenantContext } from '../tenant/context/tenant.context';
 
 interface DuplicateCandidateSummary {
   id: string;
@@ -43,11 +45,17 @@ export class PatientsService {
     private readonly dataSource: DataSource,
     private readonly redisLock: RedisLockService,
     private readonly stellarService: StellarService,
+    private readonly tenantFieldValidationService: TenantFieldValidationService,
   ) {}
 
   async create(dto: CreatePatientDto): Promise<Patient> {
     if (dto?.dateOfBirth && Number.isNaN(new Date(dto.dateOfBirth as any).getTime())) {
       throw new BadRequestException('Invalid date of birth');
+    }
+
+    const tenantId = TenantContext.getTenantId();
+    if (tenantId) {
+      await this.tenantFieldValidationService.validateFields(tenantId, dto.customFields ?? {});
     }
 
     if ((dto as any)?.mrn) {
@@ -193,7 +201,13 @@ export class PatientsService {
         ORDER BY score DESC
         LIMIT 10
       `,
-      [fullName.toLowerCase(), dto.firstName.toLowerCase(), dto.lastName.toLowerCase(), dto.dateOfBirth, normalizedGender],
+      [
+        fullName.toLowerCase(),
+        dto.firstName.toLowerCase(),
+        dto.lastName.toLowerCase(),
+        dto.dateOfBirth,
+        normalizedGender,
+      ],
     );
 
     const normalizedCandidates = Array.isArray(fuzzyMatches) ? fuzzyMatches : [];
@@ -296,14 +310,23 @@ export class PatientsService {
     };
   }
 
-  async mergePatients(sourceId: string, targetId: string, adminId: string, reason?: string): Promise<Patient> {
+  async mergePatients(
+    sourceId: string,
+    targetId: string,
+    adminId: string,
+    reason?: string,
+  ): Promise<Patient> {
     const lockKeys = [sourceId, targetId].sort().map((id) => `merge:${id}`);
     const LOCK_TTL_MS = 30_000;
 
-    const acquired = await Promise.all(lockKeys.map((k) => this.redisLock.acquireLock(k, LOCK_TTL_MS)));
+    const acquired = await Promise.all(
+      lockKeys.map((k) => this.redisLock.acquireLock(k, LOCK_TTL_MS)),
+    );
     if (acquired.some((ok) => !ok)) {
       await Promise.all(lockKeys.map((k) => this.redisLock.releaseLock(k)));
-      throw new ConflictException('A concurrent merge is already in progress for one of these patients');
+      throw new ConflictException(
+        'A concurrent merge is already in progress for one of these patients',
+      );
     }
 
     const qr = this.dataSource.createQueryRunner();
@@ -312,13 +335,20 @@ export class PatientsService {
 
     try {
       const [target, source] = await Promise.all([
-        qr.manager.findOne(Patient, { where: { id: targetId }, lock: { mode: 'optimistic', version: undefined } }),
-        qr.manager.findOne(Patient, { where: { id: sourceId }, lock: { mode: 'optimistic', version: undefined } }),
+        qr.manager.findOne(Patient, {
+          where: { id: targetId },
+          lock: { mode: 'optimistic', version: undefined },
+        }),
+        qr.manager.findOne(Patient, {
+          where: { id: sourceId },
+          lock: { mode: 'optimistic', version: undefined },
+        }),
       ]);
 
       if (!target) throw new NotFoundException(`Target patient ${targetId} not found`);
       if (!source) throw new NotFoundException(`Source patient ${sourceId} not found`);
-      if (source.id === target.id) throw new BadRequestException('Cannot merge a patient with itself');
+      if (source.id === target.id)
+        throw new BadRequestException('Cannot merge a patient with itself');
 
       await qr.manager.save(
         AuditLogEntity,
@@ -333,7 +363,13 @@ export class PatientsService {
         }),
       );
 
-      for (const table of ['records', 'medical_records', 'access_grants', 'billing', 'prescriptions']) {
+      for (const table of [
+        'records',
+        'medical_records',
+        'access_grants',
+        'billing',
+        'prescriptions',
+      ]) {
         await qr.manager.update(table, { patientId: source.id }, { patientId: target.id });
       }
 


### PR DESCRIPTION
## Summary
- Adds a `TenantFieldValidationRule` entity (`tenantId`, `fieldName`, `type`, regex `pattern`, `required`, `errorMessage`, `isActive`)
- Adds `TenantFieldValidationService` to `src/data-validation-integrity`: loads a tenant's active rules and validates a `customFields` bag against them (required-field and type/regex checks); rejects invalid rule definitions (e.g. a `REGEX` rule with no or malformed pattern) at creation/update time; fields with no matching tenant rule fall through unvalidated (default behavior preserved — no per-DTO code change needed for new custom fields)
- Adds admin CRUD endpoints under `/admin/tenants/:tenantId/field-validation-rules` (list/create/update), guarded by `JwtAuthGuard` + `RolesGuard('admin')`
- Adds a nullable `Patient.customFields` JSON column for jurisdiction-specific attributes (e.g. local insurance numbers, national ID formats) and wires `PatientsService.create()` to validate it against the requesting tenant's rules (via the existing `TenantContext` AsyncLocalStorage) before persisting
- Migration for the new table and the `patients.customFields` column

Closes #848

## Validation performed
- `npx tsc --noEmit` — no new type errors
- `npx eslint --fix` on all changed files — remaining findings are pre-existing `no-unsafe-*` patterns already present throughout `patients.service.ts` (it already used `as any` extensively before this change)
- `npx jest src/data-validation-integrity/services/tenant-field-validation.service.spec.ts` — 9/9 passing, covering rule precedence (applies when present, falls back to no validation when absent, does not leak across tenants) and invalid rule rejection
- `npx jest src/patients` — `patients.service.spec.ts` (updated with the new provider mock) passes in full; `notification-preferences.spec.ts` fails with 9 pre-existing failures unrelated to this change (confirmed identical on `main` — `PatientsService`'s test module there was already missing `DataSource`/`RedisLockService`/`StellarService` providers before this PR)
- `npx jest src/data-validation-integrity` — pre-existing, unrelated failure in `medical-validation.spec.ts` (imports `../services/icd10-validation.service`, but that file lives directly under `src/data-validation-integrity/`, not a `services/` subfolder — confirmed identical on `main`)