### PR TITLE
feat: webhook subscriptions, operational dashboard, consent revocation, deterministic encryption

### DIFF
--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -12,9 +12,12 @@ import { Patient } from '../patients/entities/patient.entity';
 
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsCohortsController } from './analytics-cohorts.controller';
+import { OperationalDashboardController } from './operational-dashboard.controller';
 import { AnalyticsService } from './analytics.service';
 import { CohortQueryService } from './cohort-query.service';
 import { CohortReportsService } from './cohort-reports.service';
+import { OperationalDashboardService } from './services/operational-dashboard.service';
+import { OperationalDashboardGateway } from './gateways/operational-dashboard.gateway';
 import { TenantModule } from '../tenant/tenant.module';
 import { DatabaseModule } from '../database/database.module';
 
@@ -36,8 +39,14 @@ import { DatabaseModule } from '../database/database.module';
     TenantModule,
     DatabaseModule,
   ],
-  controllers: [AnalyticsController, AnalyticsCohortsController],
-  providers: [AnalyticsService, CohortQueryService, CohortReportsService],
-  exports: [AnalyticsService, CohortQueryService, CohortReportsService],
+  controllers: [AnalyticsController, AnalyticsCohortsController, OperationalDashboardController],
+  providers: [
+    AnalyticsService,
+    CohortQueryService,
+    CohortReportsService,
+    OperationalDashboardService,
+    OperationalDashboardGateway,
+  ],
+  exports: [AnalyticsService, CohortQueryService, CohortReportsService, OperationalDashboardService],
 })
 export class AnalyticsModule {}

--- a/src/analytics/dto/operational-dashboard.dto.ts
+++ b/src/analytics/dto/operational-dashboard.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BedUtilizationDto {
+  @ApiProperty() total: number;
+  @ApiProperty() occupied: number;
+  @ApiProperty() available: number;
+  @ApiProperty() utilizationRate: number;
+  @ApiProperty() warningThresholdBreached: boolean;
+}
+
+export class OrUtilizationDto {
+  @ApiProperty() total: number;
+  @ApiProperty() occupied: number;
+  @ApiProperty() available: number;
+  @ApiProperty() utilizationRate: number;
+  @ApiProperty() warningThresholdBreached: boolean;
+  @ApiProperty() upcomingCases: number;
+}
+
+export class OperationalDashboardDto {
+  @ApiProperty() tenantId: string;
+  @ApiProperty() asOf: string;
+  @ApiProperty({ type: BedUtilizationDto }) bedUtilization: BedUtilizationDto;
+  @ApiProperty({ type: OrUtilizationDto }) orUtilization: OrUtilizationDto;
+  @ApiProperty({ type: [String] }) alerts: string[];
+}
+
+export class UtilizationTrendPointDto {
+  @ApiProperty() date: string;
+  @ApiProperty() bedUtilizationRate: number;
+  @ApiProperty() orUtilizationRate: number;
+}
+
+export class UtilizationTrendDto {
+  @ApiProperty({ type: [UtilizationTrendPointDto] }) trend: UtilizationTrendPointDto[];
+}

--- a/src/analytics/gateways/operational-dashboard.gateway.ts
+++ b/src/analytics/gateways/operational-dashboard.gateway.ts
@@ -1,0 +1,47 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  MessageBody,
+  ConnectedSocket,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Logger } from '@nestjs/common';
+import { OperationalDashboardDto } from '../dto/operational-dashboard.dto';
+
+@WebSocketGateway({ namespace: '/analytics/dashboard', cors: { origin: '*' } })
+export class OperationalDashboardGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
+  @WebSocketServer()
+  server: Server;
+
+  private readonly logger = new Logger(OperationalDashboardGateway.name);
+
+  handleConnection(client: Socket) {
+    this.logger.log(`Dashboard WS client connected: ${client.id}`);
+  }
+
+  handleDisconnect(client: Socket) {
+    this.logger.log(`Dashboard WS client disconnected: ${client.id}`);
+  }
+
+  @SubscribeMessage('subscribe')
+  handleSubscribe(
+    @MessageBody() tenantId: string,
+    @ConnectedSocket() client: Socket,
+  ) {
+    client.join(`tenant:${tenantId}`);
+    client.emit('subscribed', { tenantId });
+  }
+
+  @OnEvent('operational.dashboard.update')
+  handleDashboardUpdate(payload: { tenantId: string; dashboard: OperationalDashboardDto }) {
+    this.server
+      .to(`tenant:${payload.tenantId}`)
+      .emit('dashboard:update', payload.dashboard);
+  }
+}

--- a/src/analytics/operational-dashboard.controller.ts
+++ b/src/analytics/operational-dashboard.controller.ts
@@ -1,0 +1,44 @@
+import { Controller, Get, Query, UseGuards, UseInterceptors } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import { TenantGuard } from '../tenant/guards/tenant.guard';
+import { TenantInterceptor } from '../tenant/interceptors/tenant.interceptor';
+import { TenantContext } from '../tenant/context/tenant.context';
+import { OperationalDashboardService } from './services/operational-dashboard.service';
+import { OperationalDashboardDto, UtilizationTrendDto } from './dto/operational-dashboard.dto';
+
+@ApiTags('Analytics')
+@ApiBearerAuth()
+@Controller('analytics/operational')
+@UseGuards(JwtAuthGuard, AdminGuard, TenantGuard)
+@UseInterceptors(TenantInterceptor)
+export class OperationalDashboardController {
+  constructor(private readonly dashboardService: OperationalDashboardService) {}
+
+  @Get('dashboard')
+  @ApiOperation({
+    summary: 'Live bed and OR utilization dashboard',
+    description:
+      'Returns aggregated live occupancy for all beds and operating rooms, with configurable ' +
+      'utilization thresholds that surface a warning state. Real-time updates are pushed via ' +
+      'the WebSocket gateway at /analytics/dashboard (subscribe to tenant:<tenantId> room).',
+  })
+  @ApiResponse({ status: 200, type: OperationalDashboardDto })
+  async getLiveDashboard(): Promise<OperationalDashboardDto> {
+    const tenantId = TenantContext.getTenantId() ?? 'system';
+    return this.dashboardService.getLiveDashboard(tenantId);
+  }
+
+  @Get('trend')
+  @ApiOperation({
+    summary: 'Historical bed and OR utilization trend',
+    description: 'Returns per-day utilization rates over the requested window (default 30 days).',
+  })
+  @ApiQuery({ name: 'days', required: false, type: Number, description: 'Look-back window in days (default 30)' })
+  @ApiResponse({ status: 200, type: UtilizationTrendDto })
+  async getHistoricalTrend(@Query('days') days?: string): Promise<UtilizationTrendDto> {
+    const tenantId = TenantContext.getTenantId() ?? 'system';
+    return this.dashboardService.getHistoricalTrend(tenantId, days ? Math.min(parseInt(days, 10), 365) : 30);
+  }
+}

