### PR TITLE
fix(security): close auth gaps in key mgmt, OAuth2, MFA and refresh tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -391,6 +391,21 @@ OIDC_PROVIDERS=
 # OIDC_AZURE_CLIENT_SECRET=your_azure_client_secret
 # OIDC_AZURE_REDIRECT_URI=http://localhost:3000/auth/oidc/azure/callback
 
+# Registered clients allowed to use the /oauth2/authorize + /oauth2/token
+# SMART-on-FHIR authorization server. A client_id not listed here, or a
+# redirect_uri not registered for that client, is rejected.
+# Comma-separated list of client entries (arbitrary internal names).
+# Example: OAUTH2_CLIENTS=ehr,mobile
+OAUTH2_CLIENTS=
+
+# Per-client configuration — repeat this block for each entry listed above,
+# replacing {CLIENT} with the name in uppercase (e.g. EHR, MOBILE).
+#
+# OAUTH2_CLIENT_{CLIENT}_ID=your_registered_client_id
+# OAUTH2_CLIENT_{CLIENT}_REDIRECT_URIS=https://app.example.com/callback
+# OAUTH2_CLIENT_{CLIENT}_SECRET=              # optional — omit for public (PKCE) clients
+# OAUTH2_CLIENT_{CLIENT}_PKCE_REQUIRED=       # optional — defaults to true unless SECRET is set
+
 
 # =============================================================================
 # Logging

--- a/src/OAuth2/oauth2-client-registry.service.ts
+++ b/src/OAuth2/oauth2-client-registry.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { buildOAuth2ClientsConfig, OAuth2ClientConfig } from './oauth2-client.config';
+
+/**
+ * Registered-client lookup for the OAuth2 authorization server (Issue #792).
+ * Unknown client_ids and unregistered redirect_uris must be rejected before
+ * an authorization code is ever issued or a redirect is performed.
+ */
+@Injectable()
+export class OAuth2ClientRegistryService {
+  private readonly clients: Map<string, OAuth2ClientConfig>;
+
+  constructor() {
+    this.clients = new Map(
+      buildOAuth2ClientsConfig().map((client) => [client.clientId, client]),
+    );
+  }
+
+  getClient(clientId: string): OAuth2ClientConfig | undefined {
+    return this.clients.get(clientId);
+  }
+
+  isRedirectUriRegistered(client: OAuth2ClientConfig, redirectUri: string): boolean {
+    return client.redirectUris.includes(redirectUri);
+  }
+}

--- a/src/OAuth2/oauth2-client.config.ts
+++ b/src/OAuth2/oauth2-client.config.ts
@@ -1,0 +1,53 @@
+export interface OAuth2ClientConfig {
+  clientId: string;
+  redirectUris: string[];
+  /** Present for confidential clients; omitted for public (PKCE-only) clients */
+  clientSecret?: string;
+  requirePkce: boolean;
+}
+
+/**
+ * Build the registry of clients allowed to use this OAuth2 authorization
+ * server, from environment variables (Issue #792 — client registry /
+ * redirect_uri allowlist for the SMART-on-FHIR authorize endpoint).
+ *
+ * Convention (supports N clients):
+ *   OAUTH2_CLIENTS=ehr,mobile
+ *
+ *   OAUTH2_CLIENT_{NAME}_ID=...
+ *   OAUTH2_CLIENT_{NAME}_REDIRECT_URIS=https://a.example.com/cb,https://b.example.com/cb
+ *   OAUTH2_CLIENT_{NAME}_SECRET=...            # optional — omit for public clients
+ *   OAUTH2_CLIENT_{NAME}_PKCE_REQUIRED=true    # optional — defaults to true unless a secret is set
+ *
+ * A client_id with no matching entry here is rejected by the authorize
+ * endpoint, and a redirect_uri not listed for that client is rejected too.
+ */
+export function buildOAuth2ClientsConfig(): OAuth2ClientConfig[] {
+  const rawClients = process.env.OAUTH2_CLIENTS ?? '';
+  const clientNames = rawClients
+    .split(',')
+    .map((name) => name.trim().toLowerCase())
+    .filter(Boolean);
+
+  return clientNames.map((name) => {
+    const prefix = `OAUTH2_CLIENT_${name.toUpperCase()}`;
+    const clientId = requireEnv(`${prefix}_ID`);
+    const redirectUris = requireEnv(`${prefix}_REDIRECT_URIS`)
+      .split(',')
+      .map((uri) => uri.trim())
+      .filter(Boolean);
+    const clientSecret = process.env[`${prefix}_SECRET`] || undefined;
+    const pkceRequiredEnv = process.env[`${prefix}_PKCE_REQUIRED`];
+    const requirePkce = pkceRequiredEnv ? pkceRequiredEnv === 'true' : !clientSecret;
+
+    return { clientId, redirectUris, clientSecret, requirePkce };
+  });
+}
+
+function requireEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+}

