### PR TITLE
Atomic transfer acceptance, per-aggregate checkpoints, CONTRIBUTING/CHANGELOG, Swagger tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project are documented in this file. This
+project uses [Semantic Versioning](https://semver.org/) for
+`packages/sdk` releases (tagged `v*`, see
+`.github/workflows/publish-sdk.yml`), and follows the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+Entries are grouped as `Added`, `Changed`, `Fixed`, `Deprecated`, `Removed`,
+and `Security`. Every PR with a user-visible or API-visible change —
+especially anything affecting `packages/sdk` consumers — should add an entry
+under `[Unreleased]` (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+
+## [Unreleased]
+
+### Fixed
+
+- Hospital transfer acceptance (`TransferService.acceptTransfer`) now runs
+  record-sharing, access-revocation, and the transfer's completion write in
+  a single database transaction. A failure in any step now rolls back and
+  propagates the error instead of being logged and swallowed while the
+  transfer is still marked `COMPLETED`. (#833)
+- Event projection checkpoints (`record`, `access-grant`, `audit`,
+  `analytics` projectors) are now tracked per `(projector, aggregate)` pair
+  instead of as a single global counter per projector. Event-store versions
+  are scoped per-aggregate, so a global checkpoint could cause events from
+  one aggregate to be silently skipped once another aggregate's version had
+  advanced past them, resulting in missed access grants, missed audit
+  entries, and undercounted analytics. (#834)
+
+### Added
+
+- `CONTRIBUTING.md` with setup, branching, commit, and testing conventions.
+- `CHANGELOG.md` (this file).
+- Swagger/OpenAPI decorators (`@ApiTags` and related) on controllers that
+  previously had none, so they render correctly in the Swagger UI at `/api`. (#788)
+
+[Unreleased]: https://github.com/Healthy-Stellar/Healthy-Stellar-backend/compare/main...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to Healthy-Stellar-backend
+
+Thanks for contributing to the Healthy-Stellar backend — a NestJS service for a
+decentralized healthcare system built on Stellar Soroban smart contracts.
+This guide covers how to set up the project, the conventions we follow, and
+how to get a change merged.
+
+## Getting started
+
+1. Install dependencies: `npm install`
+2. Copy environment variables: `cp .env.example .env`
+3. Run database migrations: `npm run migration:run`
+4. (Optional) Seed test data: `npm run seed`
+5. Start the dev server: `npm run start:dev`
+
+See the [README](README.md) for the full local setup, including the Docker
+Compose workflow and configuration reference.
+
+## Branching
+
+Create a feature branch off `main` using:
+
+```
+<type>/<issue-number>-<short-description>
+```
+
+Where `<type>` is one of `feature`, `fix`, `chore`, or `docs`. Examples:
+
+```
+feature/142-fix-payment-reconciliation
+fix/799-stellar-retry-stub
+docs/789-contributing-changelog
+```
+
+## Commit messages
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short summary>
+
+<body: what changed and why>
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`. Example:
+
+```
+fix(billing,stellar): close payment race conditions and dead-letter retry stub
+```
+
+## Making a change
+
+- Preserve existing architecture, naming conventions, and coding patterns in
+  the module you're touching — check for a similar service/controller/entity
+  nearby before introducing a new pattern.
+- Add or update tests alongside any behavioral change (see [Testing](#testing)).
+- If your change touches `src/migrations/`, read
+  [`src/operator-runbook/migration-safety.md`](src/operator-runbook/migration-safety.md)
+  first — the `Migration Safety Gate` CI workflow blocks destructive
+  migrations (dropped columns/tables, unique index removals, `NOT NULL`
+  without a default) unless the PR is labeled `migration-reviewed`.
+- Update [`CHANGELOG.md`](CHANGELOG.md) under `[Unreleased]` for any
+  user-visible or API-visible change, and especially for anything affecting
+  `packages/sdk` consumers.
+- Public HTTP endpoints should carry Swagger decorators (`@ApiTags`,
+  `@ApiOperation`, `@ApiResponse`, etc.) — see any controller under
+  `src/*/controllers/` for the expected shape. Endpoints without them won't
+  render in the Swagger UI at `/api`.
+
+## Code style
+
+- Lint: `npx eslint .`
+- Format: `npx prettier --check .` (`--write` to fix)
+- TypeScript: `npx tsc --noEmit`
+
+## Testing
+
+```bash
+npm run test          # unit tests
+npm run test:e2e      # end-to-end tests
+npm run test:cov      # unit tests with coverage
+npm run test:compliance
+```
+
+Coverage thresholds are enforced globally and, more strictly, for
+patient-data-critical modules (`src/patients`, `src/medical-records`,
+`src/records`, `src/audit`) — see `jest.config.js`.
+
+## packages/sdk
+
+`packages/sdk` is an auto-generated TypeScript client (`npm run generate:sdk`)
+published to npm on `v*` tags via `.github/workflows/publish-sdk.yml`. Any PR
+touching `packages/sdk/**` triggers a dry-run publish/build/test check. Note
+SDK-facing changes in `CHANGELOG.md` so consumers can track them between
+releases.
+
+## Opening a pull request
+
+- Target `main`.
+- Reference the issue you're closing (e.g. `Closes #142`).
+- Describe what changed and how you validated it (tests run, manual checks).
+- Keep PRs scoped to the issue(s) they resolve — avoid bundling unrelated
+  changes.
+
+## Reporting bugs / requesting features
+
+Open a GitHub issue describing the problem or proposal, including
+reproduction steps for bugs where applicable.

--- a/src/OAuth2/oauth2.controller.ts
+++ b/src/OAuth2/oauth2.controller.ts
@@ -22,6 +22,7 @@ import { OAuth2AuthorizeQueryDto, OAuth2TokenDto } from './dto/oidc.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { JwtPayload } from '../auth/services/auth-token.service';
 import { Patient } from '../users/entities/patient.entity';
+import { ApiTags } from '@nestjs/swagger';
 
 /**
  * OAuth2 authorization server endpoints (Issue #649 — PKCE for public clients).
@@ -31,6 +32,7 @@ import { Patient } from '../users/entities/patient.entity';
  * POST /oauth2/token      — exchange authorization code for an access token;
  *                           PKCE verifier is enforced when a challenge was stored.
  */
+@ApiTags('oauth2')
 @Controller('oauth2')
 export class OAuth2Controller {
   constructor(

--- a/src/OAuth2/oidc.controller.ts
+++ b/src/OAuth2/oidc.controller.ts
@@ -22,7 +22,9 @@ import { LinkStellarAddressDto, OidcInitiateQueryDto } from './dto/oidc.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { OidcJwtPayload } from './oidc.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('auth/oidc')
 @Controller('auth/oidc')
 export class OidcController {
   constructor(

--- a/src/OAuth2/smart.controller.ts
+++ b/src/OAuth2/smart.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiExcludeEndpoint } from '@nestjs/swagger';
 
+@ApiTags('smart-config')
 @Controller()
 export class SmartConfigController {
   @Get('.well-known/smart-configuration')

--- a/src/Telemedicine and Remote/src/controllers/Virtual visit.controller.ts
+++ b/src/Telemedicine and Remote/src/controllers/Virtual visit.controller.ts
@@ -14,7 +14,9 @@ import {
 } from '@nestjs/common';
 import { VirtualVisitService } from '../services/virtual-visit.service';
 import { VisitStatus, VisitType } from '../entities/virtual-visit.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('telemedicine/virtual-visits')
 @Controller('telemedicine/virtual-visits')
 export class VirtualVisitController {
   constructor(private readonly virtualVisitService: VirtualVisitService) {}

--- a/src/access-control/services/access-control.service.ts
+++ b/src/access-control/services/access-control.service.ts
@@ -8,7 +8,7 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { LessThanOrEqual, Repository } from 'typeorm';
+import { EntityManager, LessThanOrEqual, Repository } from 'typeorm';
 import { AccessGrant, AccessLevel, GrantStatus } from '../entities/access-grant.entity';
 import { CreateAccessGrantDto } from '../dto/create-access-grant.dto';
 import { CreateEmergencyAccessDto } from '../dto/create-emergency-access.dto';
@@ -437,8 +437,13 @@ export class AccessControlService {
     return !!validGrant;
   }
 
-  async revokeAccessByPatient(patientId: string, granteeId: string): Promise<void> {
-    const grants = await this.grantRepository.find({
+  async revokeAccessByPatient(
+    patientId: string,
+    granteeId: string,
+    manager?: EntityManager,
+  ): Promise<void> {
+    const repo = manager ? manager.getRepository(AccessGrant) : this.grantRepository;
+    const grants = await repo.find({
       where: {
         patientId,
         granteeId,
@@ -449,7 +454,7 @@ export class AccessControlService {
     for (const grant of grants) {
       grant.status = GrantStatus.REVOKED;
       grant.revokedAt = new Date();
-      await this.grantRepository.save(grant);
+      await repo.save(grant);
       this.notificationsService.emitAccessRevoked(patientId, grant.id, {
         granteeId: grant.granteeId,
         revokedAt: grant.revokedAt.toISOString(),

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, VERSION_NEUTRAL } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AppService } from './app.service';
 
+@ApiTags('app')
 @Controller({ version: VERSION_NEUTRAL })
 export class AppController {
   constructor(private readonly appService: AppService) {}

--- a/src/backup/controllers/backup.controller.ts
+++ b/src/backup/controllers/backup.controller.ts
@@ -6,7 +6,9 @@ import { BackupService } from '../services/backup.service';
 import { DisasterRecoveryService, RecoveryOptions } from '../services/disaster-recovery.service';
 import { BackupVerificationService } from '../services/backup-verification.service';
 import { BackupMonitoringService } from '../services/backup-monitoring.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('backup')
 @Controller('backup')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class BackupController {

--- a/src/bed-occupancy/bed-occupancy.controller.ts
+++ b/src/bed-occupancy/bed-occupancy.controller.ts
@@ -18,7 +18,9 @@ import {
   CreateWardDto,
   UpdateBedStatusDto,
 } from './dto/bed-occupancy.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('bed-occupancy')
 @UseGuards(JwtAuthGuard)
 @Controller('bed-occupancy')
 export class BedOccupancyController {

--- a/src/department-and-ward-management/src/departments/beds/beds.controller.ts
+++ b/src/department-and-ward-management/src/departments/beds/beds.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Post, Patch, Param, Body, Query } from '@nestjs/common';
 import { BedsService } from './beds.service';
 import { AssignBedDto } from './dto/assign-bed.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('beds')
 @Controller('beds')
 export class BedsController {
   constructor(private readonly bedsService: BedsService) {}

--- a/src/department-and-ward-management/src/departments/departments.controller.ts
+++ b/src/department-and-ward-management/src/departments/departments.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Post, Body, Param } from '@nestjs/common';
 import { DepartmentsService } from './departments.service';
 import { CreateDepartmentDto } from './dto/create-department.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('departments')
 @Controller('departments')
 export class DepartmentsController {
   constructor(private readonly departmentsService: DepartmentsService) {}

--- a/src/email-notification-service-for-critical-access-events/notifications.controller.ts
+++ b/src/email-notification-service-for-critical-access-events/notifications.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
 import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiTags } from '@nestjs/swagger';
 
 export class UnsubscribeDto {
   @IsString()
@@ -21,6 +22,7 @@ export class UnsubscribeDto {
   patientId: string;
 }
 
+@ApiTags('notifications')
 @Controller('notifications')
 export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}

--- a/src/emergency-medical-info/controllers/emergency-medical-info.controller.ts
+++ b/src/emergency-medical-info/controllers/emergency-medical-info.controller.ts
@@ -5,7 +5,9 @@ import {
   CreateEmergencyMedicalInfoDto,
   UpdateEmergencyMedicalInfoDto,
 } from '../dto/emergency-medical-info.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('emergency-medical-info')
 @UseGuards(JwtAuthGuard)
 @Controller('emergency-medical-info')
 export class EmergencyMedicalInfoController {

--- a/src/emergency-medical-info/controllers/emergency-qr.controller.ts
+++ b/src/emergency-medical-info/controllers/emergency-qr.controller.ts
@@ -10,8 +10,10 @@ import {
 import { Response } from 'express';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { EmergencyQrService } from '../services/emergency-qr.service';
+import { ApiTags } from '@nestjs/swagger';
 
 /** Authenticated endpoints for opt-in / PNG download */
+@ApiTags('emergency-medical-info/qr')
 @UseGuards(JwtAuthGuard)
 @Controller('emergency-medical-info/qr')
 export class EmergencyQrController {

--- a/src/emergency-operations/controllers/emergency-operations.controller.ts
+++ b/src/emergency-operations/controllers/emergency-operations.controller.ts
@@ -15,7 +15,9 @@ import {
 } from '../dto/emergency-operations.dto';
 import { EmergencyResourceStatus } from '../entities/emergency-resource.entity';
 import { TriageQueueStatus } from '../entities/emergency-triage.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('emergency')
 @Controller('emergency')
 export class EmergencyOperationsController {
   constructor(private emergencyService: EmergencyOperationsService) {}

--- a/src/healthcare-monitoring/controllers/clinical-alerts.controller.ts
+++ b/src/healthcare-monitoring/controllers/clinical-alerts.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Post, Put, Body, Param, Query } from '@nestjs/common';
 import { ClinicalAlertService } from '../services/clinical-alert.service';
 import { DashboardService } from '../services/dashboard.service';
 import { AlertType, AlertPriority } from '../entities/clinical-alert.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('clinical-alerts')
 @Controller('clinical-alerts')
 export class ClinicalAlertsController {
   constructor(

--- a/src/healthcare-monitoring/controllers/compliance.controller.ts
+++ b/src/healthcare-monitoring/controllers/compliance.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Post, Body, Query } from '@nestjs/common';
 import { ComplianceMonitoringService } from '../services/compliance-monitoring.service';
 import { ComplianceType } from '../entities/compliance-check.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('compliance')
 @Controller('compliance')
 export class ComplianceController {
   constructor(private complianceService: ComplianceMonitoringService) {}

--- a/src/healthcare-monitoring/controllers/dashboard.controller.ts
+++ b/src/healthcare-monitoring/controllers/dashboard.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { DashboardService } from '../services/dashboard.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('dashboard')
 @Controller('dashboard')
 export class DashboardController {
   constructor(private dashboardService: DashboardService) {}

--- a/src/healthcare-monitoring/controllers/healthcare-monitoring.controller.ts
+++ b/src/healthcare-monitoring/controllers/healthcare-monitoring.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { SystemHealthService } from '../services/system-health.service';
 import { DashboardService } from '../services/dashboard.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('healthcare-monitoring')
 @Controller('healthcare-monitoring')
 export class HealthcareMonitoringController {
   constructor(

--- a/src/hospital-config/hospital-configuration.controller.ts
+++ b/src/hospital-config/hospital-configuration.controller.ts
@@ -20,7 +20,9 @@ import { InsuranceProviderDto } from './src/hospital-configuration/dto/insurance
 import { BillingConfigDto } from './src/hospital-configuration/dto/insurance-billing.dto';
 import { EmergencyProtocolDto } from './src/hospital-configuration/dto/emergency-protocol.dto';
 import { HospitalConfigurationService } from './hospital-configuration.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('hospital-configuration')
 @Controller('hospital-configuration')
 export class HospitalConfigurationController {
   constructor(private readonly configService: HospitalConfigurationService) {}

--- a/src/hospital-registry/controllers/hospital-registry.controller.ts
+++ b/src/hospital-registry/controllers/hospital-registry.controller.ts
@@ -1,7 +1,9 @@
 import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
 import { HospitalRegistryService } from '../services/hospital-registry.service';
 import { CreateHospitalRegistryDto, UpdateHospitalRegistryDto } from '../dto/hospital-registry.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('hospital-registry')
 @Controller('hospital-registry')
 export class HospitalRegistryController {
   constructor(private readonly service: HospitalRegistryService) {}

--- a/src/hospital-registry/services/transfer.service.spec.ts
+++ b/src/hospital-registry/services/transfer.service.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { TransferService } from './transfer.service';
+import { PatientTransfer, TransferStatus } from '../entities/patient-transfer.entity';
+import { HospitalRegistry } from '../entities/hospital-registry.entity';
+import { MedicalRecordsService } from '../../medical-records/services/medical-records.service';
+import { AccessControlService } from '../../access-control/services/access-control.service';
+import { NotificationsService } from '../../notifications/services/notifications.service';
+
+describe('TransferService', () => {
+  let service: TransferService;
+  let medicalRecordsService: { shareWithHospital: jest.Mock };
+  let accessControlService: { revokeAccessByPatient: jest.Mock };
+  let mockManager: { save: jest.Mock };
+  let mockTransferRepository: {
+    findOne: jest.Mock;
+    manager: { transaction: jest.Mock };
+  };
+
+  const pendingTransfer = () => ({
+    id: 'transfer-1',
+    patientId: 'patient-1',
+    patientName: 'Jane Doe',
+    fromHospitalId: 'hospital-from',
+    toHospitalId: 'hospital-to',
+    status: TransferStatus.PENDING,
+    sharedRecordIds: ['record-1', 'record-2'],
+    fromHospital: { email: 'from@hospital.test' },
+    toHospital: { email: 'to@hospital.test' },
+  });
+
+  beforeEach(async () => {
+    mockManager = {
+      save: jest.fn((_entity, data) => Promise.resolve(data)),
+    };
+
+    mockTransferRepository = {
+      findOne: jest.fn(),
+      manager: {
+        transaction: jest.fn((cb) => cb(mockManager)),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TransferService,
+        { provide: getRepositoryToken(PatientTransfer), useValue: mockTransferRepository },
+        { provide: getRepositoryToken(HospitalRegistry), useValue: { findOne: jest.fn() } },
+        {
+          provide: MedicalRecordsService,
+          useValue: { shareWithHospital: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: AccessControlService,
+          useValue: { revokeAccessByPatient: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: NotificationsService,
+          useValue: { emitRecordUploaded: jest.fn() },
+        },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(TransferService);
+    medicalRecordsService = module.get(MedicalRecordsService);
+    accessControlService = module.get(AccessControlService);
+  });
+
+  describe('acceptTransfer', () => {
+    it('completes the transfer when sharing and revocation succeed', async () => {
+      mockTransferRepository.findOne.mockResolvedValue(pendingTransfer());
+
+      const result = await service.acceptTransfer('transfer-1', { acceptedBy: 'user-1' });
+
+      expect(result.status).toBe(TransferStatus.COMPLETED);
+      expect(medicalRecordsService.shareWithHospital).toHaveBeenCalledTimes(2);
+      expect(accessControlService.revokeAccessByPatient).toHaveBeenCalledWith(
+        'patient-1',
+        'hospital-from',
+        mockManager,
+      );
+      expect(mockTransferRepository.manager.transaction).toHaveBeenCalledTimes(1);
+      expect(mockManager.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not mark the transfer COMPLETED when record sharing fails', async () => {
+      mockTransferRepository.findOne.mockResolvedValue(pendingTransfer());
+      medicalRecordsService.shareWithHospital.mockRejectedValueOnce(new Error('IPFS unavailable'));
+
+      await expect(
+        service.acceptTransfer('transfer-1', { acceptedBy: 'user-1' }),
+      ).rejects.toThrow('IPFS unavailable');
+
+      expect(accessControlService.revokeAccessByPatient).not.toHaveBeenCalled();
+      expect(mockManager.save).not.toHaveBeenCalled();
+    });
+
+    it('does not mark the transfer COMPLETED when access revocation fails', async () => {
+      mockTransferRepository.findOne.mockResolvedValue(pendingTransfer());
+      accessControlService.revokeAccessByPatient.mockRejectedValueOnce(
+        new Error('access-control unavailable'),
+      );
+
+      await expect(
+        service.acceptTransfer('transfer-1', { acceptedBy: 'user-1' }),
+      ).rejects.toThrow('access-control unavailable');
+
+      expect(mockManager.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hospital-registry/services/transfer.service.ts
+++ b/src/hospital-registry/services/transfer.service.ts
@@ -99,27 +99,40 @@ export class TransferService {
     transfer.acceptedAt = new Date();
     transfer.acceptedBy = dto.acceptedBy;
 
-    if (transfer.sharedRecordIds.length > 0) {
-      for (const recordId of transfer.sharedRecordIds) {
-        try {
-          await this.medicalRecordsService.shareWithHospital(recordId, transfer.toHospitalId);
-        } catch (err) {
-          this.logger.warn('Failed to share record ' + recordId + ': ' + (err instanceof Error ? err.message : String(err)));
-        }
-      }
-    }
-
+    let saved: PatientTransfer;
     try {
-      await this.accessControlService.revokeAccessByPatient(transfer.patientId, transfer.fromHospitalId);
+      saved = await this.transferRepo.manager.transaction(async (manager) => {
+        if (transfer.sharedRecordIds.length > 0) {
+          for (const recordId of transfer.sharedRecordIds) {
+            await this.medicalRecordsService.shareWithHospital(
+              recordId,
+              transfer.toHospitalId,
+              manager,
+            );
+          }
+        }
+
+        await this.accessControlService.revokeAccessByPatient(
+          transfer.patientId,
+          transfer.fromHospitalId,
+          manager,
+        );
+
+        transfer.status = TransferStatus.COMPLETED;
+        transfer.completedAt = new Date();
+        transfer.stellarTxHash = await this.writeStellarTransferReceipt(transfer);
+
+        return manager.save(PatientTransfer, transfer);
+      });
     } catch (err) {
-      this.logger.warn('Failed to revoke access: ' + (err instanceof Error ? err.message : String(err)));
+      this.logger.error(
+        'Transfer ' +
+          transferId +
+          ' failed during acceptance, rolled back: ' +
+          (err instanceof Error ? err.message : String(err)),
+      );
+      throw err;
     }
-
-    transfer.status = TransferStatus.COMPLETED;
-    transfer.completedAt = new Date();
-    transfer.stellarTxHash = await this.writeStellarTransferReceipt(transfer);
-
-    const saved = await this.transferRepo.save(transfer);
 
     await this.sendTransferNotifications(saved);
 

--- a/src/infection-control/infection-control.controller.ts
+++ b/src/infection-control/infection-control.controller.ts
@@ -13,7 +13,9 @@ import { UpdateOutbreakIncidentDto } from './dto/update-outbreak-incident.dto';
 import { CreateHandHygieneAuditDto } from './dto/create-hand-hygiene-audit.dto';
 import { CreateOutbreakThresholdDto } from './dto/create-outbreak-threshold.dto';
 import { UpdateOutbreakThresholdDto } from './dto/update-outbreak-threshold.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('infection-control')
 @Controller('infection-control')
 export class InfectionControlController {
   constructor(

--- a/src/medical-records/controllers/medical-records-validated.controller.ts
+++ b/src/medical-records/controllers/medical-records-validated.controller.ts
@@ -5,7 +5,9 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { MedicalEmergencyErrorFilter } from '../../common/errors/medical-emergency-error.filter';
 import { MedicalOperationAuditService } from '../../common/audit/medical-operation-audit.service';
 import { MedicalDataValidationPipe } from '../../common/validation/medical-data.validator.pipe';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('medical-records')
 @Controller('medical-records')
 @UseGuards(JwtAuthGuard)
 @UseFilters(MedicalEmergencyErrorFilter)

--- a/src/medical-records/services/medical-records.service.ts
+++ b/src/medical-records/services/medical-records.service.ts
@@ -624,8 +624,13 @@ export class MedicalRecordsService {
     });
   }
 
-  async shareWithHospital(recordId: string, hospitalId: string): Promise<void> {
-    const record = await this.medicalRecordRepository.findOne({
+  async shareWithHospital(
+    recordId: string,
+    hospitalId: string,
+    manager?: EntityManager,
+  ): Promise<void> {
+    const repo = manager ? manager.getRepository(MedicalRecord) : this.medicalRecordRepository;
+    const record = await repo.findOne({
       where: { id: recordId },
     });
     if (!record) {
@@ -633,7 +638,7 @@ export class MedicalRecordsService {
     }
 
     record.organizationId = hospitalId;
-    await this.medicalRecordRepository.save(record);
+    await repo.save(record);
 
     this.logger.log(`Medical record ${recordId} shared with hospital ${hospitalId}`);
   }

--- a/src/medical-staff/medical-staff.controller.ts
+++ b/src/medical-staff/medical-staff.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Post, Put, Delete, Body, Param, Query, UseGuards } from '@nestjs/common';
 import { CreateShiftDto, WeeklyScheduleQueryDto } from './dto/shift.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('medical-staff')
 @Controller('medical-staff')
 export class MedicalStaffController {
   constructor(private readonly staffService: MedicalStaffService) {}

--- a/src/medication-administration/controllers/adverse-reaction.controller.ts
+++ b/src/medication-administration/controllers/adverse-reaction.controller.ts
@@ -5,7 +5,9 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { ReactionSeverity } from '../entities/adverse-drug-reaction.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('adverse-reactions')
 @Controller('adverse-reactions')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class AdverseReactionController {

--- a/src/medication-administration/controllers/barcode.controller.ts
+++ b/src/medication-administration/controllers/barcode.controller.ts
@@ -4,7 +4,9 @@ import { BarcodeScanDto } from '../dto/barcode-scan.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('barcode-verification')
 @Controller('barcode-verification')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class BarcodeController {

--- a/src/medication-administration/controllers/mar.controller.ts
+++ b/src/medication-administration/controllers/mar.controller.ts
@@ -16,7 +16,9 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { UserRole } from '../../auth/entities/user.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('medication-administration')
 @Controller('medication-administration')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class MarController {

--- a/src/medication-administration/controllers/reconciliation.controller.ts
+++ b/src/medication-administration/controllers/reconciliation.controller.ts
@@ -8,7 +8,9 @@ import {
   ReconciliationType,
   ReconciliationStatus,
 } from '../entities/medication-reconciliation.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('medication-reconciliation')
 @Controller('medication-reconciliation')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class ReconciliationController {

--- a/src/migrations/1785000000000-ScopeProjectionCheckpointsByAggregate.ts
+++ b/src/migrations/1785000000000-ScopeProjectionCheckpointsByAggregate.ts
@@ -1,0 +1,84 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Event-store versions are scoped per-aggregate, but `projection_checkpoints`
+ * tracked a single global row per projector. Once the global checkpoint
+ * advanced past a low version from one aggregate, events with version <=
+ * that from every other aggregate were silently skipped as "already
+ * processed". This migration re-scopes the checkpoint to (projector_name,
+ * aggregate_id) so each aggregate's progress is tracked independently.
+ *
+ * Also aligns the table's column names with the `ProjectionCheckpoint`
+ * entity, which already declared snake_case column names that this table
+ * never actually had.
+ */
+export class ScopeProjectionCheckpointsByAggregate1785000000000 implements MigrationInterface {
+  name = 'ScopeProjectionCheckpointsByAggregate1785000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" RENAME COLUMN "projectorName" TO "projector_name"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" RENAME COLUMN "lastProcessedVersion" TO "last_processed_version"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" RENAME COLUMN "updatedAt" TO "updated_at"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" ADD COLUMN IF NOT EXISTS "event_count" BIGINT NOT NULL DEFAULT 0`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" ADD COLUMN "id" UUID NOT NULL DEFAULT uuid_generate_v4()`,
+    );
+    // Existing rows tracked global progress; fold that history under a sentinel
+    // aggregate so replay/idempotency for those projectors is unaffected until
+    // fresh per-aggregate rows are written going forward.
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" ADD COLUMN "aggregate_id" VARCHAR(100) NOT NULL DEFAULT '__legacy_global__'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" ALTER COLUMN "aggregate_id" DROP DEFAULT`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" DROP CONSTRAINT "PK_projection_checkpoints"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" ADD CONSTRAINT "PK_projection_checkpoints" PRIMARY KEY ("id")`,
+    );
+    await queryRunner.query(`
+      ALTER TABLE "projection_checkpoints"
+      ADD CONSTRAINT "UQ_projection_checkpoints_projector_aggregate" UNIQUE ("projector_name", "aggregate_id")
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_projection_checkpoints_projector" ON "projection_checkpoints" ("projector_name")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_projection_checkpoints_projector"`);
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" DROP CONSTRAINT "UQ_projection_checkpoints_projector_aggregate"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" DROP CONSTRAINT "PK_projection_checkpoints"`,
+    );
+    await queryRunner.query(`ALTER TABLE "projection_checkpoints" DROP COLUMN "aggregate_id"`);
+    await queryRunner.query(`ALTER TABLE "projection_checkpoints" DROP COLUMN "id"`);
+    await queryRunner.query(`ALTER TABLE "projection_checkpoints" DROP COLUMN "event_count"`);
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" ADD CONSTRAINT "PK_projection_checkpoints" PRIMARY KEY ("projector_name")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" RENAME COLUMN "projector_name" TO "projectorName"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" RENAME COLUMN "last_processed_version" TO "lastProcessedVersion"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projection_checkpoints" RENAME COLUMN "updated_at" TO "updatedAt"`,
+    );
+  }
+}

--- a/src/pathology/controllers/cytology.controller.ts
+++ b/src/pathology/controllers/cytology.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Post, Body, Param, UseGuards, Request } from '@nestjs/
 import { CytologyService } from '../services/cytology.service';
 import { CreateCytologySlideDto } from '../dto/create-cytology-slide.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pathology/cytology')
 @Controller('pathology/cytology')
 @UseGuards(JwtAuthGuard)
 export class CytologyController {

--- a/src/pathology/controllers/digital-pathology.controller.ts
+++ b/src/pathology/controllers/digital-pathology.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Post, Body, Param, Query, UseGuards, Request } from '@
 import { DigitalPathologyService } from '../services/digital-pathology.service';
 import { UploadDigitalImageDto } from '../dto/upload-digital-image.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pathology/images')
 @Controller('pathology/images')
 @UseGuards(JwtAuthGuard)
 export class DigitalPathologyController {

--- a/src/pathology/controllers/genetic-testing.controller.ts
+++ b/src/pathology/controllers/genetic-testing.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Post, Patch, Body, Param, UseGuards, Request } from '@
 import { GeneticTestingService } from '../services/genetic-testing.service';
 import { CreateGeneticTestDto, UpdateGeneticTestResultDto } from '../dto/create-genetic-test.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pathology/genetic')
 @Controller('pathology/genetic')
 @UseGuards(JwtAuthGuard)
 export class GeneticTestingController {

--- a/src/pathology/controllers/histology.controller.ts
+++ b/src/pathology/controllers/histology.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Post, Body, Param, UseGuards, Request } from '@nestjs/
 import { HistologyService } from '../services/histology.service';
 import { CreateHistologySlideDto } from '../dto/create-histology-slide.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pathology/histology')
 @Controller('pathology/histology')
 @UseGuards(JwtAuthGuard)
 export class HistologyController {

--- a/src/pathology/controllers/molecular-diagnostics.controller.ts
+++ b/src/pathology/controllers/molecular-diagnostics.controller.ts
@@ -5,7 +5,9 @@ import {
   UpdateMolecularTestResultDto,
 } from '../dto/create-molecular-test.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pathology/molecular')
 @Controller('pathology/molecular')
 @UseGuards(JwtAuthGuard)
 export class MolecularDiagnosticsController {

--- a/src/pathology/controllers/pathology-case.controller.ts
+++ b/src/pathology/controllers/pathology-case.controller.ts
@@ -15,7 +15,9 @@ import { CreatePathologyCaseDto } from '../dto/create-pathology-case.dto';
 import { UpdatePathologyCaseDto } from '../dto/update-pathology-case.dto';
 import { SearchPathologyDto } from '../dto/search-pathology.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pathology/cases')
 @Controller('pathology/cases')
 @UseGuards(JwtAuthGuard)
 export class PathologyCaseController {

--- a/src/pathology/controllers/pathology-report.controller.ts
+++ b/src/pathology/controllers/pathology-report.controller.ts
@@ -4,7 +4,9 @@ import { ReportTemplateService } from '../services/report-template.service';
 import { CreatePathologyReportDto } from '../dto/create-pathology-report.dto';
 import { CreateReportTemplateDto } from '../dto/create-report-template.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pathology/reports')
 @Controller('pathology/reports')
 @UseGuards(JwtAuthGuard)
 export class PathologyReportController {

--- a/src/pathology/controllers/quality-control.controller.ts
+++ b/src/pathology/controllers/quality-control.controller.ts
@@ -12,7 +12,9 @@ import {
 import { PathologyQualityService } from '../services/pathology-quality.service';
 import { CreateQualityControlDto } from '../dto/create-quality-control.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pathology/quality')
 @Controller('pathology/quality')
 @UseGuards(JwtAuthGuard)
 export class QualityControlController {

--- a/src/pathology/controllers/specimen.controller.ts
+++ b/src/pathology/controllers/specimen.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Post, Patch, Body, Param, UseGuards, Request } from '@
 import { SpecimenProcessingService } from '../services/specimen-processing.service';
 import { CreateSpecimenDto } from '../dto/create-specimen.dto';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pathology/specimens')
 @Controller('pathology/specimens')
 @UseGuards(JwtAuthGuard)
 export class SpecimenController {

--- a/src/pharmacy/controllers/drug-formulary.controller.ts
+++ b/src/pharmacy/controllers/drug-formulary.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Post, Body, Param, Patch, Delete, Query } from '@nestj
 import { DrugFormularyService } from '../services/drug-formulary.service';
 import { FormularyTier } from '../entities/drug-formulary.entity';
 import { PaginationDto } from '../../common/dto/pagination.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pharmacy/formulary')
 @Controller('pharmacy/formulary')
 export class DrugFormularyController {
   constructor(private formularyService: DrugFormularyService) {}

--- a/src/pharmacy/controllers/drug-recall.controller.ts
+++ b/src/pharmacy/controllers/drug-recall.controller.ts
@@ -3,7 +3,9 @@ import { DrugRecallService } from '../services/drug-recall.service';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 import { CreateDrugRecallDto } from './create-drug-recall.dto';
 import { UpdateDrugRecallDto } from './update-drug-recall.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pharmacy/recalls')
 @Controller('pharmacy/recalls')
 export class DrugRecallController {
   constructor(private recallService: DrugRecallService) {}

--- a/src/pharmacy/controllers/drug-supplier.controller.ts
+++ b/src/pharmacy/controllers/drug-supplier.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Post, Body, Param, Patch, Delete, Query } from '@nestjs/common';
 import { DrugSupplierService } from '../services/drug-supplier.service';
 import { PaginationDto } from '../../common/dto/pagination.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pharmacy/suppliers')
 @Controller('pharmacy/suppliers')
 export class DrugSupplierController {
   constructor(private supplierService: DrugSupplierService) {}

--- a/src/pharmacy/controllers/drug-waste.controller.ts
+++ b/src/pharmacy/controllers/drug-waste.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Post, Body, Param, Patch, Query } from '@nestjs/common
 import { DrugWasteService } from '../services/drug-waste.service';
 import { WasteReason } from '../entities/drug-waste.entity';
 import { PaginationDto } from '../../common/dto/pagination.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pharmacy/waste')
 @Controller('pharmacy/waste')
 export class DrugWasteController {
   constructor(private wasteService: DrugWasteService) {}

--- a/src/pharmacy/controllers/medication-safety.controller.ts
+++ b/src/pharmacy/controllers/medication-safety.controller.ts
@@ -5,7 +5,9 @@ import {
   PrescriptionValidationService,
   PatientFactors,
 } from '../services/prescription-validation.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('medication-safety')
 @Controller('pharmacy/safety')
 // @UseGuards(JwtAuthGuard)
 export class MedicationSafetyController {

--- a/src/pharmacy/controllers/prescription-refill.controller.ts
+++ b/src/pharmacy/controllers/prescription-refill.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Post, Body, Param, Query, UseGuards } from '@nestjs/common';
 import { PrescriptionRefillService } from '../services/prescription-refill.service';
 import { RefillPrescriptionDto } from '../dto/refill-prescription.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('prescription-refill')
 @Controller('pharmacy/refills')
 // @UseGuards(JwtAuthGuard)
 export class PrescriptionRefillController {

--- a/src/pharmacy/controllers/purchase-order.controller.ts
+++ b/src/pharmacy/controllers/purchase-order.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Post, Body, Param, Patch, Query } from '@nestjs/common';
 import { PurchaseOrderService } from '../services/purchase-order.service';
 import { PaginationDto } from '../../common/dto/pagination.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('pharmacy/purchase-orders')
 @Controller('pharmacy/purchase-orders')
 export class PurchaseOrderController {
   constructor(private purchaseOrderService: PurchaseOrderService) {}

--- a/src/profile-and-optimize-database-query-performance-under-load/src/app.controller.ts
+++ b/src/profile-and-optimize-database-query-performance-under-load/src/app.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService, IndexOptimizationEntry } from './app.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('app')
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}

--- a/src/profile-and-optimize-database-query-performance-under-load/src/modules/audit-log/audit-log.controller.ts
+++ b/src/profile-and-optimize-database-query-performance-under-load/src/modules/audit-log/audit-log.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Post, Body, Query, HttpCode, Param } from '@nestjs/common';
 import { AuditLogService } from './audit-log.service';
 import { AuditLog } from './entities/audit-log.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('audit-logs')
 @Controller('audit-logs')
 export class AuditLogController {
   constructor(private readonly auditLogService: AuditLogService) {}

--- a/src/profile-and-optimize-database-query-performance-under-load/src/modules/records/records.controller.ts
+++ b/src/profile-and-optimize-database-query-performance-under-load/src/modules/records/records.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Post, Body, Query, Param, Patch } from '@nestjs/common';
 import { RecordsService } from './records.service';
 import { Record } from './entities/record.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('records')
 @Controller('records')
 export class RecordsController {
   constructor(private readonly recordsService: RecordsService) {}

--- a/src/projections/checkpoint/checkpoint.service.spec.ts
+++ b/src/projections/checkpoint/checkpoint.service.spec.ts
@@ -1,0 +1,130 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CheckpointService } from './checkpoint.service';
+import { ProjectionCheckpoint } from './projection-checkpoint.entity';
+
+describe('CheckpointService', () => {
+  let service: CheckpointService;
+  let queryBuilder: {
+    insert: jest.Mock;
+    into: jest.Mock;
+    values: jest.Mock;
+    orUpdate: jest.Mock;
+    execute: jest.Mock;
+    select: jest.Mock;
+    where: jest.Mock;
+    getRawOne: jest.Mock;
+  };
+  let mockRepo: {
+    findOne: jest.Mock;
+    delete: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    queryBuilder = {
+      insert: jest.fn().mockReturnThis(),
+      into: jest.fn().mockReturnThis(),
+      values: jest.fn().mockReturnThis(),
+      orUpdate: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue(undefined),
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getRawOne: jest.fn(),
+    };
+
+    mockRepo = {
+      findOne: jest.fn(),
+      delete: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CheckpointService,
+        { provide: getRepositoryToken(ProjectionCheckpoint), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get(CheckpointService);
+  });
+
+  describe('getVersion', () => {
+    it('is scoped to a single (projector, aggregate) pair', async () => {
+      mockRepo.findOne.mockResolvedValue({ lastProcessedVersion: 3 });
+
+      const version = await service.getVersion('RecordProjector', 'agg-1');
+
+      expect(version).toBe(3);
+      expect(mockRepo.findOne).toHaveBeenCalledWith({
+        where: { projectorName: 'RecordProjector', aggregateId: 'agg-1' },
+      });
+    });
+
+    it('returns 0 when no checkpoint exists yet for that aggregate', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      const version = await service.getVersion('RecordProjector', 'agg-unknown');
+
+      expect(version).toBe(0);
+    });
+
+    it('does not let one aggregate advancing gate a different aggregate', async () => {
+      mockRepo.findOne.mockImplementation(({ where }) =>
+        Promise.resolve(
+          where.aggregateId === 'agg-1' ? { lastProcessedVersion: 5 } : null,
+        ),
+      );
+
+      const advancedAggregate = await service.getVersion('RecordProjector', 'agg-1');
+      const freshAggregate = await service.getVersion('RecordProjector', 'agg-2');
+
+      expect(advancedAggregate).toBe(5);
+      expect(freshAggregate).toBe(0);
+    });
+  });
+
+  describe('advance', () => {
+    it('upserts on the (projector_name, aggregate_id) conflict target', async () => {
+      await service.advance('RecordProjector', 'agg-1', 2);
+
+      expect(queryBuilder.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectorName: 'RecordProjector',
+          aggregateId: 'agg-1',
+          lastProcessedVersion: 2,
+        }),
+      );
+      expect(queryBuilder.orUpdate).toHaveBeenCalledWith(
+        ['last_processed_version', 'event_count', 'updated_at'],
+        ['projector_name', 'aggregate_id'],
+      );
+    });
+  });
+
+  describe('reset', () => {
+    it('deletes every per-aggregate row for the projector', async () => {
+      await service.reset('RecordProjector');
+
+      expect(mockRepo.delete).toHaveBeenCalledWith({ projectorName: 'RecordProjector' });
+    });
+  });
+
+  describe('getMaxVersion', () => {
+    it('returns the highest recorded version across all aggregates for a projector', async () => {
+      queryBuilder.getRawOne.mockResolvedValue({ max: '7' });
+
+      const max = await service.getMaxVersion('RecordProjector');
+
+      expect(max).toBe(7);
+    });
+
+    it('returns 0 when the projector has no checkpoints yet', async () => {
+      queryBuilder.getRawOne.mockResolvedValue({ max: null });
+
+      const max = await service.getMaxVersion('RecordProjector');
+
+      expect(max).toBe(0);
+    });
+  });
+});

--- a/src/projections/checkpoint/checkpoint.service.ts
+++ b/src/projections/checkpoint/checkpoint.service.ts
@@ -10,35 +10,47 @@ export class CheckpointService {
     private readonly repo: Repository<ProjectionCheckpoint>,
   ) {}
 
-  async getVersion(projectorName: string): Promise<number> {
-    const row = await this.repo.findOne({ where: { projectorName } });
+  async getVersion(projectorName: string, aggregateId: string): Promise<number> {
+    const row = await this.repo.findOne({ where: { projectorName, aggregateId } });
     return row?.lastProcessedVersion ?? 0;
   }
 
-  async advance(projectorName: string, version: number): Promise<void> {
+  async advance(projectorName: string, aggregateId: string, version: number): Promise<void> {
     await this.repo
       .createQueryBuilder()
       .insert()
       .into(ProjectionCheckpoint)
       .values({
         projectorName,
+        aggregateId,
         lastProcessedVersion: version,
         eventCount: () => '"event_count" + 1',
         updatedAt: new Date(),
       })
-      .orUpdate(['last_processed_version', 'event_count', 'updated_at'], ['projector_name'])
+      .orUpdate(
+        ['last_processed_version', 'event_count', 'updated_at'],
+        ['projector_name', 'aggregate_id'],
+      )
       .execute();
   }
 
+  /** Resets every per-aggregate checkpoint tracked for a projector (e.g. before a full replay). */
   async reset(projectorName: string): Promise<void> {
-    await this.repo.upsert(
-      {
-        projectorName,
-        lastProcessedVersion: 0,
-        eventCount: 0,
-        updatedAt: new Date(),
-      },
-      ['projectorName'],
-    );
+    await this.repo.delete({ projectorName });
+  }
+
+  /**
+   * Highest per-aggregate version recorded for a projector, for coarse admin
+   * status reporting only. This is NOT a substitute for the per-aggregate
+   * check in `getVersion` — a single number can't represent per-aggregate
+   * progress.
+   */
+  async getMaxVersion(projectorName: string): Promise<number> {
+    const result = await this.repo
+      .createQueryBuilder('checkpoint')
+      .select('MAX(checkpoint.lastProcessedVersion)', 'max')
+      .where('checkpoint.projectorName = :projectorName', { projectorName })
+      .getRawOne<{ max: string | null }>();
+    return result?.max ? Number(result.max) : 0;
   }
 }

--- a/src/projections/checkpoint/projection-checkpoint.entity.ts
+++ b/src/projections/checkpoint/projection-checkpoint.entity.ts
@@ -1,11 +1,22 @@
-import { Entity, Column, Index } from 'typeorm';
-import { BaseEntity } from '../../common/entities/base.entity';
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
 
 @Entity('projection_checkpoints')
-export class ProjectionCheckpoint extends BaseEntity {
-  @Index({ unique: true })
+@Index(['projectorName', 'aggregateId'], { unique: true })
+export class ProjectionCheckpoint {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
   @Column({ name: 'projector_name' })
   projectorName: string;
+
+  /**
+   * Event-store versions are scoped per-aggregate, so the checkpoint must be
+   * tracked per (projector, aggregate) pair rather than as a single global
+   * counter — otherwise progress on one aggregate incorrectly gates events
+   * from every other aggregate.
+   */
+  @Column({ name: 'aggregate_id' })
+  aggregateId: string;
 
   @Column({ name: 'last_processed_version', type: 'bigint', default: 0 })
   lastProcessedVersion: number;

--- a/src/projections/projections-admin.controller.ts
+++ b/src/projections/projections-admin.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Post, Get, Param, UseGuards, HttpCode, HttpStatus } from '@nestjs/common';
 import { ProjectionRebuildService } from './rebuild/projection-rebuild.service';
 import { ProjectionStatusDto } from './dto/projection-status.dto';
+import { ApiTags } from '@nestjs/swagger';
 
 // Replace with your project's admin guard
 // import { AdminGuard } from '../auth/guards/admin.guard';
 
+@ApiTags('projections-admin')
 @Controller('admin/projections')
 // @UseGuards(AdminGuard)
 export class ProjectionsAdminController {

--- a/src/projections/projectors/access-grant.projector.ts
+++ b/src/projections/projectors/access-grant.projector.ts
@@ -24,8 +24,10 @@ export class AccessGrantProjector implements IEventHandler<
   ) {}
 
   async handle(event: AccessGrantedEvent | AccessRevokedEvent): Promise<void> {
-    const lastVersion = await this.checkpoints.getVersion(PROJECTOR_NAME);
+    const aggregateId = event.grantId;
 
+    // Idempotency guard — scoped per aggregate, since event versions reset per aggregate
+    const lastVersion = await this.checkpoints.getVersion(PROJECTOR_NAME, aggregateId);
     if (event.version <= lastVersion) {
       return;
     }
@@ -37,7 +39,7 @@ export class AccessGrantProjector implements IEventHandler<
         await this.projectRevoked(event);
       }
 
-      await this.checkpoints.advance(PROJECTOR_NAME, event.version);
+      await this.checkpoints.advance(PROJECTOR_NAME, aggregateId, event.version);
     } catch (err) {
       this.logger.error(`${PROJECTOR_NAME}: failed on version ${event.version} — ${err.message}`);
       await this.dlq.add(

--- a/src/projections/projectors/analytics.projector.ts
+++ b/src/projections/projectors/analytics.projector.ts
@@ -24,15 +24,17 @@ export class AnalyticsProjector implements IEventHandler<AnalyticsEvent> {
   ) {}
 
   async handle(event: AnalyticsEvent): Promise<void> {
-    const lastVersion = await this.checkpoints.getVersion(PROJECTOR_NAME);
+    const aggregateId = event instanceof RecordUploadedEvent ? event.recordId : event.grantId;
 
+    // Idempotency guard — scoped per aggregate, since event versions reset per aggregate
+    const lastVersion = await this.checkpoints.getVersion(PROJECTOR_NAME, aggregateId);
     if (event.version <= lastVersion) {
       return;
     }
 
     try {
       await this.upsertSnapshot(event);
-      await this.checkpoints.advance(PROJECTOR_NAME, event.version);
+      await this.checkpoints.advance(PROJECTOR_NAME, aggregateId, event.version);
     } catch (err) {
       this.logger.error(`${PROJECTOR_NAME}: failed on version ${event.version} — ${err.message}`);
       await this.dlq.add(

--- a/src/projections/projectors/audit.projector.ts
+++ b/src/projections/projectors/audit.projector.ts
@@ -33,9 +33,12 @@ export class AuditProjector implements IEventHandler<AuditableEvent> {
   ) {}
 
   async handle(event: AuditableEvent): Promise<void> {
-    const lastVersion = await this.checkpoints.getVersion(PROJECTOR_NAME);
+    const aggregateId = this.extractEntityId(event);
+    const version = this.extractVersion(event);
 
-    if (event.version <= lastVersion) {
+    // Idempotency guard — scoped per aggregate, since event versions reset per aggregate
+    const lastVersion = await this.checkpoints.getVersion(PROJECTOR_NAME, aggregateId);
+    if (version <= lastVersion) {
       return;
     }
 
@@ -46,19 +49,19 @@ export class AuditProjector implements IEventHandler<AuditableEvent> {
         .insert()
         .into(AuditLogProjection)
         .values({
-          aggregateId: this.extractEntityId(event),
+          aggregateId,
           aggregateType: this.extractAggregateType(event),
           eventType: event.constructor.name,
           payload: event as unknown as Record<string, unknown>,
-          version: event.version,
+          version,
           occurredAt: event.occurredAt,
         })
         .orIgnore()
         .execute();
 
-      await this.checkpoints.advance(PROJECTOR_NAME, event.version);
+      await this.checkpoints.advance(PROJECTOR_NAME, aggregateId, version);
     } catch (err) {
-      this.logger.error(`${PROJECTOR_NAME}: failed on version ${event.version} — ${err.message}`);
+      this.logger.error(`${PROJECTOR_NAME}: failed on version ${version} — ${err.message}`);
       await this.dlq.add(
         'projection-failed',
         { projectorName: PROJECTOR_NAME, event, error: err.message },
@@ -76,6 +79,11 @@ export class AuditProjector implements IEventHandler<AuditableEvent> {
       return event.recordId;
     }
     return event.grantId;
+  }
+
+  private extractVersion(event: AuditableEvent): number {
+    if (event instanceof RecordAmendedEvent) return event.newVersion;
+    return event.version;
   }
 
   private extractActorId(event: AuditableEvent): string {

--- a/src/projections/projectors/record.projector.ts
+++ b/src/projections/projectors/record.projector.ts
@@ -22,11 +22,15 @@ export class RecordProjector implements IEventHandler<RecordUploadedEvent | Reco
   ) {}
 
   async handle(event: RecordUploadedEvent | RecordAmendedEvent): Promise<void> {
-    const lastVersion = await this.checkpoints.getVersion(PROJECTOR_NAME);
+    const aggregateId = event.recordId;
+    const version = event instanceof RecordUploadedEvent ? event.version : event.newVersion;
 
-    // Idempotency guard — skip already-processed versions
-    if (event.version <= lastVersion) {
-      this.logger.debug(`${PROJECTOR_NAME}: skipping already-projected version ${event.version}`);
+    // Idempotency guard — scoped per aggregate, since event versions reset per aggregate
+    const lastVersion = await this.checkpoints.getVersion(PROJECTOR_NAME, aggregateId);
+    if (version <= lastVersion) {
+      this.logger.debug(
+        `${PROJECTOR_NAME}: skipping already-projected version ${version} for ${aggregateId}`,
+      );
       return;
     }
 
@@ -37,9 +41,9 @@ export class RecordProjector implements IEventHandler<RecordUploadedEvent | Reco
         await this.projectAmended(event);
       }
 
-      await this.checkpoints.advance(PROJECTOR_NAME, event.version);
+      await this.checkpoints.advance(PROJECTOR_NAME, aggregateId, version);
     } catch (err) {
-      this.logger.error(`${PROJECTOR_NAME}: failed on version ${event.version} — ${err.message}`);
+      this.logger.error(`${PROJECTOR_NAME}: failed on version ${version} — ${err.message}`);
       await this.dlq.add(
         'projection-failed',
         { projectorName: PROJECTOR_NAME, event, error: err.message },

--- a/src/projections/rebuild/projection-rebuild.service.ts
+++ b/src/projections/rebuild/projection-rebuild.service.ts
@@ -57,7 +57,7 @@ export class ProjectionRebuildService {
     const raw = await this.redis.get(STATUS_KEY(projectorName));
 
     if (!raw) {
-      const lastProcessedVersion = await this.checkpoints.getVersion(projectorName);
+      const lastProcessedVersion = await this.checkpoints.getMaxVersion(projectorName);
       return {
         projectorName,
         status: RebuildStatus.IDLE,

--- a/src/rbac/controllers/policy.controller.ts
+++ b/src/rbac/controllers/policy.controller.ts
@@ -3,7 +3,9 @@ import { PolicyService, CreatePolicyDto, UpdatePolicyDto } from '../services/pol
 import { PolicyGuard } from '../guards/policy.guard';
 import { RequireAdmin } from '../decorators/policy.decorator';
 import { Policy } from '../entities/access-policy.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('policies')
 @Controller('policies')
 @UseGuards(PolicyGuard)
 export class PolicyController {

--- a/src/rbac/healthcare-security.controller.ts
+++ b/src/rbac/healthcare-security.controller.ts
@@ -27,12 +27,14 @@ import {
 } from './entities/security-incident.entity';
 import { DeviceTrustLevel } from './entities/medical-device.entity';
 import { AuditAction } from './entities/audit-log.entity';
+import { ApiTags } from '@nestjs/swagger';
 
 interface AuthUser {
   id: string;
   role: string;
 }
 
+@ApiTags('healthcare-security')
 @Controller('healthcare-security')
 export class HealthcareSecurityController {
   constructor(

--- a/src/roles/medical-rbac.controller.ts
+++ b/src/roles/medical-rbac.controller.ts
@@ -27,7 +27,9 @@ import { MedicalUser } from '../interfaces/medical-rbac.interface';
 import { EmergencyOverrideService } from '../services/emergency-override.service';
 import { MedicalAuditService } from '../services/medical-audit.service';
 import { MedicalPermissionsService } from '../services/medical-permissions.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('medical-rbac')
 @Controller('medical-rbac')
 @UseGuards(MedicalRbacGuard)
 export class MedicalRbacController {

--- a/src/security/csp-report.controller.ts
+++ b/src/security/csp-report.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, HttpCode, HttpStatus, Logger, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 
 /**
  * Receives Content Security Policy violation reports (Issue #653).
@@ -7,6 +8,7 @@ import { Body, Controller, HttpCode, HttpStatus, Logger, Post } from '@nestjs/co
  * `reportUri: ['/csp-report']`.  In production the endpoint still exists but
  * Helmet does not send reports there.
  */
+@ApiTags('csp-report')
 @Controller('csp-report')
 export class CspReportController {
   private readonly logger = new Logger(CspReportController.name);

--- a/src/stellar/controllers/stellar.controller.ts
+++ b/src/stellar/controllers/stellar.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Query, HttpCode, HttpStatus, UseGuards } from '@nestjs/common';
 import { StellarFeeService } from '../services/stellar-fee.service';
 import { FeeEstimateResponse } from '../interfaces/fee-estimate.interface';
+import { ApiTags } from '@nestjs/swagger';
 
 /**
  * Stellar Controller
@@ -8,6 +9,7 @@ import { FeeEstimateResponse } from '../interfaces/fee-estimate.interface';
  * Provides endpoints for Stellar blockchain operations including
  * fee estimation for transactions.
  */
+@ApiTags('stellar')
 @Controller('stellar')
 export class StellarController {
   constructor(private readonly stellarFeeService: StellarFeeService) {}

--- a/src/surgical-management-system/surgical/Surgical.controller.ts
+++ b/src/surgical-management-system/surgical/Surgical.controller.ts
@@ -46,7 +46,9 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { UserRole } from '../../auth/entities/user.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('surgical')
 @Controller('surgical')
 export class SurgicalController {
   constructor(

--- a/src/telemedicine-and-remote/src/controllers/Virtual visit.controller.ts
+++ b/src/telemedicine-and-remote/src/controllers/Virtual visit.controller.ts
@@ -12,7 +12,9 @@ import {
 } from '@nestjs/common';
 import { VirtualVisitService } from '../services/virtual-visit.service';
 import { VisitStatus, VisitType } from '../entities/virtual-visit.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('telemedicine/virtual-visits')
 @Controller('telemedicine/virtual-visits')
 export class VirtualVisitController {
   constructor(private readonly virtualVisitService: VirtualVisitService) {}

--- a/src/tenant-config/controllers/tenant-config.controller.ts
+++ b/src/tenant-config/controllers/tenant-config.controller.ts
@@ -23,7 +23,9 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { UserRole } from '../../auth/entities/user.entity';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('admin/tenants')
 @Controller('admin/tenants')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Throttle({ default: { limit: 100, ttl: 60000 } }) // 100 requests per minute

--- a/src/tenant-provisioning-and-onboarding-workflow/src/onboarding/controllers/onboarding.controller.ts
+++ b/src/tenant-provisioning-and-onboarding-workflow/src/onboarding/controllers/onboarding.controller.ts
@@ -13,7 +13,9 @@ import {
   RegisterHospitalDto,
   VerifyEmailDto,
 } from '../dto/onboarding.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('onboarding')
 @Controller('onboarding')
 export class OnboardingController {
   constructor(private readonly service: OnboardingService) {}

--- a/src/tenant-provisioning-and-onboarding-workflow/src/tenants/controllers/tenants.controller.ts
+++ b/src/tenant-provisioning-and-onboarding-workflow/src/tenants/controllers/tenants.controller.ts
@@ -19,7 +19,9 @@ import { CreateTenantDto, ProvisioningStatusDto, TenantResponseDto } from '../dt
 import { Tenant } from '../entities/tenant.entity';
 import { ProvisioningService } from '../services/provisioning.service';
 import { ProvisioningJobData } from '../processors/provisioning.processor';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('admin/tenants')
 @Controller('admin/tenants')
 export class TenantsController {
   private readonly logger = new Logger(TenantsController.name);

--- a/src/tenant-quota/tenant-quota.controller.ts
+++ b/src/tenant-quota/tenant-quota.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Patch, Param, Body, UseGuards, HttpCode, HttpStatus } from 
 import { TenantQuotaService } from './tenant-quota.service';
 import { RolesGuard } from '../common/guards/roles.guard'; // Example Admin Role guard
 import { Roles } from '../common/decorators/roles.decorator';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('admin/tenant-quota')
 @Controller('admin/tenant-quota')
 @UseGuards(RolesGuard)
 @Roles('ADMIN') // Restrict access to administrative accounts

--- a/src/treatment-planning/treatment-planning.controller.ts
+++ b/src/treatment-planning/treatment-planning.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Post, Body, Param, ParseIntPipe, Request } from '@nestjs/common';
 import { TreatmentPlanningService } from './treatment-planning.service';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('treatment-plans')
 @Controller('treatment-plans')
 export class TreatmentPlanningController {
   constructor(private readonly planningService: TreatmentPlanningService) {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -3,7 +3,9 @@ import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('users')
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}


### PR DESCRIPTION
## Summary

Closes #833, closes #834, closes #789, closes #788.

- **#833 — Hospital transfer marked COMPLETED even when record sharing / access revocation silently fail.** `TransferService.acceptTransfer()` now runs record-sharing, access-revocation, and the transfer's completion write inside a single database transaction (an optional `EntityManager` is now threaded through `MedicalRecordsService.shareWithHospital` and `AccessControlService.revokeAccessByPatient`). A failure anywhere in that sequence now rolls back and propagates instead of being logged as a warning while the transfer is still marked `COMPLETED`.

- **#834 — Event-store version numbers are per-aggregate but treated as a global sequence by every projector.** `CheckpointService` and the `record`/`access-grant`/`audit`/`analytics` projectors now track progress per `(projector, aggregate)` pair instead of a single global row per projector, so one aggregate's progress can no longer cause events from another aggregate to be silently skipped. Includes a migration (`1785000000000-ScopeProjectionCheckpointsByAggregate`) that adds the `aggregate_id` column and aligns the table's columns with the `ProjectionCheckpoint` entity (which never actually matched the original migration's schema). The admin rebuild-status endpoint now calls a new `getMaxVersion()` for its coarse, cross-aggregate status display.

- **#789 — No CONTRIBUTING.md or CHANGELOG.md in the repo.** Adds both, covering setup, branching/commit conventions, testing, the migration safety gate, and `packages/sdk` release process.

- **#788 — Swagger/OpenAPI decorators missing on 58 of 161 controllers.** Adds `@ApiTags` to every controller that had none (63 found at time of fix — a few more than the issue's count, likely due to controllers added since it was filed), so all endpoints render and group correctly in the Swagger UI at `/api`.

## Testing / validation performed

- Added `src/hospital-registry/services/transfer.service.spec.ts`: happy path, and rollback + error propagation when record-sharing or access-revocation fails.
- Added `src/projections/checkpoint/checkpoint.service.spec.ts`: per-aggregate isolation of `getVersion`/`advance`, the upsert conflict target, `reset`, and `getMaxVersion`.
- Ran `node scripts/check-migration-safety.js` locally — the new migration reports "no risky operations detected" (two unrelated pre-existing violations from older migrations are reported regardless of this branch).
- Verified programmatically that all 163 `*.controller.ts` files now contain `@ApiTags`, with no duplicate decorators and no accidental placement on the wrong class.
- **Not run:** `npm run build`, `npm test`, lint/format — dependencies were intentionally not installed in this environment per task constraints (no `node_modules`). Please confirm these pass in CI; I did my best to verify manually (brace/paren balance, `.prettierrc` conventions, line width) across every changed file.

## Notes / follow-ups for reviewers

- While implementing #834 I found the `ProjectionsModule` has some pre-existing issues unrelated to this ticket that I deliberately left untouched per the "don't fix unrelated pre-existing bugs" constraint: `projections.module.ts` imports `ProjectionDlqProcessor` from `./rebuild/projection-dlq.processor`, a file that does not exist anywhere in git history (predates this PR, going back to the original `feat: add event projection system` commit). There are also orphaned duplicate implementations under `src/projections/entities/projection-checkpoint.entity.ts`, `src/projections/services/*`, and `src/projections/domain-event-published.event.ts` that aren't wired into `ProjectionsModule` and whose specs (`record.projector.spec.ts`, `access-grant.projector.spec.ts`, `audit.projector.spec.ts`, `projections.integration.spec.ts`) test that unwired shape rather than the active one — these were already failing before this branch. Worth a separate cleanup issue.
- For #788, I scoped the fix to `@ApiTags` (the specific gap called out in the issue — zero `@Api*` decorators causing missing Swagger UI grouping). Per-endpoint `@ApiOperation`/`@ApiResponse` decoration across 63 controllers felt like a much larger, separate effort.