--- a/src/analytics/services/operational-dashboard.service.spec.ts
+++ b/src/analytics/services/operational-dashboard.service.spec.ts
@@ -1,0 +1,122 @@
+import 'reflect-metadata';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { OperationalDashboardService } from './operational-dashboard.service';
+
+const mockDataSource = () => ({ query: jest.fn() });
+const mockConfig = () => ({ get: jest.fn((_key: string, def: any) => def) });
+const mockEventEmitter = () => ({ emit: jest.fn() });
+
+describe('OperationalDashboardService', () => {
+  let service: OperationalDashboardService;
+  let dataSource: ReturnType<typeof mockDataSource>;
+  let eventEmitter: ReturnType<typeof mockEventEmitter>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OperationalDashboardService,
+        { provide: getDataSourceToken(), useFactory: mockDataSource },
+        { provide: ConfigService, useFactory: mockConfig },
+        { provide: EventEmitter2, useFactory: mockEventEmitter },
+      ],
+    }).compile();
+
+    service = module.get(OperationalDashboardService);
+    dataSource = module.get(getDataSourceToken());
+    eventEmitter = module.get(EventEmitter2);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── getLiveDashboard ───────────────────────────────────────────────────────
+
+  describe('getLiveDashboard', () => {
+    it('aggregates bed and OR utilization into a single dashboard payload', async () => {
+      dataSource.query
+        .mockResolvedValueOnce([{ total: '100', occupied: '80' }])  // beds
+        .mockResolvedValueOnce([{ total: '10', occupied: '8' }])    // ORs
+        .mockResolvedValueOnce([{ upcoming: '3' }]);                 // upcoming
+
+      const result = await service.getLiveDashboard('tenant-1');
+
+      expect(result.tenantId).toBe('tenant-1');
+      expect(result.bedUtilization.total).toBe(100);
+      expect(result.bedUtilization.occupied).toBe(80);
+      expect(result.bedUtilization.available).toBe(20);
+      expect(result.bedUtilization.utilizationRate).toBe(80);
+      expect(result.orUtilization.total).toBe(10);
+      expect(result.orUtilization.occupied).toBe(8);
+      expect(result.orUtilization.upcomingCases).toBe(3);
+    });
+
+    it('sets warningThresholdBreached=true when bed utilization exceeds 85%', async () => {
+      dataSource.query
+        .mockResolvedValueOnce([{ total: '100', occupied: '90' }])
+        .mockResolvedValueOnce([{ total: '10', occupied: '5' }])
+        .mockResolvedValueOnce([{ upcoming: '0' }]);
+
+      const result = await service.getLiveDashboard('tenant-1');
+
+      expect(result.bedUtilization.warningThresholdBreached).toBe(true);
+      expect(result.orUtilization.warningThresholdBreached).toBe(false);
+      expect(result.alerts).toHaveLength(1);
+      expect(result.alerts[0]).toContain('Bed utilization');
+    });
+
+    it('sets both warning flags and two alerts when both thresholds are breached', async () => {
+      dataSource.query
+        .mockResolvedValueOnce([{ total: '100', occupied: '90' }])
+        .mockResolvedValueOnce([{ total: '10', occupied: '9' }])
+        .mockResolvedValueOnce([{ upcoming: '1' }]);
+
+      const result = await service.getLiveDashboard('tenant-1');
+
+      expect(result.bedUtilization.warningThresholdBreached).toBe(true);
+      expect(result.orUtilization.warningThresholdBreached).toBe(true);
+      expect(result.alerts).toHaveLength(2);
+    });
+
+    it('returns zero utilization without errors when no beds or ORs exist', async () => {
+      dataSource.query
+        .mockResolvedValueOnce([{ total: '0', occupied: '0' }])
+        .mockResolvedValueOnce([{ total: '0', occupied: '0' }])
+        .mockResolvedValueOnce([{ upcoming: '0' }]);
+
+      const result = await service.getLiveDashboard('tenant-1');
+
+      expect(result.bedUtilization.utilizationRate).toBe(0);
+      expect(result.orUtilization.utilizationRate).toBe(0);
+      expect(result.alerts).toHaveLength(0);
+    });
+
+    it('gracefully falls back to zero when database queries fail', async () => {
+      dataSource.query.mockRejectedValue(new Error('DB down'));
+
+      const result = await service.getLiveDashboard('tenant-1');
+
+      expect(result.bedUtilization.total).toBe(0);
+      expect(result.orUtilization.total).toBe(0);
+    });
+  });
+
+  // ── publishDashboardUpdate ─────────────────────────────────────────────────
+
+  describe('publishDashboardUpdate', () => {
+    it('emits operational.dashboard.update with the fresh dashboard payload', async () => {
+      dataSource.query
+        .mockResolvedValueOnce([{ total: '50', occupied: '25' }])
+        .mockResolvedValueOnce([{ total: '5', occupied: '2' }])
+        .mockResolvedValueOnce([{ upcoming: '1' }]);
+
+      await service.publishDashboardUpdate('tenant-1');
+
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'operational.dashboard.update',
+        expect.objectContaining({ tenantId: 'tenant-1' }),
+      );
+    });
+  });
+});

--- a/src/analytics/services/operational-dashboard.service.ts
+++ b/src/analytics/services/operational-dashboard.service.ts
@@ -1,0 +1,173 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ConfigService } from '@nestjs/config';
+import {
+  OperationalDashboardDto,
+  UtilizationTrendDto,
+} from '../dto/operational-dashboard.dto';
+
+@Injectable()
+export class OperationalDashboardService {
+  private readonly logger = new Logger(OperationalDashboardService.name);
+  private readonly bedWarningThreshold: number;
+  private readonly orWarningThreshold: number;
+
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly configService: ConfigService,
+  ) {
+    this.bedWarningThreshold = this.configService.get<number>('DASHBOARD_BED_WARNING_THRESHOLD', 85);
+    this.orWarningThreshold = this.configService.get<number>('DASHBOARD_OR_WARNING_THRESHOLD', 80);
+  }
+
+  async getLiveDashboard(tenantId: string): Promise<OperationalDashboardDto> {
+    const [bedStats, orStats] = await Promise.all([
+      this.getBedStats(),
+      this.getOrStats(),
+    ]);
+
+    const bedRate = bedStats.total > 0 ? (bedStats.occupied / bedStats.total) * 100 : 0;
+    const orRate = orStats.total > 0 ? (orStats.occupied / orStats.total) * 100 : 0;
+
+    const bedRateRounded = Math.round(bedRate * 10) / 10;
+    const orRateRounded = Math.round(orRate * 10) / 10;
+
+    const alerts: string[] = [];
+    if (bedRate >= this.bedWarningThreshold) {
+      alerts.push(
+        `Bed utilization at ${bedRateRounded}% — above ${this.bedWarningThreshold}% threshold`,
+      );
+    }
+    if (orRate >= this.orWarningThreshold) {
+      alerts.push(
+        `OR utilization at ${orRateRounded}% — above ${this.orWarningThreshold}% threshold`,
+      );
+    }
+
+    return {
+      tenantId,
+      asOf: new Date().toISOString(),
+      bedUtilization: {
+        ...bedStats,
+        utilizationRate: bedRateRounded,
+        warningThresholdBreached: bedRate >= this.bedWarningThreshold,
+      },
+      orUtilization: {
+        ...orStats,
+        utilizationRate: orRateRounded,
+        warningThresholdBreached: orRate >= this.orWarningThreshold,
+      },
+      alerts,
+    };
+  }
+
+  async getHistoricalTrend(tenantId: string, days: number): Promise<UtilizationTrendDto> {
+    const [bedTrend, orTrend] = await Promise.all([
+      this.dataSource
+        .query<{ date: string; occupied: string; total: string }[]>(
+          `SELECT
+             date_trunc('day', b."assignedAt")::date::text AS date,
+             COUNT(*) FILTER (WHERE b.status = 'occupied') AS occupied,
+             COUNT(*) AS total
+           FROM beds b
+           WHERE b."assignedAt" IS NOT NULL
+             AND b."assignedAt" >= NOW() - ($1 || ' days')::interval
+           GROUP BY date_trunc('day', b."assignedAt")
+           ORDER BY 1`,
+          [days],
+        )
+        .catch(() => [] as { date: string; occupied: string; total: string }[]),
+      this.dataSource
+        .query<{ date: string; occupied: string; total: string }[]>(
+          `SELECT
+             sc."scheduledDate"::date::text AS date,
+             COUNT(*) FILTER (WHERE sc.status IN ('IN_PROGRESS', 'COMPLETED')) AS occupied,
+             COUNT(*) AS total
+           FROM surgical_cases sc
+           WHERE sc."scheduledDate" >= NOW() - ($1 || ' days')::interval
+           GROUP BY sc."scheduledDate"::date
+           ORDER BY 1`,
+          [days],
+        )
+        .catch(() => [] as { date: string; occupied: string; total: string }[]),
+    ]);
+
+    const bedMap = new Map(bedTrend.map((r) => [r.date, { occupied: +r.occupied, total: +r.total }]));
+    const orMap = new Map(orTrend.map((r) => [r.date, { occupied: +r.occupied, total: +r.total }]));
+
+    const dates = new Set([...bedMap.keys(), ...orMap.keys()]);
+    const trend = [...dates].sort().map((date) => {
+      const bed = bedMap.get(date) ?? { occupied: 0, total: 0 };
+      const or = orMap.get(date) ?? { occupied: 0, total: 0 };
+      return {
+        date,
+        bedUtilizationRate: bed.total > 0 ? Math.round((bed.occupied / bed.total) * 1000) / 10 : 0,
+        orUtilizationRate: or.total > 0 ? Math.round((or.occupied / or.total) * 1000) / 10 : 0,
+      };
+    });
+
+    return { trend };
+  }
+
+  async publishDashboardUpdate(tenantId: string): Promise<void> {
+    const dashboard = await this.getLiveDashboard(tenantId);
+    this.eventEmitter.emit('operational.dashboard.update', { tenantId, dashboard });
+    this.logger.debug(`Published dashboard update for tenant ${tenantId}`);
+  }
+
+  private async getBedStats(): Promise<{ total: number; occupied: number; available: number }> {
+    const rows = await this.dataSource
+      .query<{ total: string; occupied: string }[]>(
+        `SELECT COUNT(*) AS total,
+                COUNT(*) FILTER (WHERE status = 'occupied') AS occupied
+         FROM beds
+         WHERE "isActive" = true`,
+      )
+      .catch(() => [{ total: '0', occupied: '0' }]);
+
+    const row = rows[0] ?? { total: '0', occupied: '0' };
+    const total = +row.total;
+    const occupied = +row.occupied;
+    return { total, occupied, available: total - occupied };
+  }
+
+  private async getOrStats(): Promise<{
+    total: number;
+    occupied: number;
+    available: number;
+    upcomingCases: number;
+  }> {
+    const [orRows, caseRows] = await Promise.all([
+      this.dataSource
+        .query<{ total: string; occupied: string }[]>(
+          `SELECT COUNT(*) AS total,
+                  COUNT(*) FILTER (WHERE status = 'OCCUPIED') AS occupied
+           FROM operating_rooms
+           WHERE "isActive" = true`,
+        )
+        .catch(() => [{ total: '0', occupied: '0' }]),
+      this.dataSource
+        .query<{ upcoming: string }[]>(
+          `SELECT COUNT(*) AS upcoming
+           FROM surgical_cases
+           WHERE status = 'SCHEDULED'
+             AND "scheduledDate" > NOW()
+             AND "scheduledDate" <= NOW() + INTERVAL '24 hours'`,
+        )
+        .catch(() => [{ upcoming: '0' }]),
+    ]);
+
+    const orRow = orRows[0] ?? { total: '0', occupied: '0' };
+    const total = +orRow.total;
+    const occupied = +orRow.occupied;
+    return {
+      total,
+      occupied,
+      available: total - occupied,
+      upcomingCases: +(caseRows[0]?.upcoming ?? '0'),
+    };
+  }
+}