--- a/src/OAuth2/oauth2.controller.ts
+++ b/src/OAuth2/oauth2.controller.ts
@@ -16,8 +16,10 @@ import { JwtService } from '@nestjs/jwt';
 import { Request, Response } from 'express';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
 
 import { PkceService } from './pkce.service';
+import { OAuth2ClientRegistryService } from './oauth2-client-registry.service';
 import { OAuth2AuthorizeQueryDto, OAuth2TokenDto } from './dto/oidc.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { JwtPayload } from '../auth/services/auth-token.service';
@@ -38,6 +40,7 @@ export class OAuth2Controller {
   constructor(
     private readonly pkce: PkceService,
     private readonly jwt: JwtService,
+    private readonly clientRegistry: OAuth2ClientRegistryService,
     @InjectRepository(Patient)
     private readonly patientRepo: Repository<Patient>,
   ) {}
@@ -54,6 +57,21 @@ export class OAuth2Controller {
   ) {
     if (query.response_type !== 'code') {
       throw new BadRequestException('unsupported_response_type');
+    }
+
+    const client = this.clientRegistry.getClient(query.client_id);
+    if (!client) {
+      throw new BadRequestException('invalid_client: unknown client_id');
+    }
+
+    if (!this.clientRegistry.isRedirectUriRegistered(client, query.redirect_uri)) {
+      throw new BadRequestException(
+        'invalid_request: redirect_uri is not registered for this client',
+      );
+    }
+
+    if (client.requirePkce && !query.code_challenge) {
+      throw new BadRequestException('invalid_request: code_challenge is required for this client');
     }
 
     const user = (req as any).user as JwtPayload;
@@ -89,6 +107,17 @@ export class OAuth2Controller {
       throw new BadRequestException(
         'invalid_request: code, client_id and redirect_uri are required',
       );
+    }
+
+    const client = this.clientRegistry.getClient(dto.client_id);
+    if (!client) {
+      throw new BadRequestException('invalid_client: unknown client_id');
+    }
+
+    if (client.clientSecret) {
+      if (!dto.client_secret || !this.isClientSecretValid(dto.client_secret, client.clientSecret)) {
+        throw new UnauthorizedException('invalid_client: client authentication failed');
+      }
     }
 
     // consumeCode validates PKCE when a challenge was stored for this code
@@ -135,5 +164,14 @@ export class OAuth2Controller {
     }
 
     return response;
+  }
+
+  private isClientSecretValid(provided: string, expected: string): boolean {
+    const providedBuf = Buffer.from(provided);
+    const expectedBuf = Buffer.from(expected);
+    if (providedBuf.length !== expectedBuf.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(providedBuf, expectedBuf);
   }
 }

--- a/src/OAuth2/oidc.module.ts
+++ b/src/OAuth2/oidc.module.ts
@@ -10,6 +10,7 @@ import { OidcController } from './oidc.controller';
 import { OAuth2Controller } from './oauth2.controller';
 import { SmartConfigController } from './smart.controller';
 import { PkceService } from './pkce.service';
+import { OAuth2ClientRegistryService } from './oauth2-client-registry.service';
 import { buildOidcConfig } from './oidc.config';
 import { UsersModule } from '../users/users.module';
 import { User } from '../auth/entities/user.entity';
@@ -60,8 +61,9 @@ import { Patient } from '../users/entities/patient.entity';
     OidcStrategy,
     OidcService,
     PkceService,
+    OAuth2ClientRegistryService,
   ],
   controllers: [OidcController, OAuth2Controller, SmartConfigController],
-  exports: [OidcService, OidcClientRegistry, PkceService],
+  exports: [OidcService, OidcClientRegistry, PkceService, OAuth2ClientRegistryService],
 })
 export class OidcModule {}

