### PR TITLE
fix(event-store): paginate streamAll by global sequence, not per-aggregate version

### DIFF
--- a/src/event-store/event-store.service.ts
+++ b/src/event-store/event-store.service.ts
@@ -144,27 +144,38 @@ export class EventStoreService {
   /**
    * Stream all events from the event store for replaying (rebuilding projections).
    * Uses batched loading to maintain memory efficiency.
+   *
+   * Pages by `globalSequence`, not `version`: `version` is scoped per
+   * aggregate, so paginating by it corrupts full-stream reads — once the
+   * cursor passes another aggregate's version number, that aggregate's
+   * remaining events get silently skipped (or duplicated, if the cursor
+   * happens to be lower than events already emitted). `globalSequence` is a
+   * single strictly-increasing counter across every aggregate, so ordering
+   * and cursoring by it is safe.
    */
-  async *streamAll(fromVersion = 0): AsyncGenerator<{ event: DomainEvent; version: number }> {
-    const batchSize = 100;
-    let currentVersion = fromVersion;
+  async *streamAll(
+    fromSequence = 0,
+    batchSize = 100,
+  ): AsyncGenerator<{ event: DomainEvent; globalSequence: number }> {
+    let cursor = fromSequence;
 
     while (true) {
       const rows = await this.eventRepo
         .createQueryBuilder('e')
-        .where('e.version > :currentVersion', { currentVersion })
-        .orderBy('e.version', 'ASC')
+        .where('e.globalSequence > :cursor', { cursor })
+        .orderBy('e.globalSequence', 'ASC')
         .take(batchSize)
         .getMany();
 
       if (rows.length === 0) break;
 
       for (const row of rows) {
+        const globalSequence = Number(row.globalSequence);
         yield {
           event: this._rowToDomainEvent(row),
-          version: row.version,
+          globalSequence,
         };
-        currentVersion = row.version;
+        cursor = globalSequence;
       }
     }
   }

--- a/src/event-store/event-store.spec.ts
+++ b/src/event-store/event-store.spec.ts
@@ -229,6 +229,102 @@ describe('EventStoreService', () => {
       expect(snap!.state).toEqual({ patientId: 'p1', cid: 'Qm1' });
     });
   });
+
+  // ── streamAll ───────────────────────────────────────────────────────────────
+
+  describe('streamAll', () => {
+    /**
+     * A stateful fake query builder that mimics what Postgres would actually
+     * do for `WHERE global_sequence > :cursor ORDER BY global_sequence ASC
+     * LIMIT :take`: it re-evaluates the filter/limit against the full row
+     * set on every call, exactly like the real per-page SELECT does.
+     */
+    function buildPaginatedQb(rows: EventEntity[]) {
+      let cursor = -Infinity;
+      let limit = rows.length;
+      const qb: Partial<SelectQueryBuilder<EventEntity>> = {};
+      qb.where = jest.fn().mockImplementation((_cond: string, params: { cursor: number }) => {
+        cursor = params.cursor;
+        return qb;
+      });
+      qb.orderBy = jest.fn().mockReturnValue(qb);
+      qb.take = jest.fn().mockImplementation((n: number) => {
+        limit = n;
+        return qb;
+      });
+      qb.getMany = jest.fn().mockImplementation(() =>
+        Promise.resolve(
+          rows
+            .filter((r) => r.globalSequence > cursor)
+            .sort((a, b) => a.globalSequence - b.globalSequence)
+            .slice(0, limit),
+        ),
+      );
+      return qb;
+    }
+
+    it('streams interleaved events from multiple aggregates fully, exactly once, and in global order across pages', async () => {
+      // Two aggregates whose per-aggregate `version` numbers deliberately
+      // collide (both have a v1, v2, ...), which is exactly what made the
+      // old `WHERE version > :cursor` pagination unsafe: a cursor derived
+      // from one aggregate's version silently skipped/duplicated events
+      // belonging to the other. `globalSequence` is unique and ordered
+      // across the whole table, so it must not collide.
+      const rows: EventEntity[] = [
+        makeEvent({ id: 'e1', aggregateId: 'agg-A', version: 1, globalSequence: 1, eventType: 'RecordUploaded' }),
+        makeEvent({ id: 'e2', aggregateId: 'agg-B', version: 1, globalSequence: 2, eventType: 'RecordUploaded' }),
+        makeEvent({ id: 'e3', aggregateId: 'agg-A', version: 2, globalSequence: 3, eventType: 'AccessGranted' }),
+        makeEvent({ id: 'e4', aggregateId: 'agg-B', version: 2, globalSequence: 4, eventType: 'AccessGranted' }),
+        makeEvent({ id: 'e5', aggregateId: 'agg-A', version: 3, globalSequence: 5, eventType: 'AccessRevoked' }),
+      ];
+
+      const qb = buildPaginatedQb(rows);
+      eventRepo.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      const seen: { aggregateId: string; version?: number; globalSequence: number }[] = [];
+      // A page size of 2 forces multiple round-trips over 5 rows
+      // (2 + 2 + 1, then a final empty page that ends the stream),
+      // proving the cursor survives across multiple pages, not just one.
+      for await (const { event, globalSequence } of service.streamAll(0, 2)) {
+        seen.push({ aggregateId: event.aggregateId, version: event.version, globalSequence });
+      }
+
+      // Every row streamed exactly once, in strict global order.
+      expect(seen.map((s) => s.globalSequence)).toEqual([1, 2, 3, 4, 5]);
+      expect(seen).toHaveLength(rows.length);
+
+      // Both aggregates are represented in full despite overlapping versions.
+      expect(seen.map((s) => s.aggregateId)).toEqual([
+        'agg-A',
+        'agg-B',
+        'agg-A',
+        'agg-B',
+        'agg-A',
+      ]);
+      expect(seen.filter((s) => s.aggregateId === 'agg-A')).toHaveLength(3);
+      expect(seen.filter((s) => s.aggregateId === 'agg-B')).toHaveLength(2);
+
+      // No (aggregateId, version) pair was skipped or emitted twice.
+      const uniqueKeys = new Set(seen.map((s) => `${s.aggregateId}:${s.version}`));
+      expect(uniqueKeys.size).toBe(rows.length);
+
+      // Confirms pagination actually happened across multiple round-trips
+      // (3 pages of data plus the trailing empty page that ends the loop).
+      expect(eventRepo.createQueryBuilder).toHaveBeenCalledTimes(4);
+    });
+
+    it('returns nothing when the store is empty', async () => {
+      const qb = buildPaginatedQb([]);
+      eventRepo.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+      const seen: unknown[] = [];
+      for await (const item of service.streamAll(0, 2)) {
+        seen.push(item);
+      }
+
+      expect(seen).toHaveLength(0);
+    });
+  });
 });
 
 // ── MedicalRecordAggregate ────────────────────────────────────────────────────