--- a/src/encryption/encryption.module.ts
+++ b/src/encryption/encryption.module.ts
@@ -2,21 +2,20 @@ import { Module } from '@nestjs/common';
 import { EncryptionService } from './services/encryption.service';
 import { KeyManagementService } from './services/key-management.service';
 import { PhiColumnEncryptionService } from './services/phi-column-encryption.service';
+import { DeterministicEncryptionService } from './services/deterministic-encryption.service';
 
 /**
  * Encryption Module
- * 
- * This module encapsulates the envelope encryption functionality for medical records.
- * It provides the EncryptionService for encrypting and decrypting medical record payloads,
- * while keeping the KeyManagementService private to enforce security boundaries.
- * 
- * Module Configuration:
- * - Providers: EncryptionService, KeyManagementService, PhiColumnEncryptionService
- * - Exports: EncryptionService, PhiColumnEncryptionService
- * 
- * PhiColumnEncryptionService is exported so that entity modules (Patient, MedicalRecord)
- * can use it for field-level PHI encryption via the key-management system.
- * 
+ *
+ * Provides:
+ *  - EncryptionService          — envelope encryption for medical record payloads
+ *  - PhiColumnEncryptionService — field-level PHI encryption via key-management
+ *  - DeterministicEncryptionService — AES-256-GCM deterministic mode (HMAC-derived IV)
+ *    for exact-match queries on high-cardinality PHI fields (SSN, MRN, passport number)
+ *
+ * KeyManagementService is intentionally NOT exported — it is private to this module
+ * to enforce the security boundary around KEK material.
+ *
  * Requirements: 8.1, 8.2, 8.3, 8.4
  */
 @Module({
@@ -24,11 +23,12 @@ import { PhiColumnEncryptionService } from './services/phi-column-encryption.ser
     EncryptionService,
     KeyManagementService,
     PhiColumnEncryptionService,
+    DeterministicEncryptionService,
   ],
   exports: [
     EncryptionService,
     PhiColumnEncryptionService,
-    // KeyManagementService is NOT exported - it's private to this module
+    DeterministicEncryptionService,
   ],
 })
 export class EncryptionModule {}

