### PR TITLE
fix: resolve issues #807, #808, #809, #810

### DIFF
--- a/src/diagnosis/controllers/diagnosis.controller.ts
+++ b/src/diagnosis/controllers/diagnosis.controller.ts
@@ -9,8 +9,10 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { DiagnosisService } from '../services/diagnosis.service';
 import { Icd11Service, Icd11SearchResultDto } from '../services/icd11.service';
 import {
@@ -22,6 +24,7 @@ import {
 
 @ApiTags('Diagnosis')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('diagnosis')
 export class DiagnosisController {
   constructor(

--- a/src/patients/guards/admin-guard.ts
+++ b/src/patients/guards/admin-guard.ts
@@ -5,7 +5,7 @@ export class AdminGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
-    const user = request.user || { role: 'admin' }; // assuming JwtAuthGuard populated this
+    const user = request.user;
     if (!user) {
       throw new ForbiddenException('User not authenticated');
     }

--- a/src/patients/guards/patient-privacy.guard.ts
+++ b/src/patients/guards/patient-privacy.guard.ts
@@ -9,7 +9,7 @@ export class PatientPrivacyGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
-    const user = request.user || { role: 'admin' }; // assuming JwtAuthGuard populated this
+    const user = request.user;
     const patientId = request?.params?.id || request?.body?.id;
 
     if (!user) {

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -177,7 +177,7 @@ export class PatientsService {
           "sex",
           mrn,
           GREATEST(
-            similarity(lower(coalesce("firstName", '') || ' ' || coalesce("lastName", ''))), $1),
+            similarity(lower(coalesce("firstName", '') || ' ' || coalesce("lastName", '')), $1),
             similarity(lower(coalesce("firstName", '')), $2),
             similarity(lower(coalesce("lastName", '')), $3)
           )::float AS score
@@ -186,7 +186,7 @@ export class PatientsService {
           AND "dateOfBirth" = $4
           AND lower(coalesce("sex", 'unknown')) = $5
           AND (
-            similarity(lower(coalesce("firstName", '') || ' ' || coalesce("lastName", ''))), $1) > 0.85
+            similarity(lower(coalesce("firstName", '') || ' ' || coalesce("lastName", '')), $1) > 0.85
             OR similarity(lower(coalesce("firstName", '')), $2) > 0.85
             OR similarity(lower(coalesce("lastName", '')), $3) > 0.85
           )

--- a/src/stellar/services/multi-sig-transaction.service.ts
+++ b/src/stellar/services/multi-sig-transaction.service.ts
@@ -42,7 +42,9 @@ export class MultiSigTransactionService {
   }
 
   async approveTransaction(transactionId: string, dto: ApproveRejectDto): Promise<MultiSigTransactionResponse> {
-    const entity = await this.findPendingOrThrow(transactionId);
+    const entity = await this.repo.findOne({ where: { id: transactionId }, lock: { mode: 'pessimistic_write' } });
+    if (!entity) throw new NotFoundException('Not found');
+    if (entity.status !== MultiSigTransactionStatus.PENDING_SIGNATURES) throw new BadRequestException('Already ' + entity.status);
     if (new Date() > entity.expiresAt) { entity.status = MultiSigTransactionStatus.EXPIRED; await this.repo.save(entity); throw new BadRequestException('Transaction expired'); }
     const se = entity.signatures?.find(s => s.signerId === dto.signerId);
     if (!se) throw new BadRequestException('Not authorised');


### PR DESCRIPTION
closes #807 
closes #809 
closes #808 
closes #810 

#807 - Add pessimistic write lock in approveTransaction() to prevent
       concurrent approval race condition silently dropping signatures.

#808 - Remove fail-open default in PatientPrivacyGuard and AdminGuard:
       request.user || { role: 'admin' } replaced with request.user only,
       so unauthenticated requests are rejected with 403.

#809 - Fix mismatched parentheses in detectDuplicate() SQL GREATEST()
       expression; each similarity() call now has correct closing parens.

#810 - Add @UseGuards(JwtAuthGuard) at controller class level in
       DiagnosisController so all diagnosis endpoints require authentication.