### PR TITLE
Reports: export scheduled reports to Excel (XLSX)

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "csv-writer": "^1.6.0",
     "dataloader": "^2.2.3",
     "dotenv": "^16.6.1",
+    "exceljs": "^4.4.0",
     "express-rate-limit": "^8.2.1",
     "geoip-lite": "^2.0.1",
     "graphql": "^16.13.2",

--- a/src/reports/dto/report-schedule.dto.ts
+++ b/src/reports/dto/report-schedule.dto.ts
@@ -35,6 +35,7 @@ export class CreateReportScheduleDto {
   @IsEmail({}, { each: true })
   recipients: string[];
 
+  /** Output format for delivered reports: 'pdf' | 'csv' | 'xlsx'. */
   @IsEnum(ReportFormat)
   @IsOptional()
   format?: ReportFormat;
@@ -66,6 +67,7 @@ export class UpdateReportScheduleDto {
   @IsOptional()
   recipients?: string[];
 
+  /** Output format for delivered reports: 'pdf' | 'csv' | 'xlsx'. */
   @IsEnum(ReportFormat)
   @IsOptional()
   format?: ReportFormat;

--- a/src/reports/entities/report-job.entity.ts
+++ b/src/reports/entities/report-job.entity.ts
@@ -13,6 +13,7 @@ import { User } from '../../auth/entities/user.entity';
 export enum ReportFormat {
   PDF = 'pdf',
   CSV = 'csv',
+  XLSX = 'xlsx',
 }
 
 export enum ReportStatus {

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -25,7 +25,7 @@ export class ReportsController {
   @Post('generate')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Queue a report generation job' })
+  @ApiOperation({ summary: 'Queue a report generation job (pdf, csv, or xlsx)' })
   @ApiResponse({ status: 202, description: 'Report generation queued' })
   async generateReport(
     @Req() req: Request,

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -5,6 +5,8 @@ import { ReportJob, ReportFormat, ReportStatus } from './entities/report-job.ent
 import { ConfigService } from '@nestjs/config';
 import { NotificationsService } from '../notifications/services/notifications.service';
 import { EntityManager } from 'typeorm';
+import { I18nService } from '../i18n/i18n.service';
+import * as ExcelJS from 'exceljs';
 
 jest.mock(
   'ipfs-http-client',
@@ -23,6 +25,7 @@ describe('ReportsService', () => {
   let mockEntityManager;
   let mockConfigService;
   let mockNotificationsService;
+  let mockI18nService;
 
   beforeEach(async () => {
     mockReportJobRepo = {
@@ -45,6 +48,11 @@ describe('ReportsService', () => {
       sendEmail: jest.fn(),
     };
 
+    mockI18nService = {
+      isRtlLocale: jest.fn().mockReturnValue(false),
+      formatDate: jest.fn().mockReturnValue('2026-01-01'),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReportsService,
@@ -63,6 +71,10 @@ describe('ReportsService', () => {
         {
           provide: NotificationsService,
           useValue: mockNotificationsService,
+        },
+        {
+          provide: I18nService,
+          useValue: mockI18nService,
         },
       ],
     }).compile();
@@ -142,6 +154,96 @@ describe('ReportsService', () => {
       await expect(service.getJobStatus('job-1', 'patient-123')).rejects.toThrow(
         'Download link has expired',
       );
+    });
+  });
+
+  describe('generateXlsxBuffer (XLSX export)', () => {
+    const patient = { id: 'patient-123', firstName: 'Jane', lastName: 'Doe' } as any;
+
+    const records = [
+      {
+        createdAt: new Date('2026-01-05T10:00:00Z'),
+        recordType: 'consultation',
+        title: 'Annual Checkup',
+        metadata: { transactionHash: '0xabc' },
+      },
+    ] as any[];
+
+    const grants = [
+      {
+        granteeId: 'dr-smith',
+        status: 'ACTIVE',
+        accessLevel: 'READ',
+        expiresAt: new Date('2026-06-01T00:00:00Z'),
+        sorobanTxHash: '0xdef',
+      },
+    ] as any[];
+
+    const logs = [
+      {
+        timestamp: new Date('2026-01-06T12:00:00Z'),
+        action: 'DATA_ACCESS',
+        description: 'Viewed record',
+        details: { transactionHash: '0xghi' },
+      },
+    ] as any[];
+
+    const billings = [
+      {
+        invoiceNumber: 'INV-001',
+        serviceDate: new Date('2026-01-04T00:00:00Z'),
+        providerName: 'Dr. Smith',
+        totalCharges: 250.5,
+        totalPayments: 200,
+        balance: 50.5,
+        status: 'open',
+        dueDate: new Date('2026-02-04T00:00:00Z'),
+      },
+    ] as any[];
+
+    it('generates a multi-sheet workbook with the expected sheet names and columns', async () => {
+      const buffer = await service['generateXlsxBuffer'](patient, records, grants, logs, billings);
+
+      expect(Buffer.isBuffer(buffer)).toBe(true);
+
+      const workbook = new ExcelJS.Workbook();
+      await workbook.xlsx.load(buffer);
+
+      const sheetNames = workbook.worksheets.map((ws) => ws.name);
+      expect(sheetNames).toEqual([
+        'Summary',
+        'Medical Records',
+        'Access Grants',
+        'Audit Logs',
+        'Billing Summary',
+      ]);
+
+      const recordsSheet = workbook.getWorksheet('Medical Records');
+      expect(recordsSheet.getRow(1).values.slice(1)).toEqual([
+        'Date',
+        'Type',
+        'Title',
+        'Transaction Hash',
+      ]);
+      expect(recordsSheet.getRow(2).getCell(1).value).toBeInstanceOf(Date);
+
+      const billingSheet = workbook.getWorksheet('Billing Summary');
+      expect(billingSheet.getRow(1).values.slice(1)).toEqual([
+        'Invoice Number',
+        'Service Date',
+        'Provider',
+        'Total Charges',
+        'Total Payments',
+        'Balance',
+        'Status',
+        'Due Date',
+      ]);
+
+      // Currency and date columns should carry native Excel number formats,
+      // not just be stringified in the cell value.
+      expect(billingSheet.getColumn('totalCharges' as any).numFmt).toBe('"$"#,##0.00');
+      expect(billingSheet.getColumn('serviceDate' as any).numFmt).toBe('yyyy-mm-dd');
+      expect(billingSheet.getRow(2).getCell(4).value).toBe(250.5);
     });
   });
 });

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -11,7 +11,9 @@ import {
 import { AuditLogEntity } from '../common/audit/audit-log.entity';
 import { User } from '../auth/entities/user.entity';
 import { AccessGrant } from '../access-control/entities/access-grant.entity';
+import { Billing } from '../billing/entities/billing.entity';
 import * as PDFDocument from 'pdfkit';
+import * as ExcelJS from 'exceljs';
 import { create as ipfsHttpClient } from 'ipfs-http-client';
 import { v4 as uuidv4 } from 'uuid';
 import { PassThrough } from 'stream';
@@ -145,6 +147,14 @@ export class ReportsService {
       let buffer: Buffer;
       if (format === ReportFormat.PDF) {
         buffer = await this.generatePdfBuffer(patient, records, grants, userAuditLogs);
+      } else if (format === ReportFormat.XLSX) {
+        // Billing data is only needed for the XLSX "Billing Summary" sheet, so it is
+        // fetched lazily here rather than for every report format.
+        const billings = await this.entityManager.find(Billing, {
+          where: { patientId },
+          order: { serviceDate: 'DESC' },
+        });
+        buffer = await this.generateXlsxBuffer(patient, records, grants, userAuditLogs, billings);
       } else {
         buffer = await this.generateCsvBuffer(records, grants, userAuditLogs);
       }
@@ -305,5 +315,154 @@ export class ReportsService {
     });
 
     return Buffer.from(csv, 'utf-8');
+  }
+
+  /**
+   * Builds a multi-sheet XLSX workbook mirroring the sections used by the PDF/CSV
+   * exports (Medical Records, Access Grants, Audit Logs) plus a Summary overview
+   * sheet and a Billing Summary sheet sourced from the billing module. Date and
+   * currency columns use native Excel number formats so they render/sort/filter
+   * correctly instead of as plain text.
+   */
+  private async generateXlsxBuffer(
+    patient: User,
+    records: MedicalRecord[],
+    grants: AccessGrant[],
+    logs: AuditLogEntity[],
+    billings: Billing[],
+  ): Promise<Buffer> {
+    const DATE_FORMAT = 'yyyy-mm-dd';
+    const DATETIME_FORMAT = 'yyyy-mm-dd hh:mm:ss';
+    const CURRENCY_FORMAT = '"$"#,##0.00';
+
+    const workbook = new ExcelJS.Workbook();
+    workbook.creator = 'Healthy Stellar Reports';
+    workbook.created = new Date();
+
+    const styleHeader = (worksheet: ExcelJS.Worksheet) => {
+      const headerRow = worksheet.getRow(1);
+      headerRow.font = { bold: true };
+      headerRow.eachCell((cell) => {
+        cell.fill = {
+          type: 'pattern',
+          pattern: 'solid',
+          fgColor: { argb: 'FFE0E0E0' },
+        };
+      });
+    };
+
+    // ── Summary sheet ──────────────────────────────────────────────────────
+    const summarySheet = workbook.addWorksheet('Summary');
+    summarySheet.columns = [
+      { header: 'Field', key: 'field', width: 28 },
+      { header: 'Value', key: 'value', width: 40 },
+    ];
+    summarySheet.addRows([
+      { field: 'Patient Name', value: `${patient?.firstName || ''} ${patient?.lastName || ''}`.trim() },
+      { field: 'Patient ID', value: patient?.id || '' },
+      { field: 'Generated On', value: new Date() },
+      { field: 'Medical Records Count', value: records.length },
+      { field: 'Access Grants Count', value: grants.length },
+      { field: 'Audit Log Entries', value: logs.length },
+      { field: 'Billing Records Count', value: billings.length },
+    ]);
+    summarySheet.getCell('B4').numFmt = DATETIME_FORMAT; // "Generated On" row
+    styleHeader(summarySheet);
+
+    // ── Medical Records sheet ──────────────────────────────────────────────
+    const recordsSheet = workbook.addWorksheet('Medical Records');
+    recordsSheet.columns = [
+      { header: 'Date', key: 'date', width: 14 },
+      { header: 'Type', key: 'type', width: 16 },
+      { header: 'Title', key: 'title', width: 30 },
+      { header: 'Transaction Hash', key: 'txHash', width: 44 },
+    ];
+    records.forEach((record) => {
+      const metadataHash = (record.metadata as Record<string, string>)?.transactionHash || '';
+      recordsSheet.addRow({
+        date: new Date(record.createdAt),
+        type: record.recordType?.toUpperCase() || 'UNKNOWN',
+        title: record.title || '',
+        txHash: metadataHash,
+      });
+    });
+    recordsSheet.getColumn('date').numFmt = DATE_FORMAT;
+    styleHeader(recordsSheet);
+
+    // ── Access Grants sheet ──────────────────────────────────────────────
+    const grantsSheet = workbook.addWorksheet('Access Grants');
+    grantsSheet.columns = [
+      { header: 'Granted To', key: 'grantedTo', width: 26 },
+      { header: 'Status', key: 'status', width: 14 },
+      { header: 'Access Level', key: 'accessLevel', width: 16 },
+      { header: 'Expires At', key: 'expiresAt', width: 14 },
+      { header: 'Transaction Hash', key: 'txHash', width: 44 },
+    ];
+    grants.forEach((grant) => {
+      const isExpired = grant.expiresAt && new Date(grant.expiresAt) < new Date();
+      grantsSheet.addRow({
+        grantedTo: grant.granteeId,
+        status: isExpired ? 'EXPIRED' : grant.status,
+        accessLevel: grant.accessLevel,
+        expiresAt: grant.expiresAt ? new Date(grant.expiresAt) : null,
+        txHash: grant.sorobanTxHash || '',
+      });
+    });
+    grantsSheet.getColumn('expiresAt').numFmt = DATE_FORMAT;
+    styleHeader(grantsSheet);
+
+    // ── Audit Logs sheet ───────────────────────────────────────────────────
+    const logsSheet = workbook.addWorksheet('Audit Logs');
+    logsSheet.columns = [
+      { header: 'Timestamp', key: 'timestamp', width: 20 },
+      { header: 'Action', key: 'action', width: 24 },
+      { header: 'Description', key: 'description', width: 40 },
+      { header: 'Transaction Hash', key: 'txHash', width: 44 },
+    ];
+    logs.forEach((log) => {
+      const metadataHash = log.details?.transactionHash || log.metadata?.transactionHash || '';
+      logsSheet.addRow({
+        timestamp: new Date(log.timestamp),
+        action: log.action,
+        description: log.description || '',
+        txHash: metadataHash,
+      });
+    });
+    logsSheet.getColumn('timestamp').numFmt = DATETIME_FORMAT;
+    styleHeader(logsSheet);
+
+    // ── Billing Summary sheet ──────────────────────────────────────────────
+    const billingSheet = workbook.addWorksheet('Billing Summary');
+    billingSheet.columns = [
+      { header: 'Invoice Number', key: 'invoiceNumber', width: 20 },
+      { header: 'Service Date', key: 'serviceDate', width: 14 },
+      { header: 'Provider', key: 'provider', width: 24 },
+      { header: 'Total Charges', key: 'totalCharges', width: 16 },
+      { header: 'Total Payments', key: 'totalPayments', width: 16 },
+      { header: 'Balance', key: 'balance', width: 16 },
+      { header: 'Status', key: 'status', width: 12 },
+      { header: 'Due Date', key: 'dueDate', width: 14 },
+    ];
+    billings.forEach((billing) => {
+      billingSheet.addRow({
+        invoiceNumber: billing.invoiceNumber,
+        serviceDate: billing.serviceDate ? new Date(billing.serviceDate) : null,
+        provider: billing.providerName,
+        totalCharges: Number(billing.totalCharges),
+        totalPayments: Number(billing.totalPayments),
+        balance: Number(billing.balance),
+        status: billing.status,
+        dueDate: billing.dueDate ? new Date(billing.dueDate) : null,
+      });
+    });
+    billingSheet.getColumn('serviceDate').numFmt = DATE_FORMAT;
+    billingSheet.getColumn('dueDate').numFmt = DATE_FORMAT;
+    billingSheet.getColumn('totalCharges').numFmt = CURRENCY_FORMAT;
+    billingSheet.getColumn('totalPayments').numFmt = CURRENCY_FORMAT;
+    billingSheet.getColumn('balance').numFmt = CURRENCY_FORMAT;
+    styleHeader(billingSheet);
+
+    const arrayBuffer = await workbook.xlsx.writeBuffer();
+    return Buffer.from(arrayBuffer);
   }
 }


### PR DESCRIPTION
## Summary
Adds XLSX as a supported export format for patient reports, alongside the existing PDF/CSV pipeline in `ReportsService`. Scheduled reports (`report-schedule.*`) automatically gain XLSX support because they validate `format` against the same shared `ReportFormat` enum used by the report generation endpoint. The XLSX output is a multi-sheet workbook (Summary, Medical Records, Access Grants, Audit Logs, Billing Summary) with native Excel date and currency number formats instead of stringified values.

## Context
- **Format options before:** `pdf | csv` (`ReportFormat` enum in `src/reports/entities/report-job.entity.ts`, reused by `src/reports/dto/report-schedule.dto.ts` and `src/reports/entities/report-schedule.entity.ts`).
- **Format options after:** `pdf | csv | xlsx`. No new enum was introduced — the existing `ReportFormat` enum was extended with `XLSX = 'xlsx'`, so `POST /reports/generate`, the admin report-schedule CRUD endpoints, and the `ReportSchedule` entity's `format` column all pick it up without further changes.
- **Implementation:** `ReportsService.generateReport` gains a new branch that calls a new private `generateXlsxBuffer(...)` method (mirrors the existing `generatePdfBuffer`/`generateCsvBuffer` pattern and reuses the same data already fetched for PDF/CSV — medical records, access grants, audit logs). For XLSX only, it additionally fetches the patient's `Billing` records (via the existing `EntityManager`, same pattern as the other entities) to populate a "Billing Summary" sheet with real currency data (`totalCharges`, `totalPayments`, `balance`) and a "Due Date" column, giving a concrete example of currency/date `numFmt` formatting (`"$"#,##0.00` and `yyyy-mm-dd`/`yyyy-mm-dd hh:mm:ss`) rather than plain strings.
- **New dependency:** `exceljs` (`^4.4.0`) was added to `dependencies` in `package.json`. **`npm install` was not run** in this environment (no `node_modules` present, and this session was instructed not to run a full install) — `npm install` must be run before `npx jest` or the app will pick up the new code.

## Testing notes
- Added a new test suite in `src/reports/reports.service.spec.ts` (`generateXlsxBuffer (XLSX export)`) that builds a workbook from fixture data and loads it back with `ExcelJS.Workbook#xlsx.load`, asserting: the five expected sheet names/order, the "Medical Records" and "Billing Summary" header rows match the expected column structure, a records date cell is a real `Date` instance, and the billing sheet's currency/date columns carry the expected `numFmt` (`"$"#,##0.00` / `yyyy-mm-dd`) instead of being plain text.
- While updating this spec file, also added the missing `I18nService` mock provider to the `ReportsService` `TestingModule` — `ReportsService`'s constructor already required `I18nService` (added in an earlier, unrelated commit) but the spec's providers array never included it, so the whole spec file was failing to compile before this change even without any of the XLSX work.
- Could not actually run `npx jest src/reports --selectProjects unit` in this environment: the worktree has no `node_modules` at all (not specific to `exceljs`), and a fresh `npx jest` also failed (`Cannot find module 'ci-info'`) due to a broken local npx cache unrelated to this change. Run `npm install` then `npx jest src/reports --selectProjects unit` to verify.

Closes #860