--- a/src/event-store/event.entity.ts
+++ b/src/event-store/event.entity.ts
@@ -3,6 +3,7 @@ import {
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
+  Generated,
   Index,
   Unique,
 } from 'typeorm';
@@ -39,9 +40,24 @@ export class EventEntity {
   /**
    * Monotonically increasing per-aggregate version number.
    * Used for optimistic concurrency control.
+   *
+   * NOT safe for cursoring over the full event stream: this counter resets
+   * per aggregate, so it is neither globally unique nor globally ordered.
+   * Use `globalSequence` for that (see EventStoreService#streamAll).
    */
   @Column({ type: 'integer' })
   version: number;
+
+  /**
+   * Globally monotonic sequence assigned by a dedicated DB sequence at
+   * insert time. Strictly increasing across the entire table regardless of
+   * aggregate — this is the correct cursor key for reading/paginating the
+   * full event stream (e.g. full projection rebuilds), unlike `version`.
+   */
+  @Column({ type: 'bigint', name: 'global_sequence' })
+  @Generated('increment')
+  @Index('UQ_event_store_global_sequence', { unique: true })
+  globalSequence: number;
 
   /** Business time: when the event logically occurred. */
   @CreateDateColumn({ type: 'timestamp with time zone', name: 'occurred_at' })

--- a/src/migrations/1785500000000-AddGlobalSequenceToEventStore.ts
+++ b/src/migrations/1785500000000-AddGlobalSequenceToEventStore.ts
@@ -1,0 +1,79 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds a globally monotonic `global_sequence` column to `event_store`.
+ *
+ * `version` on this table is scoped per-aggregate (see the column comment
+ * on EventEntity), so it is not safe to use for cursoring over the *entire*
+ * event stream: once a pagination cursor built from `version` passes another
+ * aggregate's version number, that aggregate's remaining events are silently
+ * skipped (or, if the cursor resets lower, re-emitted) during full
+ * projection rebuilds. `EventStoreService#streamAll` was doing exactly that.
+ *
+ * `global_sequence` is backed by a dedicated sequence, assigned at insert
+ * time, and is strictly increasing across the whole table regardless of
+ * aggregate — the correct key for full-stream pagination.
+ */
+export class AddGlobalSequenceToEventStore1785500000000 implements MigrationInterface {
+  name = 'AddGlobalSequenceToEventStore1785500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE SEQUENCE IF NOT EXISTS "event_store_global_sequence_seq";
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "event_store" ADD COLUMN IF NOT EXISTS "global_sequence" BIGINT;
+    `);
+
+    // Backfill existing rows in (approximate) original insertion order.
+    // event_store is append-only (UPDATE/DELETE are trigger-blocked), so
+    // recorded_at + id is a reliable proxy for the order rows were written.
+    await queryRunner.query(`
+      UPDATE "event_store" e
+      SET "global_sequence" = ordered.rn
+      FROM (
+        SELECT "id", ROW_NUMBER() OVER (ORDER BY "recorded_at" ASC, "id" ASC) AS rn
+        FROM "event_store"
+      ) ordered
+      WHERE e."id" = ordered."id"
+        AND e."global_sequence" IS NULL;
+    `);
+
+    // Point the sequence past whatever we just backfilled, then wire it up
+    // as the column default so every future insert gets the next value.
+    await queryRunner.query(`
+      SELECT setval(
+        'event_store_global_sequence_seq',
+        COALESCE((SELECT MAX("global_sequence") FROM "event_store"), 0) + 1,
+        false
+      );
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "event_store"
+      ALTER COLUMN "global_sequence" SET DEFAULT nextval('event_store_global_sequence_seq');
+    `);
+
+    await queryRunner.query(`
+      ALTER SEQUENCE "event_store_global_sequence_seq" OWNED BY "event_store"."global_sequence";
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "event_store" ALTER COLUMN "global_sequence" SET NOT NULL;
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_event_store_global_sequence"
+        ON "event_store" ("global_sequence");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "UQ_event_store_global_sequence"`);
+    await queryRunner.query(
+      `ALTER TABLE "event_store" DROP COLUMN IF EXISTS "global_sequence"`,
+    );
+    await queryRunner.query(`DROP SEQUENCE IF EXISTS "event_store_global_sequence_seq"`);
+  }
+}

--- a/src/projections/rebuild/projection-rebuild.processor.ts
+++ b/src/projections/rebuild/projection-rebuild.processor.ts
@@ -49,8 +49,9 @@ export class ProjectionRebuildProcessor {
         progressPercent: 0,
       });
 
-      // Stream and republish all events through the EventBus
-      for await (const { event, version } of this.eventStore.streamAll(0)) {
+      // Stream and republish all events through the EventBus, in global
+      // insertion order (paginated by globalSequence — see EventStoreService#streamAll)
+      for await (const { event } of this.eventStore.streamAll(0)) {
         await this.eventBus.publish(event as unknown as IEvent);
         processed++;
         


### PR DESCRIPTION
## 1. Summary

`EventStoreService.streamAll()` — the full-stream reader used by projection rebuilds (`ProjectionRebuildProcessor`) — paginated with `WHERE version > :cursor ORDER BY version ASC`, advancing the cursor from the last row's `version` column. `version` on `event_store` is scoped **per aggregate** (it restarts at 1 for every aggregate), not globally unique or ordered, so paging by it silently skipped or duplicated events across aggregates during a full rebuild.

This adds a `global_sequence` column to `event_store` — a dedicated Postgres sequence assigned at insert time, strictly increasing across the whole table regardless of aggregate — and repoints `streamAll()`'s cursor at it.

Changes:
- `src/migrations/1785500000000-AddGlobalSequenceToEventStore.ts`: adds `global_sequence` (bigint, backed by `event_store_global_sequence_seq`, unique index), backfilling existing rows in insertion order (`recorded_at`, `id`) before wiring the sequence up as the column default.
- `src/event-store/event.entity.ts`: adds the `globalSequence` column (`@Generated('increment')`) with a doc comment clarifying it — not `version` — is the safe cursor key for full-stream reads.
- `src/event-store/event-store.service.ts`: `streamAll()` now pages by `e.globalSequence > :cursor ORDER BY e.globalSequence ASC`. Also added an optional `batchSize` param (default 100, unchanged) so pagination can be exercised with small pages in tests without touching production call sites.
- `src/projections/rebuild/projection-rebuild.processor.ts`: updated the `streamAll()` destructure (it only ever used `event`, so no behavioral change there beyond consuming the fixed stream).
- `src/event-store/event-store.spec.ts`: new regression test.

## 2. Context: before/after pagination behavior

**Before:** cursor advanced by the emitted row's `version`. Given aggregate A (versions 1, 2, 3) and aggregate B (versions 1, 2) interleaved by insertion order, once the cursor reached, say, `2` from aggregate B, the next page's `WHERE version > 2` would skip aggregate A's still-unprocessed version-1/2 events (or, depending on interleaving, re-emit already-seen rows) — because the comparison mixes version numbers from unrelated aggregates. Full projection rebuilds could silently under- or over-process events with no error raised.

**After:** cursor advances by `globalSequence`, a single strictly-increasing counter assigned once per row across the entire table. `WHERE global_sequence > :cursor ORDER BY global_sequence ASC` therefore always resumes exactly where the previous page left off, regardless of how many aggregates are interleaved, guaranteeing every event is streamed exactly once in true global insertion order.

## 3. Testing notes

Added `describe('streamAll', ...)` in `src/event-store/event-store.spec.ts`:
- Builds a stateful fake query builder that re-filters/sorts/limits a fixture row set on every call, mimicking what the real per-page SQL does.
- Fixture has two aggregates with **colliding** `version` numbers (both have v1, v2, ...) interleaved by `globalSequence` — the exact shape that broke the old cursor.
- Streams with `batchSize = 2` (via the new optional param) to force multiple round-trips over 5 rows.
- Asserts: events arrive in strict `globalSequence` order, both aggregates are represented in full (3 events for A, 2 for B), no `(aggregateId, version)` pair is skipped or duplicated, and pagination genuinely spanned multiple `createQueryBuilder` calls.
- Also covers the empty-store case.

I could not execute the suite in this environment — `node_modules` is not installed here and installing dependencies was out of scope for this task, so `npx jest src/event-store --selectProjects unit` fails with `Cannot find module 'ci-info'` before it reaches this repo's tests. Please run the suite in CI/a normal dev environment to confirm.

Closes #835