--- a/src/auth/services/auth-token.service.ts
+++ b/src/auth/services/auth-token.service.ts
@@ -46,7 +46,7 @@ export class AuthTokenService {
 
   /**
    * Generate refresh token for session renewal.
-   * Signed with REFRESH_TOKEN_SECRET so access and refresh tokens
+   * Signed with JWT_REFRESH_SECRET so access and refresh tokens
    * cannot be substituted for each other.
    */
   generateRefreshToken(user: User, sessionId: string): string {
@@ -57,7 +57,7 @@ export class AuthTokenService {
     };
 
     return this.jwtService.sign(payload, {
-      secret: this.configService.get<string>('REFRESH_TOKEN_SECRET'),
+      secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
       expiresIn: '7d',
       algorithm: 'HS512',
     }); // refresh tokens use a separate static secret — not subject to JWT_SECRET rotation
@@ -91,7 +91,7 @@ export class AuthTokenService {
   verifyRefreshToken(token: string): any {
     try {
       return this.jwtService.verify(token, {
-        secret: this.configService.get<string>('REFRESH_TOKEN_SECRET'),
+        secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
         algorithms: ['HS512'],
       });
     } catch (error) {

--- a/src/auth/services/mfa.service.spec.ts
+++ b/src/auth/services/mfa.service.spec.ts
@@ -1,0 +1,79 @@
+import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as speakeasy from 'speakeasy';
+import { MfaService } from './mfa.service';
+import { DataEncryptionService } from '../../common/services/data-encryption.service';
+
+describe('MfaService', () => {
+  let service: MfaService;
+  let userRepository: { findOne: jest.Mock; save: jest.Mock };
+  let mfaRepository: { create: jest.Mock; save: jest.Mock };
+
+  const user = {
+    id: 'user-1',
+    email: 'patient@example.com',
+    mfaSecret: null as string | null,
+    mfaEnabled: false,
+  };
+
+  beforeEach(() => {
+    user.mfaSecret = null;
+    user.mfaEnabled = false;
+
+    userRepository = {
+      findOne: jest.fn().mockResolvedValue(user),
+      save: jest.fn().mockImplementation(async (u) => {
+        Object.assign(user, u);
+        return user;
+      }),
+    };
+    mfaRepository = {
+      create: jest.fn().mockImplementation((data) => data),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const configService = {
+      get: jest.fn().mockReturnValue('a'.repeat(32)),
+    } as unknown as ConfigService;
+
+    service = new MfaService(
+      mfaRepository as any,
+      userRepository as any,
+      new DataEncryptionService(configService),
+    );
+  });
+
+  it('verifies enrollment against the exact secret returned by setupMfa (Issue #793)', async () => {
+    const setup = await service.setupMfa(user.id);
+
+    // The persisted secret must round-trip to the one shown for QR scanning.
+    const validCode = speakeasy.totp({ secret: setup.secret, encoding: 'base32' });
+
+    const result = await service.verifyAndEnableMfa(user.id, validCode);
+
+    expect(result.success).toBe(true);
+    expect(user.mfaEnabled).toBe(true);
+  });
+
+  it('rejects verification when setup was never called', async () => {
+    await expect(service.verifyAndEnableMfa(user.id, '123456')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects verification when the persisted secret is corrupted', async () => {
+    user.mfaSecret = 'not-valid-ciphertext';
+
+    await expect(service.verifyAndEnableMfa(user.id, '123456')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects an incorrect verification code', async () => {
+    await service.setupMfa(user.id);
+
+    await expect(service.verifyAndEnableMfa(user.id, '000000')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+});

--- a/src/auth/services/mfa.service.ts
+++ b/src/auth/services/mfa.service.ts
@@ -83,19 +83,17 @@ export class MfaService {
       throw new NotFoundException('User not found');
     }
 
-    let secret = '';
-    try {
-      secret = this.dataEncryptionService.decrypt(user.mfaSecret || '');
-    } catch {
-      secret = user.mfaSecret || '';
+    if (!user.mfaSecret) {
+      throw new BadRequestException('MFA setup has not been initiated. Call setup first.');
     }
 
-    if (!secret) {
-      secret = speakeasy.generateSecret({
-        name: `Healthy Stellar (${user.email})`,
-        issuer: 'Healthy Stellar',
-        length: 32,
-      }).base32;
+    let secret: string;
+    try {
+      secret = this.dataEncryptionService.decrypt(user.mfaSecret);
+    } catch {
+      throw new BadRequestException(
+        'MFA setup secret is invalid or corrupted. Please restart MFA setup.',
+      );
     }
 
     const verified = speakeasy.totp.verify({

--- a/src/key-management/controllers/key-management-admin.controller.ts
+++ b/src/key-management/controllers/key-management-admin.controller.ts
@@ -1,9 +1,15 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { EnvelopeKeyManagementService } from '../services/envelope-key-management.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { UserRole } from '../../auth/entities/user.entity';
 
 @ApiTags('Admin - Key Management')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
 @Controller('admin/key-management')
 export class KeyManagementAdminController {
   constructor(private readonly keyMgmt: EnvelopeKeyManagementService) {}

--- a/test/.env.test
+++ b/test/.env.test
@@ -21,7 +21,7 @@ DB_SSL_ENABLED=false
 # JWT Configuration (use simple secrets for tests)
 JWT_SECRET=test-jwt-secret-key-for-testing-only
 JWT_EXPIRATION=1h
-REFRESH_TOKEN_SECRET=test-refresh-secret-key-for-testing-only
+JWT_REFRESH_SECRET=test-refresh-secret-key-for-testing-only
 REFRESH_TOKEN_EXPIRATION=7d
 
 # Encryption (use test key - NOT for production)
@@ -53,3 +53,10 @@ USE_DETERMINISTIC_DATA=true
 
 # Disable rate limiting in tests
 RATE_LIMIT_ENABLED=false
+
+# OAuth2 client registry (Issue #792) — clients used by the SMART-on-FHIR e2e tests
+OAUTH2_CLIENTS=smartapp,fhirapp
+OAUTH2_CLIENT_SMARTAPP_ID=smart-app
+OAUTH2_CLIENT_SMARTAPP_REDIRECT_URIS=https://app.example.com/callback
+OAUTH2_CLIENT_FHIRAPP_ID=fhir-app
+OAUTH2_CLIENT_FHIRAPP_REDIRECT_URIS=https://fhir-app.example.com/callback


### PR DESCRIPTION
## Summary

Fixes four independently-reported security issues:

- closes #791 — `KeyManagementAdminController` had zero auth guards, letting any unauthenticated caller trigger master-key rotation and read rotation history. Added `@UseGuards(JwtAuthGuard, RolesGuard)` + `@Roles(UserRole.ADMIN)`, mirroring the already-secured sibling `KekRotationController`.
- closes #792 — `/oauth2/authorize` and `/oauth2/token` accepted any caller-supplied `client_id`/`redirect_uri` with no registry lookup, enabling open-redirect / authorization-code exfiltration against the SMART-on-FHIR authorization server. Added an env-driven client registry (`OAUTH2_CLIENTS` + `OAUTH2_CLIENT_{NAME}_*`, following the existing `OIDC_PROVIDERS` convention): `authorize()` now rejects unknown `client_id`s and unregistered `redirect_uri`s and requires PKCE for public clients; `token()` validates `client_secret` (timing-safe compare) for confidential clients.
- closes #793 — `verifyAndEnableMfa()` retained a fallback that silently generated a brand-new, unrelated TOTP secret whenever the user's persisted `mfaSecret` was missing or failed to decrypt. Removed the fallback; it now fails loudly with a clear `BadRequestException` instead. (The original persistence bug in `setupMfa()` had already been fixed by an unrelated prior commit — this closes the remaining unsafe fallback path and adds regression coverage for the full setup → verify round trip.)
- closes #794 — `auth-token.service.ts` signed/verified refresh tokens with `REFRESH_TOKEN_SECRET` (no default), which doesn't match `JWT_REFRESH_SECRET`, the name required by `env.validation.ts` and set by `.env.example`/`.env.docker`. In any environment configured per the shipped templates, refresh tokens were signed with `secret: undefined`. Renamed both call sites to `JWT_REFRESH_SECRET`, and fixed the same stale name in `test/.env.test`.

## Testing / validation performed

- Manual, line-by-line static review of every changed file (TypeScript syntax, string-enum typing, import paths, Prettier line-width) — this environment has no `node_modules` installed and the task instructions explicitly prohibit installing any dependencies, so `nest build` / `jest` / `eslint` could not be executed directly.
- Confirmed via `grep` that no other reference to the old `REFRESH_TOKEN_SECRET` name remains anywhere in `src/` or `test/`.
- Added `src/auth/services/mfa.service.spec.ts` covering: setup → verify round trip succeeds against the exact persisted secret, verify-before-setup is rejected, a corrupted persisted secret is rejected, and an incorrect TOTP code is rejected.
- Updated `test/.env.test` to register the `smart-app`/`fhir-app` OAuth2 clients already exercised by `test/e2e/smart-on-fhir.e2e-spec.ts`, so the existing e2e suite keeps passing against the new fail-closed client allowlist.
- Deliberately used `UserRole.ADMIN` (a real, type-checked enum member) rather than copying the sibling `KekRotationController`'s `@Roles('security-admin', 'admin')`, since `'security-admin'` is not a member of the `UserRole` string enum and is not type-safe against it.