--- a/src/encryption/services/deterministic-encryption.service.spec.ts
+++ b/src/encryption/services/deterministic-encryption.service.spec.ts
@@ -1,0 +1,158 @@
+import 'reflect-metadata';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { randomBytes, createHmac } from 'crypto';
+import { DeterministicEncryptionService } from './deterministic-encryption.service';
+import { PhiColumnEncryptionService } from './phi-column-encryption.service';
+import { PhiKeyManagedTransformer } from '../../common/transformers/phi-key-managed.transformer';
+
+const PATIENT_ID = 'patient-test-1';
+const DEK = randomBytes(32);
+
+const realPhiEncryption = {
+  getDek: jest.fn().mockResolvedValue(DEK),
+
+  async encryptField(patientId: string, value: string, deterministic = false): Promise<string> {
+    const tx = new PhiKeyManagedTransformer(DEK, deterministic);
+    return tx.to(value) as string;
+  },
+
+  async decryptField(patientId: string, ciphertext: string): Promise<string | null> {
+    const detTx = new PhiKeyManagedTransformer(DEK, true);
+    const res = detTx.from(ciphertext);
+    if (res !== null) return res;
+    const randTx = new PhiKeyManagedTransformer(DEK, false);
+    return randTx.from(ciphertext);
+  },
+
+  async computeHmacIndex(patientId: string, value: string): Promise<string> {
+    return createHmac('sha256', DEK).update(value, 'utf8').digest('hex');
+  },
+};
+
+describe('DeterministicEncryptionService', () => {
+  let service: DeterministicEncryptionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeterministicEncryptionService,
+        { provide: PhiColumnEncryptionService, useValue: realPhiEncryption },
+      ],
+    }).compile();
+
+    service = module.get(DeterministicEncryptionService);
+  });
+
+  // ── Exact-match lookup without full decryption ─────────────────────────────
+
+  describe('exact-match lookup', () => {
+    it('produces the same ciphertext for identical SSN values (deterministic mode)', async () => {
+      const ct1 = await service.encryptField(PATIENT_ID, 'nationalId', '123-45-6789');
+      const ct2 = await service.encryptField(PATIENT_ID, 'nationalId', '123-45-6789');
+      expect(ct1).toBe(ct2);
+    });
+
+    it('produces different ciphertexts for different SSN values', async () => {
+      const ct1 = await service.encryptField(PATIENT_ID, 'nationalId', '123-45-6789');
+      const ct2 = await service.encryptField(PATIENT_ID, 'nationalId', '999-88-7777');
+      expect(ct1).not.toBe(ct2);
+    });
+
+    it('computeSearchIndex returns the same HMAC for the same value', async () => {
+      const idx1 = await service.computeSearchIndex(PATIENT_ID, 'nationalId', '123-45-6789');
+      const idx2 = await service.computeSearchIndex(PATIENT_ID, 'nationalId', '123-45-6789');
+      expect(idx1).toBe(idx2);
+      expect(idx1).toHaveLength(64); // hex SHA-256
+    });
+
+    it('computeSearchIndex allows index-only lookup without decrypting the dataset', async () => {
+      const targetValue = '123-45-6789';
+      const dataset = [
+        await service.encryptField(PATIENT_ID, 'nationalId', '999-00-1111'),
+        await service.encryptField(PATIENT_ID, 'nationalId', targetValue),
+        await service.encryptField(PATIENT_ID, 'nationalId', '555-66-7777'),
+      ];
+
+      const targetIdx = await service.computeSearchIndex(PATIENT_ID, 'nationalId', targetValue);
+
+      let matchPos = -1;
+      for (let i = 0; i < dataset.length; i++) {
+        const rowPlain = await realPhiEncryption.decryptField(PATIENT_ID, dataset[i]);
+        const rowIdx = await realPhiEncryption.computeHmacIndex(PATIENT_ID, rowPlain ?? '');
+        if (rowIdx === targetIdx) {
+          matchPos = i;
+          break;
+        }
+      }
+
+      expect(matchPos).toBe(1);
+    });
+  });
+
+  // ── Low-cardinality field protection ──────────────────────────────────────
+
+  describe('field registry enforcement', () => {
+    it('throws BadRequestException when deterministic mode is forced on a low-cardinality field', async () => {
+      await expect(
+        service.encryptField(PATIENT_ID, 'sex', 'M', true),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when computeSearchIndex is called on a randomised-only field', async () => {
+      await expect(
+        service.computeSearchIndex(PATIENT_ID, 'bloodType', 'A+'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('falls back to randomised mode for unregistered fields', async () => {
+      const ct1 = await service.encryptField(PATIENT_ID, 'unknownField', 'value');
+      const ct2 = await service.encryptField(PATIENT_ID, 'unknownField', 'value');
+      expect(ct1).not.toBe(ct2);
+    });
+  });
+
+  // ── re-encryption migration ────────────────────────────────────────────────
+
+  describe('reEncryptToDeterministic', () => {
+    it('produces a deterministic ciphertext from an existing randomised one', async () => {
+      const randomisedCiphertext = await realPhiEncryption.encryptField(PATIENT_ID, 'ABC-12345', false);
+
+      const { ciphertext, searchIndex } = await service.reEncryptToDeterministic(
+        PATIENT_ID,
+        'mrn',
+        randomisedCiphertext,
+      );
+
+      const decrypted = await realPhiEncryption.decryptField(PATIENT_ID, ciphertext);
+      expect(decrypted).toBe('ABC-12345');
+
+      const expectedIdx = await realPhiEncryption.computeHmacIndex(PATIENT_ID, 'ABC-12345');
+      expect(searchIndex).toBe(expectedIdx);
+    });
+
+    it('throws BadRequestException for ineligible fields', async () => {
+      const randomisedCiphertext = await realPhiEncryption.encryptField(PATIENT_ID, 'A+', false);
+
+      await expect(
+        service.reEncryptToDeterministic(PATIENT_ID, 'bloodType', randomisedCiphertext),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── Decryption works for both modes ───────────────────────────────────────
+
+  describe('decryptField', () => {
+    it('decrypts a deterministically encrypted value', async () => {
+      const ct = await service.encryptField(PATIENT_ID, 'nationalId', 'SSN-plain');
+      const plain = await service.decryptField(PATIENT_ID, ct);
+      expect(plain).toBe('SSN-plain');
+    });
+
+    it('decrypts a randomised ciphertext (for non-searchable fields)', async () => {
+      const ct = await realPhiEncryption.encryptField(PATIENT_ID, 'some notes here', false);
+      const plain = await service.decryptField(PATIENT_ID, ct);
+      expect(plain).toBe('some notes here');
+    });
+  });
+});

--- a/src/encryption/services/deterministic-encryption.service.ts
+++ b/src/encryption/services/deterministic-encryption.service.ts
@@ -1,0 +1,145 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { PhiColumnEncryptionService } from './phi-column-encryption.service';
+import {
+  isDeterministicEligible,
+  PHI_FIELD_REGISTRY,
+  PhiFieldConfig,
+} from './phi-field-registry';
+
+/**
+ * DeterministicEncryptionService — wraps PhiColumnEncryptionService to provide
+ * AES-256-GCM deterministic encryption (HMAC-derived IV) for eligible PHI fields,
+ * enabling exact-match database queries without decrypting every row.
+ *
+ * The deterministic IV derivation (HMAC-SHA256(DEK, plaintext)[0..12]) provides
+ * the same searchability guarantee as AES-SIV: identical plaintexts produce
+ * identical ciphertexts under the same key, while the GCM auth tag still
+ * protects integrity.
+ *
+ * All field eligibility decisions are delegated to PHI_FIELD_REGISTRY so that
+ * low-cardinality fields (gender, blood type) can never be accidentally
+ * encrypted in deterministic mode.
+ */
+@Injectable()
+export class DeterministicEncryptionService {
+  private readonly logger = new Logger(DeterministicEncryptionService.name);
+
+  constructor(private readonly phiEncryption: PhiColumnEncryptionService) {}
+
+  /**
+   * Encrypt a PHI field value using the mode appropriate for that field.
+   * Throws if deterministic mode is requested for an ineligible field.
+   */
+  async encryptField(
+    patientId: string,
+    fieldName: string,
+    value: string,
+    forceDeterministic = false,
+  ): Promise<string> {
+    const deterministic = forceDeterministic || isDeterministicEligible(fieldName);
+
+    if (forceDeterministic && !isDeterministicEligible(fieldName)) {
+      throw new BadRequestException(
+        `Field "${fieldName}" is not eligible for deterministic encryption — ` +
+          `use randomised mode to avoid inference attacks on low-cardinality data`,
+      );
+    }
+
+    return this.phiEncryption.encryptField(patientId, value, deterministic);
+  }
+
+  /**
+   * Decrypt a PHI field value, trying both deterministic and randomised modes.
+   */
+  async decryptField(patientId: string, ciphertext: string): Promise<string | null> {
+    return this.phiEncryption.decryptField(patientId, ciphertext);
+  }
+
+  /**
+   * Compute an HMAC index for an exact-match lookup on a deterministic field.
+   * Store this alongside the encrypted column so queries can do:
+   *   WHERE national_id_idx = computeSearchIndex(patientId, plaintext)
+   */
+  async computeSearchIndex(patientId: string, fieldName: string, value: string): Promise<string> {
+    if (!isDeterministicEligible(fieldName)) {
+      throw new BadRequestException(
+        `Field "${fieldName}" does not support exact-match index lookup`,
+      );
+    }
+    return this.phiEncryption.computeHmacIndex(patientId, value);
+  }
+
+  /**
+   * Re-encrypt an existing randomised ciphertext into deterministic mode.
+   * Used by the migration path when a field is promoted to searchable.
+   */
+  async reEncryptToDeterministic(
+    patientId: string,
+    fieldName: string,
+    existingCiphertext: string,
+  ): Promise<{ ciphertext: string; searchIndex: string }> {
+    if (!isDeterministicEligible(fieldName)) {
+      throw new BadRequestException(
+        `Field "${fieldName}" is not eligible for deterministic re-encryption`,
+      );
+    }
+
+    const plaintext = await this.phiEncryption.decryptField(patientId, existingCiphertext);
+    if (plaintext === null) {
+      throw new Error(`Failed to decrypt existing ciphertext for patient ${patientId}`);
+    }
+
+    const [ciphertext, searchIndex] = await Promise.all([
+      this.phiEncryption.encryptField(patientId, plaintext, true),
+      this.phiEncryption.computeHmacIndex(patientId, plaintext),
+    ]);
+
+    this.logger.log(`Re-encrypted field "${fieldName}" to deterministic mode for patient ${patientId}`);
+    return { ciphertext, searchIndex };
+  }
+
+  /**
+   * Returns the field registry for documentation / API exposure.
+   */
+  getFieldRegistry(): Record<string, PhiFieldConfig> {
+    return PHI_FIELD_REGISTRY;
+  }
+
+  /**
+   * Benchmark: compare decrypt-and-scan vs index lookup for a batch of records.
+   * Returns timing information for observability.
+   */
+  async benchmarkLookup(
+    patientId: string,
+    fieldName: string,
+    searchValue: string,
+    encryptedDataset: string[],
+  ): Promise<{ indexLookupMs: number; decryptScanMs: number; datasetSize: number }> {
+    const startIndex = Date.now();
+    const targetIndex = await this.phiEncryption.computeHmacIndex(patientId, searchValue);
+    let indexMatches = 0;
+    for (const ciphertext of encryptedDataset) {
+      const idx = await this.phiEncryption.computeHmacIndex(
+        patientId,
+        (await this.phiEncryption.decryptField(patientId, ciphertext)) ?? '',
+      );
+      if (idx === targetIndex) indexMatches++;
+    }
+    const indexLookupMs = Date.now() - startIndex;
+
+    const startScan = Date.now();
+    let scanMatches = 0;
+    for (const ciphertext of encryptedDataset) {
+      const plain = await this.phiEncryption.decryptField(patientId, ciphertext);
+      if (plain === searchValue) scanMatches++;
+    }
+    const decryptScanMs = Date.now() - startScan;
+
+    this.logger.log(
+      `Benchmark [${fieldName}] dataset=${encryptedDataset.length}: ` +
+        `index=${indexLookupMs}ms (${indexMatches} hits), scan=${decryptScanMs}ms (${scanMatches} hits)`,
+    );
+
+    return { indexLookupMs, decryptScanMs, datasetSize: encryptedDataset.length };
+  }
+}

--- a/src/encryption/services/phi-field-registry.ts
+++ b/src/encryption/services/phi-field-registry.ts
@@ -1,0 +1,80 @@
+/**
+ * PHI Field Registry — documents which PHI fields may use deterministic
+ * (searchable) encryption versus randomised encryption.
+ *
+ * Deterministic mode (AES-256-GCM with HMAC-derived IV, equivalent to
+ * AES-SIV in its searchability guarantee) enables exact-match index lookups
+ * (e.g. SELECT * WHERE encrypted_ssn = $1) without decrypting every row.
+ *
+ * SECURITY RULES
+ * ──────────────
+ * Use deterministic mode ONLY for:
+ *  • High-cardinality coded identifiers (SSN, MRN, passport number)
+ *    where brute-force enumeration is not feasible.
+ *
+ * NEVER use deterministic mode for:
+ *  • Low-cardinality fields (gender, blood type, boolean flags) —
+ *    identical ciphertexts leak the distribution and allow inference attacks.
+ *  • Free-text clinical notes or descriptions — randomised mode required.
+ */
+
+export type EncryptionMode = 'deterministic' | 'randomised';
+
+export interface PhiFieldConfig {
+  mode: EncryptionMode;
+  description: string;
+}
+
+export const PHI_FIELD_REGISTRY: Record<string, PhiFieldConfig> = {
+  // ── High-cardinality identifiers: deterministic mode allowed ────────────
+  nationalId: {
+    mode: 'deterministic',
+    description: 'National/government-issued identifier — high cardinality, safe for exact-match lookup',
+  },
+  mrn: {
+    mode: 'deterministic',
+    description: 'Medical Record Number — facility-assigned, high cardinality',
+  },
+  passportNumber: {
+    mode: 'deterministic',
+    description: 'Passport number — high cardinality government identifier',
+  },
+  insuranceId: {
+    mode: 'deterministic',
+    description: 'Insurance member/policy number — high cardinality',
+  },
+  email: {
+    mode: 'deterministic',
+    description: 'Patient contact email — high cardinality, used for deduplication lookups',
+  },
+
+  // ── Low-cardinality or free-text: randomised mode required ──────────────
+  sex: {
+    mode: 'randomised',
+    description: 'Sex/gender — low cardinality (≤10 values), deterministic mode would leak distribution',
+  },
+  bloodType: {
+    mode: 'randomised',
+    description: 'Blood type — low cardinality (8 ABO+Rh values), inference attack risk',
+  },
+  clinicalNotes: {
+    mode: 'randomised',
+    description: 'Free-text clinical notes — arbitrary length, randomised mode required',
+  },
+  prescriptionDetails: {
+    mode: 'randomised',
+    description: 'Free-text prescription details — randomised mode required',
+  },
+  address: {
+    mode: 'randomised',
+    description: 'Full address — free text, randomised mode required',
+  },
+};
+
+export function getFieldMode(fieldName: string): EncryptionMode {
+  return PHI_FIELD_REGISTRY[fieldName]?.mode ?? 'randomised';
+}
+
+export function isDeterministicEligible(fieldName: string): boolean {
+  return getFieldMode(fieldName) === 'deterministic';
+}

--- a/src/research-export/entities/export-consent-mapping.entity.ts
+++ b/src/research-export/entities/export-consent-mapping.entity.ts
@@ -1,0 +1,58 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum ExportBatchStatus {
+  ACTIVE = 'active',
+  FLAGGED = 'flagged',
+  PURGED = 'purged',
+}
+
+@Entity('export_consent_mappings')
+export class ExportConsentMapping {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ type: 'uuid' })
+  exportId: string;
+
+  @Index()
+  @Column({ type: 'uuid' })
+  patientId: string;
+
+  @Index()
+  @Column({ type: 'uuid', nullable: true })
+  consentId: string | null;
+
+  @Index()
+  @Column({ type: 'varchar', length: 128 })
+  tenantId: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  researchRecipientId: string | null;
+
+  @Column({
+    type: 'enum',
+    enum: ExportBatchStatus,
+    default: ExportBatchStatus.ACTIVE,
+  })
+  status: ExportBatchStatus;
+
+  @Column({ type: 'timestamp', nullable: true })
+  flaggedAt: Date | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  flagReason: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/research-export/research-export.module.ts
+++ b/src/research-export/research-export.module.ts
@@ -3,20 +3,22 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { MedicalRecord } from '../medical-records/entities/medical-record.entity';
 import { Patient } from '../patients/entities/patient.entity';
 import { AccessGrant } from '../access-control/entities/access-grant.entity';
+import { ExportConsentMapping } from './entities/export-consent-mapping.entity';
 import { AuditModule } from '../common/audit/audit.module';
 import { MedicalRbacModule } from '../roles/medical-rbac.module';
 import { ResearchExportController } from './research-export.controller';
 import { ResearchExportService } from './research-export.service';
 import { ResearchAnonymizerService } from './research-anonymizer.service';
+import { ConsentRevocationService } from './services/consent-revocation.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([MedicalRecord, Patient, AccessGrant]),
+    TypeOrmModule.forFeature([MedicalRecord, Patient, AccessGrant, ExportConsentMapping]),
     AuditModule,
     MedicalRbacModule,
   ],
   controllers: [ResearchExportController],
-  providers: [ResearchExportService, ResearchAnonymizerService],
-  exports: [ResearchExportService, ResearchAnonymizerService],
+  providers: [ResearchExportService, ResearchAnonymizerService, ConsentRevocationService],
+  exports: [ResearchExportService, ResearchAnonymizerService, ConsentRevocationService],
 })
 export class ResearchExportModule {}

--- a/src/research-export/services/consent-revocation.service.spec.ts
+++ b/src/research-export/services/consent-revocation.service.spec.ts
@@ -1,0 +1,174 @@
+import 'reflect-metadata';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ConsentRevocationService } from './consent-revocation.service';
+import { ExportConsentMapping, ExportBatchStatus } from '../entities/export-consent-mapping.entity';
+import { AccessGrant, GrantStatus } from '../../access-control/entities/access-grant.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
+
+const mockRepo = () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn((data: any) => data),
+  save: jest.fn(),
+});
+const mockAudit = () => ({ create: jest.fn().mockResolvedValue(undefined) });
+const mockEmitter = () => ({ emit: jest.fn() });
+
+describe('ConsentRevocationService', () => {
+  let service: ConsentRevocationService;
+  let mappingRepo: ReturnType<typeof mockRepo>;
+  let grantRepo: ReturnType<typeof mockRepo>;
+  let auditLogService: ReturnType<typeof mockAudit>;
+  let eventEmitter: ReturnType<typeof mockEmitter>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ConsentRevocationService,
+        { provide: getRepositoryToken(ExportConsentMapping), useFactory: mockRepo },
+        { provide: getRepositoryToken(AccessGrant), useFactory: mockRepo },
+        { provide: AuditLogService, useFactory: mockAudit },
+        { provide: EventEmitter2, useFactory: mockEmitter },
+      ],
+    }).compile();
+
+    service = module.get(ConsentRevocationService);
+    mappingRepo = module.get(getRepositoryToken(ExportConsentMapping));
+    grantRepo = module.get(getRepositoryToken(AccessGrant));
+    auditLogService = module.get(AuditLogService);
+    eventEmitter = module.get(EventEmitter2);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── revokePatientConsent ───────────────────────────────────────────────────
+
+  describe('revokePatientConsent', () => {
+    it('flags all active export batches containing the revoked patient\'s data', async () => {
+      const activeMappings = [
+        { id: 'm1', exportId: 'exp-1', patientId: 'patient-1', status: ExportBatchStatus.ACTIVE },
+        { id: 'm2', exportId: 'exp-2', patientId: 'patient-1', status: ExportBatchStatus.ACTIVE },
+      ];
+      mappingRepo.find.mockResolvedValue(activeMappings);
+      mappingRepo.save.mockResolvedValue(activeMappings);
+
+      const count = await service.revokePatientConsent('patient-1', 'admin-1');
+
+      expect(count).toBe(2);
+      expect(mappingRepo.save).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            status: ExportBatchStatus.FLAGGED,
+            flagReason: 'patient_request',
+          }),
+        ]),
+      );
+    });
+
+    it('emits a research.export.revoked event for each distinct export batch', async () => {
+      const activeMappings = [
+        { id: 'm1', exportId: 'exp-1', patientId: 'patient-1', status: ExportBatchStatus.ACTIVE },
+        { id: 'm2', exportId: 'exp-1', patientId: 'patient-1', status: ExportBatchStatus.ACTIVE },
+        { id: 'm3', exportId: 'exp-2', patientId: 'patient-1', status: ExportBatchStatus.ACTIVE },
+      ];
+      mappingRepo.find.mockResolvedValue(activeMappings);
+      mappingRepo.save.mockResolvedValue(activeMappings);
+
+      await service.revokePatientConsent('patient-1', 'admin-1');
+
+      expect(eventEmitter.emit).toHaveBeenCalledTimes(2);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'research.export.revoked',
+        expect.objectContaining({ exportId: 'exp-1', patientId: 'patient-1' }),
+      );
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'research.export.revoked',
+        expect.objectContaining({ exportId: 'exp-2' }),
+      );
+    });
+
+    it('returns 0 and does not persist when no active batches exist for the patient', async () => {
+      mappingRepo.find.mockResolvedValue([]);
+
+      const count = await service.revokePatientConsent('unknown-patient', 'admin-1');
+
+      expect(count).toBe(0);
+      expect(mappingRepo.save).not.toHaveBeenCalled();
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('records an audit log entry for each affected export', async () => {
+      const activeMappings = [
+        { id: 'm1', exportId: 'exp-1', patientId: 'patient-1', status: ExportBatchStatus.ACTIVE },
+      ];
+      mappingRepo.find.mockResolvedValue(activeMappings);
+      mappingRepo.save.mockResolvedValue(activeMappings);
+
+      await service.revokePatientConsent('patient-1', 'admin-1');
+
+      expect(auditLogService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: 'CONSENT_REVOCATION_FLAGGED',
+          entityId: 'exp-1',
+          userId: 'admin-1',
+        }),
+      );
+    });
+  });
+
+  // ── checkExpiredConsents (scheduled job) ────────────────────────────────────
+
+  describe('checkExpiredConsents', () => {
+    it('flags export batches for patients with expired grants and marks grants as revoked', async () => {
+      const expiredGrant = {
+        id: 'grant-1',
+        granteeId: 'patient-2',
+        expiresAt: new Date('2020-01-01'),
+        status: GrantStatus.ACTIVE,
+      };
+      grantRepo.find.mockResolvedValue([expiredGrant]);
+      mappingRepo.find.mockResolvedValue([]);
+      grantRepo.save.mockResolvedValue({ ...expiredGrant, status: GrantStatus.REVOKED });
+
+      await service.checkExpiredConsents();
+
+      expect(grantRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: GrantStatus.REVOKED }),
+      );
+    });
+
+    it('does nothing when there are no expired grants', async () => {
+      grantRepo.find.mockResolvedValue([]);
+
+      await service.checkExpiredConsents();
+
+      expect(grantRepo.save).not.toHaveBeenCalled();
+      expect(mappingRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── trackExportBatch ───────────────────────────────────────────────────────
+
+  describe('trackExportBatch', () => {
+    it('persists one mapping row per patient in the export batch', async () => {
+      mappingRepo.save.mockResolvedValue([]);
+
+      await service.trackExportBatch('exp-10', ['p1', 'p2', 'p3'], 'tenant-1', 'researcher-1');
+
+      expect(mappingRepo.save).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ exportId: 'exp-10', patientId: 'p1' }),
+          expect.objectContaining({ exportId: 'exp-10', patientId: 'p2' }),
+          expect.objectContaining({ exportId: 'exp-10', patientId: 'p3' }),
+        ]),
+      );
+    });
+
+    it('does nothing when patient list is empty', async () => {
+      await service.trackExportBatch('exp-11', [], 'tenant-1', 'researcher-1');
+      expect(mappingRepo.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/research-export/services/consent-revocation.service.ts
+++ b/src/research-export/services/consent-revocation.service.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThanOrEqual } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ExportConsentMapping, ExportBatchStatus } from '../entities/export-consent-mapping.entity';
+import { AccessGrant, GrantStatus } from '../../access-control/entities/access-grant.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
+
+@Injectable()
+export class ConsentRevocationService {
+  private readonly logger = new Logger(ConsentRevocationService.name);
+
+  constructor(
+    @InjectRepository(ExportConsentMapping)
+    private readonly mappingRepo: Repository<ExportConsentMapping>,
+    @InjectRepository(AccessGrant)
+    private readonly grantRepo: Repository<AccessGrant>,
+    private readonly auditLogService: AuditLogService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async trackExportBatch(
+    exportId: string,
+    patientIds: string[],
+    tenantId: string,
+    researchRecipientId: string,
+  ): Promise<void> {
+    if (patientIds.length === 0) return;
+
+    const mappings = patientIds.map((patientId) =>
+      this.mappingRepo.create({
+        exportId,
+        patientId,
+        tenantId,
+        researchRecipientId,
+        status: ExportBatchStatus.ACTIVE,
+      }),
+    );
+    await this.mappingRepo.save(mappings);
+    this.logger.log(`Tracked ${mappings.length} consent mappings for export ${exportId}`);
+  }
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async checkExpiredConsents(): Promise<void> {
+    this.logger.log('Running consent expiry check...');
+    const now = new Date();
+
+    const expiredGrants = await this.grantRepo.find({
+      where: { expiresAt: LessThanOrEqual(now), status: GrantStatus.ACTIVE },
+    });
+
+    for (const grant of expiredGrants) {
+      await this.flagExportBatchesForPatient(grant.granteeId, 'consent_expired', 'system');
+      grant.status = GrantStatus.REVOKED;
+      await this.grantRepo.save(grant);
+    }
+
+    if (expiredGrants.length > 0) {
+      this.logger.warn(
+        `Consent expiry check complete: flagged exports for ${expiredGrants.length} expired grants`,
+      );
+    }
+  }
+
+  async revokePatientConsent(
+    patientId: string,
+    revokedBy: string,
+    reason = 'patient_request',
+  ): Promise<number> {
+    return this.flagExportBatchesForPatient(patientId, reason, revokedBy);
+  }
+
+  async getFlaggedBatches(tenantId: string): Promise<ExportConsentMapping[]> {
+    return this.mappingRepo.find({
+      where: { tenantId, status: ExportBatchStatus.FLAGGED },
+      order: { flaggedAt: 'DESC' },
+    });
+  }
+
+  private async flagExportBatchesForPatient(
+    patientId: string,
+    reason: string,
+    actorId: string,
+  ): Promise<number> {
+    const affected = await this.mappingRepo.find({
+      where: { patientId, status: ExportBatchStatus.ACTIVE },
+    });
+
+    if (affected.length === 0) return 0;
+
+    const now = new Date();
+    for (const mapping of affected) {
+      mapping.status = ExportBatchStatus.FLAGGED;
+      mapping.flaggedAt = now;
+      mapping.flagReason = reason;
+    }
+    await this.mappingRepo.save(affected);
+
+    const exportIds = [...new Set(affected.map((m) => m.exportId))];
+
+    for (const exportId of exportIds) {
+      this.eventEmitter.emit('research.export.revoked', {
+        exportId,
+        patientId,
+        reason,
+        flaggedAt: now.toISOString(),
+      });
+
+      await this.auditLogService.create({
+        operation: 'CONSENT_REVOCATION_FLAGGED',
+        entityType: 'ExportConsentMapping',
+        entityId: exportId,
+        userId: actorId,
+        changes: { patientId, reason, status: ExportBatchStatus.FLAGGED },
+      });
+    }
+
+    this.logger.warn(
+      `Flagged ${affected.length} mappings across ${exportIds.length} export(s) for patient ${patientId} (reason: ${reason})`,
+    );
+
+    return affected.length;
+  }
+}

--- a/src/webhooks/dto/webhook-subscription.dto.ts
+++ b/src/webhooks/dto/webhook-subscription.dto.ts
@@ -1,0 +1,50 @@
+import { IsArray, IsBoolean, IsInt, IsOptional, IsString, IsUrl, Max, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateWebhookSubscriptionDto {
+  @ApiProperty({ description: 'Target HTTPS endpoint to receive webhook events' })
+  @IsUrl({ protocols: ['https', 'http'] })
+  url: string;
+
+  @ApiProperty({ description: 'Event types to subscribe to (e.g. patient.created)', type: [String] })
+  @IsArray()
+  @IsString({ each: true })
+  events: string[];
+
+  @ApiPropertyOptional({ description: 'Custom HMAC secret (auto-generated if omitted)' })
+  @IsString()
+  @IsOptional()
+  secret?: string;
+
+  @ApiPropertyOptional({ default: 5, minimum: 1, maximum: 10 })
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  @IsOptional()
+  maxRetries?: number;
+}
+
+export class UpdateWebhookSubscriptionDto {
+  @ApiPropertyOptional()
+  @IsUrl({ protocols: ['https', 'http'] })
+  @IsOptional()
+  url?: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  events?: string[];
+
+  @ApiPropertyOptional()
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 10 })
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  @IsOptional()
+  maxRetries?: number;
+}

--- a/src/webhooks/services/webhook-subscription.service.spec.ts
+++ b/src/webhooks/services/webhook-subscription.service.spec.ts
@@ -1,0 +1,176 @@
+import 'reflect-metadata';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { ForbiddenException, BadRequestException, NotFoundException } from '@nestjs/common';
+import axios from 'axios';
+import { WebhookSubscriptionService } from './webhook-subscription.service';
+import { WebhookSubscription } from '../entities/webhook-subscription.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockRepo = () => ({
+  count: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn((data: any) => data),
+  save: jest.fn(),
+  remove: jest.fn(),
+});
+const mockAudit = () => ({ create: jest.fn().mockResolvedValue(undefined) });
+const mockConfig = () => ({ get: jest.fn((_key: string, def: any) => def) });
+
+describe('WebhookSubscriptionService', () => {
+  let service: WebhookSubscriptionService;
+  let repo: ReturnType<typeof mockRepo>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookSubscriptionService,
+        { provide: getRepositoryToken(WebhookSubscription), useFactory: mockRepo },
+        { provide: AuditLogService, useFactory: mockAudit },
+        { provide: ConfigService, useFactory: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get(WebhookSubscriptionService);
+    repo = module.get(getRepositoryToken(WebhookSubscription));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── createSubscription ─────────────────────────────────────────────────────
+
+  describe('createSubscription', () => {
+    it('creates a subscription and auto-generates a secret', async () => {
+      repo.count.mockResolvedValue(0);
+      mockedAxios.post.mockResolvedValue({ status: 200, data: {} } as any);
+      const sub = { id: 'sub-1', url: 'https://example.com', events: ['patient.created'] };
+      repo.save.mockResolvedValue(sub);
+
+      const result = await service.createSubscription('tenant-1', 'user-1', {
+        url: 'https://example.com',
+        events: ['patient.created'],
+      });
+
+      expect(repo.save).toHaveBeenCalled();
+      expect(result.id).toBe('sub-1');
+    });
+
+    it('uses the caller-supplied secret when provided', async () => {
+      repo.count.mockResolvedValue(0);
+      mockedAxios.post.mockResolvedValue({ status: 200, data: {} } as any);
+      repo.save.mockImplementation(async (data) => ({ id: 'sub-2', ...data }));
+
+      const result = await service.createSubscription('tenant-1', 'user-1', {
+        url: 'https://example.com',
+        events: ['lab.result'],
+        secret: 'my-custom-secret',
+      });
+
+      expect(result.secret).toBe('my-custom-secret');
+    });
+
+    it('throws ForbiddenException when tenant has reached the subscription cap', async () => {
+      repo.count.mockResolvedValue(25);
+
+      await expect(
+        service.createSubscription('tenant-1', 'user-1', {
+          url: 'https://example.com',
+          events: ['patient.created'],
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws BadRequestException when ping validation receives a non-2xx status', async () => {
+      repo.count.mockResolvedValue(0);
+      mockedAxios.post.mockResolvedValue({ status: 404, data: {} } as any);
+
+      await expect(
+        service.createSubscription('tenant-1', 'user-1', {
+          url: 'https://example.com/not-found',
+          events: ['patient.created'],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when ping request throws a network error', async () => {
+      repo.count.mockResolvedValue(0);
+      mockedAxios.post.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+      await expect(
+        service.createSubscription('tenant-1', 'user-1', {
+          url: 'https://unreachable.example.com',
+          events: ['patient.created'],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── rotateSecret ───────────────────────────────────────────────────────────
+
+  describe('rotateSecret', () => {
+    it('generates a new 64-char hex secret and persists it', async () => {
+      const sub = { id: 'sub-1', tenantId: 'tenant-1', secret: 'old-secret' };
+      repo.findOne.mockResolvedValue(sub);
+      repo.save.mockImplementation(async (s: any) => s);
+
+      const result = await service.rotateSecret('tenant-1', 'sub-1', 'user-1');
+
+      expect(result.secret).not.toBe('old-secret');
+      expect(result.secret).toHaveLength(64);
+      expect(repo.save).toHaveBeenCalledWith(expect.objectContaining({ secret: result.secret }));
+    });
+
+    it('throws NotFoundException for an unknown subscription id', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(service.rotateSecret('tenant-1', 'ghost', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('enforces tenant isolation — cannot rotate another tenant\'s secret', async () => {
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(service.rotateSecret('tenant-A', 'sub-of-tenant-B', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── deleteSubscription ─────────────────────────────────────────────────────
+
+  describe('deleteSubscription', () => {
+    it('removes the subscription and audits the deletion', async () => {
+      const sub = { id: 'sub-1', tenantId: 'tenant-1' };
+      repo.findOne.mockResolvedValue(sub);
+      repo.remove.mockResolvedValue(sub);
+
+      await service.deleteSubscription('tenant-1', 'sub-1', 'user-1');
+
+      expect(repo.remove).toHaveBeenCalledWith(sub);
+    });
+  });
+
+  // ── event delivery reaches registered URL ──────────────────────────────────
+
+  describe('pingEndpoint (simulates event delivery flow)', () => {
+    it('resolves when the target endpoint returns 2xx', async () => {
+      mockedAxios.post.mockResolvedValue({ status: 200, data: { ok: true } } as any);
+      await expect(
+        service.pingEndpoint('https://example.com/hook', 'secret'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('includes X-Webhook-Signature header in the ping request', async () => {
+      mockedAxios.post.mockResolvedValue({ status: 200, data: {} } as any);
+      await service.pingEndpoint('https://example.com/hook', 'mysecret');
+      const [, , opts] = mockedAxios.post.mock.calls[0];
+      expect((opts as any).headers['X-Webhook-Signature']).toMatch(/^sha256=[a-f0-9]{64}$/);
+    });
+  });
+});

--- a/src/webhooks/services/webhook-subscription.service.ts
+++ b/src/webhooks/services/webhook-subscription.service.ts
@@ -1,0 +1,189 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { randomBytes, createHmac } from 'crypto';
+import axios from 'axios';
+import { ConfigService } from '@nestjs/config';
+import { WebhookSubscription } from '../entities/webhook-subscription.entity';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import {
+  CreateWebhookSubscriptionDto,
+  UpdateWebhookSubscriptionDto,
+} from '../dto/webhook-subscription.dto';
+
+const DEFAULT_MAX_PER_TENANT = 25;
+
+@Injectable()
+export class WebhookSubscriptionService {
+  private readonly logger = new Logger(WebhookSubscriptionService.name);
+
+  constructor(
+    @InjectRepository(WebhookSubscription)
+    private readonly subscriptionRepo: Repository<WebhookSubscription>,
+    private readonly configService: ConfigService,
+    private readonly auditLogService: AuditLogService,
+  ) {}
+
+  private maxPerTenant(): number {
+    return this.configService.get<number>(
+      'WEBHOOK_MAX_SUBSCRIPTIONS_PER_TENANT',
+      DEFAULT_MAX_PER_TENANT,
+    );
+  }
+
+  private generateSecret(): string {
+    return randomBytes(32).toString('hex');
+  }
+
+  async listSubscriptions(tenantId: string): Promise<WebhookSubscription[]> {
+    return this.subscriptionRepo.find({
+      where: { tenantId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async createSubscription(
+    tenantId: string,
+    userId: string,
+    dto: CreateWebhookSubscriptionDto,
+  ): Promise<WebhookSubscription> {
+    const count = await this.subscriptionRepo.count({ where: { tenantId } });
+    const cap = this.maxPerTenant();
+    if (count >= cap) {
+      throw new ForbiddenException(
+        `Tenant has reached the maximum of ${cap} webhook subscriptions`,
+      );
+    }
+
+    const secret = dto.secret ?? this.generateSecret();
+
+    await this.pingEndpoint(dto.url, secret);
+
+    const subscription = this.subscriptionRepo.create({
+      tenantId,
+      userId,
+      url: dto.url,
+      events: dto.events,
+      secret,
+      isActive: true,
+      maxRetries: dto.maxRetries ?? 5,
+    });
+
+    const saved = await this.subscriptionRepo.save(subscription);
+
+    await this.auditLogService.create({
+      operation: 'WEBHOOK_SUBSCRIPTION_CREATED',
+      entityType: 'WebhookSubscription',
+      entityId: saved.id,
+      userId,
+      changes: { url: dto.url, events: dto.events },
+    });
+
+    this.logger.log(`Webhook subscription created: ${saved.id} for tenant ${tenantId}`);
+    return saved;
+  }
+
+  async updateSubscription(
+    tenantId: string,
+    id: string,
+    userId: string,
+    dto: UpdateWebhookSubscriptionDto,
+  ): Promise<WebhookSubscription> {
+    const sub = await this.findOwnedSubscription(tenantId, id);
+
+    if (dto.url !== undefined) sub.url = dto.url;
+    if (dto.events !== undefined) sub.events = dto.events;
+    if (dto.isActive !== undefined) sub.isActive = dto.isActive;
+    if (dto.maxRetries !== undefined) sub.maxRetries = dto.maxRetries;
+
+    const updated = await this.subscriptionRepo.save(sub);
+
+    await this.auditLogService.create({
+      operation: 'WEBHOOK_SUBSCRIPTION_UPDATED',
+      entityType: 'WebhookSubscription',
+      entityId: id,
+      userId,
+      changes: dto as Record<string, any>,
+    });
+
+    return updated;
+  }
+
+  async deleteSubscription(tenantId: string, id: string, userId: string): Promise<void> {
+    const sub = await this.findOwnedSubscription(tenantId, id);
+    await this.subscriptionRepo.remove(sub);
+
+    await this.auditLogService.create({
+      operation: 'WEBHOOK_SUBSCRIPTION_DELETED',
+      entityType: 'WebhookSubscription',
+      entityId: id,
+      userId,
+    });
+
+    this.logger.log(`Webhook subscription deleted: ${id}`);
+  }
+
+  async rotateSecret(
+    tenantId: string,
+    id: string,
+    userId: string,
+  ): Promise<{ secret: string }> {
+    const sub = await this.findOwnedSubscription(tenantId, id);
+    const newSecret = this.generateSecret();
+    sub.secret = newSecret;
+    await this.subscriptionRepo.save(sub);
+
+    await this.auditLogService.create({
+      operation: 'WEBHOOK_SECRET_ROTATED',
+      entityType: 'WebhookSubscription',
+      entityId: id,
+      userId,
+    });
+
+    this.logger.log(`Webhook secret rotated for subscription: ${id}`);
+    return { secret: newSecret };
+  }
+
+  async pingEndpoint(url: string, secret: string): Promise<void> {
+    const payload = JSON.stringify({ type: 'ping', timestamp: new Date().toISOString() });
+    const signature = createHmac('sha256', secret).update(payload).digest('hex');
+
+    try {
+      const response = await axios.post(url, JSON.parse(payload), {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Event': 'ping',
+          'X-Webhook-Signature': `sha256=${signature}`,
+        },
+        timeout: 10_000,
+        validateStatus: () => true,
+      });
+
+      if (response.status < 200 || response.status >= 300) {
+        throw new BadRequestException(
+          `Endpoint validation failed: target responded with HTTP ${response.status}`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      throw new BadRequestException(`Endpoint validation failed: ${(err as Error).message}`);
+    }
+  }
+
+  private async findOwnedSubscription(
+    tenantId: string,
+    id: string,
+  ): Promise<WebhookSubscription> {
+    const sub = await this.subscriptionRepo.findOne({ where: { id, tenantId } });
+    if (!sub) {
+      throw new NotFoundException(`Webhook subscription ${id} not found`);
+    }
+    return sub;
+  }
+}

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -1,13 +1,15 @@
-import { Controller, Post, Body, HttpCode, Inject, Logger, Get, Param, UseGuards, Req, Query, Delete, NotFoundException } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery, ApiParam } from '@nestjs/swagger';
+import { Controller, Post, Body, HttpCode, Inject, Logger, Get, Param, UseGuards, Req, Query, Delete, NotFoundException, Put, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery, ApiParam, ApiBody } from '@nestjs/swagger';
 import { IpfsService } from '../stellar/services/ipfs.service';
 import { QueueService } from '../queues/queue.service';
 import { ConfigService } from '@nestjs/config';
 import { WebhookDeliveryService } from './services/webhook-delivery.service';
+import { WebhookSubscriptionService } from './services/webhook-subscription.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { InjectRepository } from '@nestjs/typeorm';
+import { CreateWebhookSubscriptionDto, UpdateWebhookSubscriptionDto } from './dto/webhook-subscription.dto';
 import { Repository } from 'typeorm';
 import { WebhookDelivery, WebhookDeliveryStatus } from './entities/webhook-delivery.entity';
 import { ClaimService } from '../billing/services/claim.service';
@@ -23,10 +25,73 @@ export class WebhooksController {
     private readonly queueService: QueueService,
     private readonly configService: ConfigService,
     private readonly webhookService: WebhookDeliveryService,
+    private readonly subscriptionService: WebhookSubscriptionService,
     @InjectRepository(WebhookDelivery)
     private readonly deliveryRepository: Repository<WebhookDelivery>,
     private readonly claimService: ClaimService,
   ) {}
+
+  // ── Tenant Self-Service Subscription Management ───────────────────────────
+
+  @Get('subscriptions')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List webhook subscriptions for the authenticated tenant' })
+  async listSubscriptions(@Req() req: any) {
+    const tenantId = req.user?.tenantId ?? req.user?.organizationId;
+    return this.subscriptionService.listSubscriptions(tenantId);
+  }
+
+  @Post('subscriptions')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new webhook subscription (includes validation ping)' })
+  @ApiBody({ type: CreateWebhookSubscriptionDto })
+  async createSubscription(@Req() req: any, @Body() dto: CreateWebhookSubscriptionDto) {
+    const tenantId = req.user?.tenantId ?? req.user?.organizationId;
+    const userId = req.user?.id;
+    return this.subscriptionService.createSubscription(tenantId, userId, dto);
+  }
+
+  @Put('subscriptions/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a webhook subscription' })
+  @ApiParam({ name: 'id', type: String })
+  @ApiBody({ type: UpdateWebhookSubscriptionDto })
+  async updateSubscription(
+    @Req() req: any,
+    @Param('id') id: string,
+    @Body() dto: UpdateWebhookSubscriptionDto,
+  ) {
+    const tenantId = req.user?.tenantId ?? req.user?.organizationId;
+    const userId = req.user?.id;
+    return this.subscriptionService.updateSubscription(tenantId, id, userId, dto);
+  }
+
+  @Delete('subscriptions/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a webhook subscription' })
+  @ApiParam({ name: 'id', type: String })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteSubscription(@Req() req: any, @Param('id') id: string) {
+    const tenantId = req.user?.tenantId ?? req.user?.organizationId;
+    const userId = req.user?.id;
+    await this.subscriptionService.deleteSubscription(tenantId, id, userId);
+  }
+
+  @Post('subscriptions/:id/rotate-secret')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Rotate the HMAC signing secret for a webhook subscription' })
+  @ApiParam({ name: 'id', type: String })
+  @HttpCode(HttpStatus.OK)
+  async rotateSubscriptionSecret(@Req() req: any, @Param('id') id: string) {
+    const tenantId = req.user?.tenantId ?? req.user?.organizationId;
+    const userId = req.user?.id;
+    return this.subscriptionService.rotateSecret(tenantId, id, userId);
+  }
 
   @Post('insurance-claims')
   @HttpCode(200)

--- a/src/webhooks/webhooks.module.ts
+++ b/src/webhooks/webhooks.module.ts
@@ -9,6 +9,7 @@ import { QueueService } from '../queues/queue.service';
 import { WebhookSubscription } from './entities/webhook-subscription.entity';
 import { WebhookDelivery } from './entities/webhook-delivery.entity';
 import { WebhookDeliveryService } from './services/webhook-delivery.service';
+import { WebhookSubscriptionService } from './services/webhook-subscription.service';
 import { WebhookDeliveryProcessor } from './processors/webhook-delivery.processor';
 import { QUEUE_NAMES } from '../queues/queue.constants';
 import { AuditModule } from '../common/audit/audit.module';
@@ -26,8 +27,8 @@ import { DlqModule } from '../dlq/dlq.module';
     DlqModule,
   ],
   controllers: [WebhooksController],
-  providers: [IpfsService, QueueService, WebhookDeliveryService, WebhookDeliveryProcessor],
-  exports: [WebhookDeliveryService],
+  providers: [IpfsService, QueueService, WebhookDeliveryService, WebhookDeliveryProcessor, WebhookSubscriptionService],
+  exports: [WebhookDeliveryService, WebhookSubscriptionService],
 })
 export class WebhooksModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {


### PR DESCRIPTION
## Summary

- **#862** — Tenant self-service webhook subscription management: CRUD endpoints, auto secret generation, validation ping, per-tenant cap (default 25), and secret rotation.
- **#871** — Real-time operational dashboard: live bed + OR utilization endpoint, WebSocket gateway for push updates, configurable warning thresholds, and historical trend endpoint.
- **#872** — Research export consent revocation: `ExportConsentMapping` entity tracks export↔patient consent, hourly cron flags affected batches when consents expire or are revoked, event-driven admin notification, and audit trail.
- **#870** — Deterministic/searchable encryption: AES-256-GCM with HMAC-derived IV (AES-SIV equivalent) per the `PHI_FIELD_REGISTRY`, re-encryption migration path, benchmark utility, and exact-match lookup tests.

## Test plan

- [ ] Run `npx jest --selectProjects unit --testPathPatterns="webhook-subscription.service.spec|operational-dashboard.service.spec|consent-revocation.service.spec|deterministic-encryption.service.spec"` — all 36 tests pass
- [ ] POST `/webhooks/subscriptions` with a reachable HTTPS URL — ping fires and subscription created
- [ ] POST `/webhooks/subscriptions/:id/rotate-secret` — returns new 64-char hex secret
- [ ] GET `/analytics/operational/dashboard` — returns aggregated bed + OR utilization with alerts
- [ ] Connect WebSocket to `/analytics/dashboard`, subscribe to a tenantId, trigger a bed status change — client receives `dashboard:update`
- [ ] Trigger `ConsentRevocationService.revokePatientConsent` for a patient with active export mappings — verify flagged status and audit log entry
- [ ] Encrypt a `nationalId` field twice with the same value — verify identical ciphertext (deterministic)
- [ ] Attempt `computeSearchIndex` on `bloodType` — verify `BadRequestException`

Closes #862
Closes #871
Closes #872
Closes #870