### PR TITLE
GraphQL: query complexity and depth limiting to prevent resource-exhaustion abuse

### DIFF
--- a/src/graphql-queries/graphql.module.ts
+++ b/src/graphql-queries/graphql.module.ts
@@ -4,6 +4,7 @@ import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import graphqlUploadExpress from 'graphql-upload/graphqlUploadExpress.js';
+import depthLimit from 'graphql-depth-limit';
 
 // Resolvers
 import {
@@ -21,8 +22,9 @@ import { RecordDataLoader } from './dataloaders/record.dataloader';
 // Services
 import { IdempotencyService } from './services/idempotency.service';
 
-// Plugins
-import { ComplexityPlugin } from './plugins/complexity.plugin';
+// Plugins (reuse the single canonical implementation from src/graphql/ —
+// this module previously pointed at a non-existent local ./plugins path)
+import { ComplexityPlugin } from '../graphql/plugins/complexity.plugin';
 
 // Guards
 import { GqlAuthGuard, GqlRolesGuard } from './guards/gql-auth.guard';
@@ -36,6 +38,7 @@ import { UsersModule } from '../users/users.module';
 import { GdprModule } from '../gdpr/gdpr.module';
 import { DevicesModule } from '../devices/devices.module';
 import { AuthModule } from '../auth/auth.module';
+import { AuditModule } from '../common/audit/audit.module';
 
 // Throttling
 import { GraphQLSubscriptionLimiter } from '../common/throttler/graphql-subscription-limiter';
@@ -51,6 +54,12 @@ import { GraphQLSubscriptionLimiter } from '../common/throttler/graphql-subscrip
         introspection: process.env.NODE_ENV !== 'production',
         context: ({ req }) => ({ req }),
         uploads: false,
+
+        // Depth limit (DoS protection) — validation-rule level, runs before
+        // the operation is resolved. Complexity limiting + per-tenant depth
+        // overrides are handled by ComplexityPlugin (registered below via
+        // its `@Plugin()` decorator), consistent with src/graphql/graphql.module.ts.
+        validationRules: [depthLimit(Number(process.env.GRAPHQL_MAX_QUERY_DEPTH ?? 7))],
         subscriptions: {
           'graphql-ws': {
             onConnect: async (context) => {
@@ -89,6 +98,7 @@ import { GraphQLSubscriptionLimiter } from '../common/throttler/graphql-subscrip
     GdprModule,
     DevicesModule,
     AuthModule,
+    AuditModule,
   ],
 
   providers: [

--- a/src/graphql/__tests__/complexity.plugin.spec.ts
+++ b/src/graphql/__tests__/complexity.plugin.spec.ts
@@ -1,0 +1,350 @@
+import { buildSchema, parse } from 'graphql';
+import {
+  ComplexityPlugin,
+  calculateQueryDepth,
+  DEFAULT_COMPLEXITY_THRESHOLD,
+  DEFAULT_MAX_QUERY_DEPTH,
+  TENANT_CONFIG_KEY_MAX_COMPLEXITY,
+  TENANT_CONFIG_KEY_MAX_DEPTH,
+} from '../plugins/complexity.plugin';
+
+/* ─── Test schema ─────────────────────────────────────────────────── */
+/* A chain of nested types (a -> b -> ... -> h), each exposing a scalar
+ * "leaf" field so complexity can be exercised at any depth without
+ * relying on introspection meta-fields. */
+
+const schema = buildSchema(`
+  type Query { a: Level1 }
+  type Level1 { leaf: String b: Level2 }
+  type Level2 { leaf: String c: Level3 }
+  type Level3 { leaf: String d: Level4 }
+  type Level4 { leaf: String e: Level5 }
+  type Level5 { leaf: String f: Level6 }
+  type Level6 { leaf: String g: Level7 }
+  type Level7 { leaf: String h: String }
+`);
+
+/* ─── Helpers / mocks ─────────────────────────────────────────────── */
+
+function createConfigService(overrides: Record<string, string | undefined> = {}) {
+  return { get: jest.fn((key: string) => overrides[key]) };
+}
+
+function createTenantConfigService() {
+  return { get: jest.fn().mockResolvedValue(undefined) };
+}
+
+function createAuditLogService() {
+  return { log: jest.fn().mockResolvedValue(undefined) };
+}
+
+function buildContext(opts: { userId?: string; tenantId?: string; headers?: Record<string, any> } = {}) {
+  return {
+    req: {
+      user: opts.userId || opts.tenantId ? { userId: opts.userId, tenantId: opts.tenantId } : undefined,
+      headers: opts.headers ?? {},
+      ip: '203.0.113.5',
+    },
+  };
+}
+
+async function resolveOperation(
+  plugin: ComplexityPlugin,
+  opts: {
+    query: string;
+    operationName?: string;
+    contextValue?: any;
+  },
+) {
+  const listener: any = await plugin.requestDidStart();
+  return listener.didResolveOperation({
+    request: { operationName: opts.operationName, variables: {} },
+    document: parse(opts.query),
+    contextValue: opts.contextValue ?? buildContext(),
+    schema,
+  });
+}
+
+/* ═══════════════════════════════════════════════════════════════════ */
+/*                      calculateQueryDepth                            */
+/* ═══════════════════════════════════════════════════════════════════ */
+
+describe('calculateQueryDepth', () => {
+  it('computes the nesting depth of a query', () => {
+    const document = parse('query Shallow { a { b { c { leaf } } } }');
+    expect(calculateQueryDepth(document, 'Shallow')).toBe(4);
+  });
+
+  it('ignores introspection fields when computing depth', () => {
+    const document = parse('query WithIntrospection { a { __typename } }');
+    // "__typename" is skipped entirely, so it contributes nothing to depth.
+    expect(calculateQueryDepth(document, 'WithIntrospection')).toBe(1);
+  });
+
+  it('resolves fragment spreads when computing depth', () => {
+    const document = parse(`
+      query WithFragment { a { ...OnLevel1 } }
+      fragment OnLevel1 on Level1 { b { c { leaf } } }
+    `);
+    expect(calculateQueryDepth(document, 'WithFragment')).toBe(4);
+  });
+
+  it('returns 0 when the named operation cannot be found', () => {
+    const document = parse('query Other { a { b { leaf } } }');
+    expect(calculateQueryDepth(document, 'DoesNotExist')).toBe(0);
+  });
+});
+
+/* ═══════════════════════════════════════════════════════════════════ */
+/*                          ComplexityPlugin                           */
+/* ═══════════════════════════════════════════════════════════════════ */
+
+describe('ComplexityPlugin', () => {
+  const schemaHost = { schema };
+
+  it('allows a query within the default depth and complexity limits', async () => {
+    const configService = createConfigService();
+    const tenantConfigService = createTenantConfigService();
+    const auditLogService = createAuditLogService();
+    const plugin = new ComplexityPlugin(
+      schemaHost as any,
+      configService as any,
+      tenantConfigService as any,
+      auditLogService as any,
+    );
+
+    await expect(
+      resolveOperation(plugin, { query: 'query Small { a { b { leaf } } }', operationName: 'Small' }),
+    ).resolves.toBeUndefined();
+    expect(auditLogService.log).not.toHaveBeenCalled();
+  });
+
+  it('rejects a query exceeding the environment-configured max depth with a GraphQLError', async () => {
+    const configService = createConfigService();
+    const tenantConfigService = createTenantConfigService();
+    const auditLogService = createAuditLogService();
+    const plugin = new ComplexityPlugin(
+      schemaHost as any,
+      configService as any,
+      tenantConfigService as any,
+      auditLogService as any,
+    );
+
+    const query = 'query OverDepth { a { b { c { d { e { f { g { h } } } } } } } }';
+
+    await expect(
+      resolveOperation(plugin, {
+        query,
+        operationName: 'OverDepth',
+        contextValue: buildContext({ userId: 'user-1', tenantId: 'tenant-a' }),
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('Query depth'),
+      extensions: {
+        code: 'GRAPHQL_QUERY_DEPTH_EXCEEDED',
+        maxDepth: DEFAULT_MAX_QUERY_DEPTH,
+      },
+    });
+
+    // Rejected queries must produce an audit trail identifying the tenant/client.
+    expect(auditLogService.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'GraphQLQuery',
+        action: 'QUERY_REJECTED',
+        userId: 'user-1',
+        metadata: expect.objectContaining({ tenantId: 'tenant-a' }),
+      }),
+    );
+  });
+
+  it('rejects a query exceeding a configured complexity threshold', async () => {
+    const configService = createConfigService({ GRAPHQL_QUERY_COMPLEXITY_THRESHOLD: '2' });
+    const tenantConfigService = createTenantConfigService();
+    const auditLogService = createAuditLogService();
+    const plugin = new ComplexityPlugin(
+      schemaHost as any,
+      configService as any,
+      tenantConfigService as any,
+      auditLogService as any,
+    );
+
+    // complexity = 1 (a) + 1 (b) + 1 (leaf) = 3 > threshold of 2
+    const query = 'query OverComplexity { a { b { leaf } } }';
+
+    await expect(
+      resolveOperation(plugin, { query, operationName: 'OverComplexity' }),
+    ).rejects.toMatchObject({
+      extensions: { code: 'GRAPHQL_QUERY_COMPLEXITY_EXCEEDED', threshold: 2 },
+    });
+  });
+
+  it('applies a per-tenant override that tightens the effective complexity threshold', async () => {
+    const configService = createConfigService({ GRAPHQL_QUERY_COMPLEXITY_THRESHOLD: '1000' });
+    const tenantConfigService = createTenantConfigService();
+    tenantConfigService.get.mockImplementation((_tenantId: string, key: string) =>
+      key === TENANT_CONFIG_KEY_MAX_COMPLEXITY ? Promise.resolve(2) : Promise.resolve(undefined),
+    );
+    const auditLogService = createAuditLogService();
+    const plugin = new ComplexityPlugin(
+      schemaHost as any,
+      configService as any,
+      tenantConfigService as any,
+      auditLogService as any,
+    );
+
+    const query = 'query OverComplexity { a { b { leaf } } }'; // complexity = 3
+
+    await expect(
+      resolveOperation(plugin, {
+        query,
+        operationName: 'OverComplexity',
+        contextValue: buildContext({ userId: 'user-1', tenantId: 'tenant-strict' }),
+      }),
+    ).rejects.toMatchObject({
+      extensions: { code: 'GRAPHQL_QUERY_COMPLEXITY_EXCEEDED', threshold: 2 },
+    });
+    expect(tenantConfigService.get).toHaveBeenCalledWith(
+      'tenant-strict',
+      TENANT_CONFIG_KEY_MAX_COMPLEXITY,
+    );
+  });
+
+  it('never allows a tenant override to loosen the limit beyond the environment ceiling', async () => {
+    const configService = createConfigService({ GRAPHQL_QUERY_COMPLEXITY_THRESHOLD: '2' });
+    const tenantConfigService = createTenantConfigService();
+    // Tenant attempts to raise its own budget far above the environment ceiling.
+    tenantConfigService.get.mockImplementation((_tenantId: string, key: string) =>
+      key === TENANT_CONFIG_KEY_MAX_COMPLEXITY ? Promise.resolve(100000) : Promise.resolve(undefined),
+    );
+    const auditLogService = createAuditLogService();
+    const plugin = new ComplexityPlugin(
+      schemaHost as any,
+      configService as any,
+      tenantConfigService as any,
+      auditLogService as any,
+    );
+
+    const query = 'query OverComplexity { a { b { leaf } } }'; // complexity = 3 > env ceiling of 2
+
+    await expect(
+      resolveOperation(plugin, {
+        query,
+        operationName: 'OverComplexity',
+        contextValue: buildContext({ userId: 'user-1', tenantId: 'tenant-loose' }),
+      }),
+    ).rejects.toMatchObject({
+      extensions: { code: 'GRAPHQL_QUERY_COMPLEXITY_EXCEEDED', threshold: 2 },
+    });
+  });
+
+  it('applies a per-tenant override that tightens the effective max depth', async () => {
+    const configService = createConfigService();
+    const tenantConfigService = createTenantConfigService();
+    tenantConfigService.get.mockImplementation((_tenantId: string, key: string) =>
+      key === TENANT_CONFIG_KEY_MAX_DEPTH ? Promise.resolve(2) : Promise.resolve(undefined),
+    );
+    const auditLogService = createAuditLogService();
+    const plugin = new ComplexityPlugin(
+      schemaHost as any,
+      configService as any,
+      tenantConfigService as any,
+      auditLogService as any,
+    );
+
+    // depth = 3 (a -> b -> leaf), fine under the env default of 7, but over
+    // this tenant's override of 2.
+    const query = 'query Small { a { b { leaf } } }';
+
+    await expect(
+      resolveOperation(plugin, {
+        query,
+        operationName: 'Small',
+        contextValue: buildContext({ userId: 'user-1', tenantId: 'tenant-strict-depth' }),
+      }),
+    ).rejects.toMatchObject({
+      extensions: { code: 'GRAPHQL_QUERY_DEPTH_EXCEEDED', maxDepth: 2 },
+    });
+  });
+
+  it('falls back to environment defaults if the tenant-config lookup fails', async () => {
+    const configService = createConfigService();
+    const tenantConfigService = createTenantConfigService();
+    tenantConfigService.get.mockRejectedValue(new Error('redis unavailable'));
+    const auditLogService = createAuditLogService();
+    const plugin = new ComplexityPlugin(
+      schemaHost as any,
+      configService as any,
+      tenantConfigService as any,
+      auditLogService as any,
+    );
+
+    await expect(
+      resolveOperation(plugin, {
+        query: 'query Small { a { b { leaf } } }',
+        operationName: 'Small',
+        contextValue: buildContext({ userId: 'user-1', tenantId: 'tenant-flaky' }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not skip the rejection if writing the audit log entry fails', async () => {
+    const configService = createConfigService({ GRAPHQL_QUERY_COMPLEXITY_THRESHOLD: '2' });
+    const tenantConfigService = createTenantConfigService();
+    const auditLogService = createAuditLogService();
+    auditLogService.log.mockRejectedValue(new Error('db unavailable'));
+    const plugin = new ComplexityPlugin(
+      schemaHost as any,
+      configService as any,
+      tenantConfigService as any,
+      auditLogService as any,
+    );
+
+    await expect(
+      resolveOperation(plugin, {
+        query: 'query OverComplexity { a { b { leaf } } }',
+        operationName: 'OverComplexity',
+      }),
+    ).rejects.toMatchObject({ extensions: { code: 'GRAPHQL_QUERY_COMPLEXITY_EXCEEDED' } });
+  });
+
+  it('does not consult tenant config for anonymous/global requests', async () => {
+    const configService = createConfigService();
+    const tenantConfigService = createTenantConfigService();
+    const auditLogService = createAuditLogService();
+    const plugin = new ComplexityPlugin(
+      schemaHost as any,
+      configService as any,
+      tenantConfigService as any,
+      auditLogService as any,
+    );
+
+    await resolveOperation(plugin, {
+      query: 'query Small { a { b { leaf } } }',
+      operationName: 'Small',
+      contextValue: buildContext(),
+    });
+
+    expect(tenantConfigService.get).not.toHaveBeenCalled();
+  });
+
+  it('uses DEFAULT_COMPLEXITY_THRESHOLD / DEFAULT_MAX_QUERY_DEPTH when nothing is configured', async () => {
+    const configService = createConfigService();
+    const tenantConfigService = createTenantConfigService();
+    const auditLogService = createAuditLogService();
+    const plugin = new ComplexityPlugin(
+      schemaHost as any,
+      configService as any,
+      tenantConfigService as any,
+      auditLogService as any,
+    );
+
+    const query = 'query OverDepth { a { b { c { d { e { f { g { h } } } } } } } }';
+
+    await expect(
+      resolveOperation(plugin, { query, operationName: 'OverDepth' }),
+    ).rejects.toMatchObject({
+      extensions: { code: 'GRAPHQL_QUERY_DEPTH_EXCEEDED', maxDepth: DEFAULT_MAX_QUERY_DEPTH },
+    });
+    expect(DEFAULT_COMPLEXITY_THRESHOLD).toBeGreaterThan(0);
+  });
+});

--- a/src/graphql/__tests__/query-depth-complexity.integration.spec.ts
+++ b/src/graphql/__tests__/query-depth-complexity.integration.spec.ts
@@ -1,22 +1,21 @@
 import { ApolloServer } from '@apollo/server';
-import { startStandaloneServer } from '@apollo/server/standalone';
-import { buildSubgraphSchema } from '@apollo/subgraph';
 import depthLimit from 'graphql-depth-limit';
-import { graphqlUploadExpress } from 'graphql-upload';
-import { gql } from 'graphql-tag';
 import { getComplexity, fieldExtensionsEstimator, simpleEstimator } from 'graphql-query-complexity';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { GraphQLError } from 'graphql';
 
 // NOTE: These are lightweight unit-ish tests that validate the Apollo server
-// rejects requests when depth/complexity limits are exceeded.
-// They do not require the full NestJS bootstrap.
+// rejects requests when depth/complexity limits are exceeded *before* any
+// resolver executes, and that rejection surfaces as a normal GraphQL error
+// (not an unhandled exception / HTTP 500). They mirror the enforcement
+// wired up in src/graphql/graphql.module.ts + src/graphql/plugins/complexity.plugin.ts,
+// without requiring the full NestJS bootstrap.
 
 describe('GraphQL depth + complexity enforcement', () => {
-    const MAX_DEPTH = 7;
-    const COMPLEXITY_THRESHOLD = 50;
+  const MAX_DEPTH = 7;
+  const COMPLEXITY_THRESHOLD = 50;
 
-    const typeDefs = `
+  const typeDefs = `
     type Query {
       a: Level1
     }
@@ -30,67 +29,129 @@ describe('GraphQL depth + complexity enforcement', () => {
     type Level7 { h: String }
   `;
 
-    const resolvers = {
-        Query: {
-            a: () => ({ b: {} }),
-        },
-        Level1: { b: () => ({ c: {} }) },
-        Level2: { c: () => ({ d: {} }) },
-        Level3: { d: () => ({ e: {} }) },
-        Level4: { e: () => ({ f: {} }) },
-        Level5: { f: () => ({ g: {} }) },
-        Level6: { g: () => ({ h: 'ok' }) },
-        Level7: { h: () => 'ok' },
-    };
+  // Every resolver is wrapped in a jest.fn() spy so tests can assert
+  // resolvers were never invoked for a rejected query (acceptance
+  // criterion: rejection happens at the validation/pre-execution level,
+  // not inside a resolver try/catch).
+  const resolverSpies = {
+    a: jest.fn(() => ({ b: {} })),
+    b: jest.fn(() => ({ c: {} })),
+    c: jest.fn(() => ({ d: {} })),
+    d: jest.fn(() => ({ e: {} })),
+    e: jest.fn(() => ({ f: {} })),
+    f: jest.fn(() => ({ g: {} })),
+    g: jest.fn(() => ({ h: 'ok' })),
+    h: jest.fn(() => 'ok'),
+  };
 
-    const schema = makeExecutableSchema({ typeDefs, resolvers });
+  const resolvers = {
+    Query: { a: resolverSpies.a },
+    Level1: { b: resolverSpies.b },
+    Level2: { c: resolverSpies.c },
+    Level3: { d: resolverSpies.d },
+    Level4: { e: resolverSpies.e },
+    Level5: { f: resolverSpies.f },
+    Level6: { g: resolverSpies.g },
+    Level7: { h: resolverSpies.h },
+  };
 
-    const server = new ApolloServer({
-        schema,
-        validationRules: [depthLimit(MAX_DEPTH)],
-        plugins: [
-            {
-                async requestDidStart() {
-                    return {
-                        async didResolveOperation(requestContext: any) {
-                            const complexity = getComplexity({
-                                schema: requestContext.schema,
-                                operationName: requestContext.request.operationName,
-                                query: requestContext.document,
-                                variables: requestContext.request.variables,
-                                estimators: [fieldExtensionsEstimator(), simpleEstimator({ defaultComplexity: 1 })],
-                            });
+  const schema = makeExecutableSchema({ typeDefs, resolvers });
 
-                            if (complexity > COMPLEXITY_THRESHOLD) {
-                                throw new GraphQLError(
-                                    `Query complexity ${complexity} exceeds maximum allowed complexity of ${COMPLEXITY_THRESHOLD}.`,
-                                    { extensions: { code: 'QUERY_COMPLEXITY_EXCEEDED', complexity, threshold: COMPLEXITY_THRESHOLD } },
-                                );
-                            }
-                        },
-                    };
-                },
+  const server = new ApolloServer({
+    schema,
+    validationRules: [depthLimit(MAX_DEPTH)],
+    plugins: [
+      {
+        async requestDidStart() {
+          return {
+            async didResolveOperation(requestContext: any) {
+              const complexity = getComplexity({
+                schema: requestContext.schema,
+                operationName: requestContext.request.operationName,
+                query: requestContext.document,
+                variables: requestContext.request.variables,
+                estimators: [fieldExtensionsEstimator(), simpleEstimator({ defaultComplexity: 1 })],
+              });
+
+              if (complexity > COMPLEXITY_THRESHOLD) {
+                throw new GraphQLError(
+                  `Query complexity ${complexity} exceeds maximum allowed complexity of ${COMPLEXITY_THRESHOLD}.`,
+                  { extensions: { code: 'QUERY_COMPLEXITY_EXCEEDED', complexity, threshold: COMPLEXITY_THRESHOLD } },
+                );
+              }
             },
-        ],
-    });
+          };
+        },
+      },
+    ],
+  });
 
-    it('rejects over-depth query', async () => {
-        const query = `
+  beforeEach(() => {
+    Object.values(resolverSpies).forEach((spy) => spy.mockClear());
+  });
+
+  it('allows a small valid query and invokes resolvers normally (control case)', async () => {
+    const query = `query Small { a { b { c { d { e { h: __typename } } } } } }`;
+
+    const result = await server.executeOperation({ query, operationName: 'Small' } as any);
+
+    expect(result.body.kind).toBe('single');
+    if (result.body.kind === 'single') {
+      expect(result.body.singleResult.errors).toBeUndefined();
+    }
+    expect(resolverSpies.a).toHaveBeenCalledTimes(1);
+    expect(resolverSpies.b).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects over-depth query with a GraphQL error, not a 500/crash', async () => {
+    const query = `
       query OverDepth { a { b { c { d { e { f { g { h } } } } } } } }
     `;
 
-        const result = await server.executeOperation({ query, operationName: 'OverDepth' } as any);
-        expect(result.errors?.[0].extensions?.code).toBeDefined();
-    });
+    const result = await server.executeOperation({ query, operationName: 'OverDepth' } as any);
 
-    it('rejects over-complexity query', async () => {
-        // Increase complexity by requesting repeated leaf fields via aliases
-        const query = `
+    expect(result.body.kind).toBe('single');
+    const errors =
+      result.body.kind === 'single' ? result.body.singleResult.errors : undefined;
+    expect(errors?.[0]).toBeInstanceOf(GraphQLError);
+    expect(errors?.[0].extensions?.code).toBeDefined();
+  });
+
+  it('never invokes any resolver for an over-depth query', async () => {
+    const query = `
+      query OverDepth { a { b { c { d { e { f { g { h } } } } } } } }
+    `;
+
+    await server.executeOperation({ query, operationName: 'OverDepth' } as any);
+
+    // Depth-limit validation fails during GraphQL's validation phase —
+    // strictly before execution — so no resolver in the chain should run.
+    Object.values(resolverSpies).forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+
+  it('rejects over-complexity query with QUERY_COMPLEXITY_EXCEEDED', async () => {
+    // Increase complexity by requesting repeated leaf fields via aliases
+    const query = `
       query OverComplexity { a { b { c { d { e { f { g { h a1:h a2:h a3:h a4:h a5:h a6:h a7:h a8:h a9:h a10:h a11:h a12:h } } } } } } } }
     `;
 
-        const result = await server.executeOperation({ query, operationName: 'OverComplexity' } as any);
-        expect(result.errors?.[0].extensions?.code).toBe('QUERY_COMPLEXITY_EXCEEDED');
-    });
-});
+    const result = await server.executeOperation({ query, operationName: 'OverComplexity' } as any);
 
+    const errors =
+      result.body.kind === 'single' ? result.body.singleResult.errors : undefined;
+    expect(errors?.[0].extensions?.code).toBe('QUERY_COMPLEXITY_EXCEEDED');
+  });
+
+  it('never invokes the leaf resolver for an over-complexity query', async () => {
+    const query = `
+      query OverComplexity { a { b { c { d { e { f { g { h a1:h a2:h a3:h a4:h a5:h a6:h a7:h a8:h a9:h a10:h a11:h a12:h } } } } } } } }
+    `;
+
+    await server.executeOperation({ query, operationName: 'OverComplexity' } as any);
+
+    // Complexity is computed statically from the document in
+    // didResolveOperation, which runs before execution starts — so even
+    // though this query is within the depth limit, no resolver should run.
+    Object.values(resolverSpies).forEach((spy) => expect(spy).not.toHaveBeenCalled());
+  });
+});

--- a/src/graphql/graphql.module.ts
+++ b/src/graphql/graphql.module.ts
@@ -6,7 +6,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PubSub } from 'graphql-subscriptions';
 import { join } from 'path';
 import depthLimit from 'graphql-depth-limit';
-import { fieldExtensionsEstimator, getComplexity, simpleEstimator } from 'graphql-query-complexity';
 import { GraphQLError } from 'graphql';
 
 
@@ -86,55 +85,16 @@ import { DevicesModule } from '../devices/devices.module';
           playground: !isProd,
           introspection: !isProd,
 
-          // Depth limit + complexity enforcement (DoS protection)
+          // Depth limit enforcement (DoS protection), validation-rule level:
+          // this runs during GraphQL's validation phase, before the
+          // operation is even resolved, so a rejected query never reaches a
+          // resolver. The env-configured value here is the hard,
+          // environment-wide ceiling; per-tenant tightening of both depth
+          // and complexity limits, plus the per-field complexity budget
+          // itself, are enforced by ComplexityPlugin (see
+          // ./plugins/complexity.plugin.ts), which is auto-registered via
+          // its `@Plugin()` decorator + inclusion in `providers` below.
           validationRules: [depthLimit(Number(process.env.GRAPHQL_MAX_QUERY_DEPTH ?? 7))],
-          plugins: [
-            {
-              async requestDidStart() {
-                return {
-                  async didResolveOperation(requestContext: any) {
-                    const maxDepth = Number(process.env.GRAPHQL_MAX_QUERY_DEPTH ?? 7);
-                    const complexityThreshold = Number(process.env.GRAPHQL_QUERY_COMPLEXITY_THRESHOLD ?? 150);
-
-                    // Complexity estimator with default field cost=1 and list cost=10.
-                    // Default field cost can be overridden via graphql-query-complexity fieldExtensions.
-                    // List fields are weighted higher to reduce DoS via large pagination selections.
-
-                    const complexity = getComplexity({
-                      schema: requestContext.schema,
-                      operationName: requestContext.request.operationName,
-                      query: requestContext.document,
-                      variables: requestContext.request.variables,
-                      estimators: [
-                        fieldExtensionsEstimator({
-                          // If a field extension specifies complexity, it will be used.
-                          defaultComplexity: 1,
-                        } as any),
-                        simpleEstimator({ defaultComplexity: 1, listComplexity: 10 } as any),
-
-                      ],
-                    });
-
-                    if (complexity > complexityThreshold) {
-                      throw new GraphQLError(
-                        `Query complexity ${complexity} exceeds maximum allowed complexity of ${complexityThreshold}. ` +
-                        `Reduce nested selection depth, page results, or trim requested fields.`,
-                        {
-                          extensions: {
-                            code: 'GRAPHQL_QUERY_COMPLEXITY_EXCEEDED',
-                            complexity,
-                            threshold: complexityThreshold,
-                            maxDepth,
-                          },
-                        },
-                      );
-                    }
-                  },
-                };
-              },
-            },
-          ],
-
 
           // graphql-ws (recommended transport) for GraphQL subscriptions
           subscriptions: {

--- a/src/graphql/plugins/complexity.plugin.ts
+++ b/src/graphql/plugins/complexity.plugin.ts
@@ -1,51 +1,359 @@
+import { Logger } from '@nestjs/common';
 import { Plugin } from '@nestjs/apollo';
-import { GraphQLRequestContext } from '@apollo/server';
 import {
   ApolloServerPlugin,
+  GraphQLRequestContext,
   GraphQLRequestListener,
 } from '@apollo/server';
+import { GraphQLSchemaHost } from '@nestjs/graphql';
+import { ConfigService } from '@nestjs/config';
 import {
-  separateOperations,
-  GraphQLSchema,
+  DocumentNode,
+  FragmentDefinitionNode,
+  GraphQLError,
+  Kind,
+  OperationDefinitionNode,
+  SelectionSetNode,
 } from 'graphql';
 import {
   fieldExtensionsEstimator,
   getComplexity,
   simpleEstimator,
 } from 'graphql-query-complexity';
-import { GraphQLSchemaHost } from '@nestjs/graphql';
-import { GraphQLError } from 'graphql';
+import { AuditLogService } from '../../common/services/audit-log.service';
+import { TenantConfigService } from '../../tenant-config/services/tenant-config.service';
 
+/**
+ * Default complexity budget applied when neither the
+ * `GRAPHQL_QUERY_COMPLEXITY_THRESHOLD` environment variable nor a
+ * per-tenant override (see TENANT_CONFIG_KEY_MAX_COMPLEXITY below) is set.
+ * Mirrors the documented default in .env.example.
+ */
+export const DEFAULT_COMPLEXITY_THRESHOLD = 150;
+
+/**
+ * @deprecated Retained for backward compatibility with existing tests/consumers
+ * that import the original hard-coded threshold. New code should read the
+ * effective, configurable threshold resolved by ComplexityPlugin instead.
+ */
 export const COMPLEXITY_THRESHOLD = 50;
 
+/**
+ * Default maximum query depth applied when neither the
+ * `GRAPHQL_MAX_QUERY_DEPTH` environment variable nor a per-tenant override
+ * (see TENANT_CONFIG_KEY_MAX_DEPTH below) is set. Mirrors the documented
+ * default in .env.example, and the `depthLimit()` validation rule wired up
+ * in graphql.module.ts.
+ */
+export const DEFAULT_MAX_QUERY_DEPTH = 7;
+
+/**
+ * Tenant-config keys used to look up per-tenant overrides via
+ * TenantConfigService. These follow the same tenantId -> key resolution
+ * pattern (tenant override -> global default -> env var) documented in
+ * src/tenant-config/services/tenant-config.service.ts. Tenant overrides can
+ * only *tighten* the environment-wide ceiling, never loosen it, so a
+ * misconfigured/compromised tenant cannot disable this DoS protection.
+ */
+export const TENANT_CONFIG_KEY_MAX_COMPLEXITY = 'graphql_max_query_complexity';
+export const TENANT_CONFIG_KEY_MAX_DEPTH = 'graphql_max_query_depth';
+
+export interface RequestingClient {
+  userId: string;
+  tenantId: string;
+  clientIp: string;
+}
+
+/**
+ * Computes the maximum selection-set nesting depth of a GraphQL operation.
+ * This is used, in addition to the static `depthLimit()` validation rule
+ * configured in graphql.module.ts, to support per-tenant depth overrides
+ * that cannot be expressed by a validation rule built once at server
+ * start-up. Introspection fields (`__typename`, `__schema`, ...) are
+ * excluded, and fragment spreads are resolved (with cycle protection).
+ */
+export function calculateQueryDepth(
+  document: DocumentNode,
+  operationName?: string | null,
+): number {
+  const fragments = new Map<string, FragmentDefinitionNode>();
+  for (const definition of document.definitions) {
+    if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+      fragments.set(definition.name.value, definition);
+    }
+  }
+
+  const operation = document.definitions.find(
+    (definition): definition is OperationDefinitionNode =>
+      definition.kind === Kind.OPERATION_DEFINITION &&
+      (operationName ? definition.name?.value === operationName : true),
+  );
+
+  if (!operation) {
+    return 0;
+  }
+
+  const visitedFragments = new Set<string>();
+
+  const walk = (selectionSet: SelectionSetNode | undefined, depth: number): number => {
+    if (!selectionSet) {
+      return depth;
+    }
+
+    let maxDepth = depth;
+
+    for (const selection of selectionSet.selections) {
+      if (selection.kind === Kind.FIELD) {
+        if (selection.name.value.startsWith('__')) {
+          continue; // ignore introspection fields
+        }
+        const childDepth = selection.selectionSet
+          ? walk(selection.selectionSet, depth + 1)
+          : depth + 1;
+        maxDepth = Math.max(maxDepth, childDepth);
+      } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+        maxDepth = Math.max(maxDepth, walk(selection.selectionSet, depth));
+      } else if (selection.kind === Kind.FRAGMENT_SPREAD) {
+        const fragmentName = selection.name.value;
+        if (visitedFragments.has(fragmentName)) {
+          continue; // avoid infinite recursion on (invalid) cyclic fragments
+        }
+        const fragment = fragments.get(fragmentName);
+        if (fragment) {
+          visitedFragments.add(fragmentName);
+          maxDepth = Math.max(maxDepth, walk(fragment.selectionSet, depth));
+          visitedFragments.delete(fragmentName);
+        }
+      }
+    }
+
+    return maxDepth;
+  };
+
+  return walk(operation.selectionSet, 0);
+}
+
+/**
+ * Enforces GraphQL query complexity and depth limits to protect against
+ * resource-exhaustion (DoS) abuse.
+ *
+ * Layered defense:
+ *  1. A static, environment-configured `depthLimit()` validation rule
+ *     (wired up in graphql.module.ts) rejects over-deep documents during
+ *     the GraphQL *validation* phase, before this plugin even runs.
+ *  2. This plugin re-checks depth (allowing per-tenant tightening) and
+ *     enforces a per-field complexity budget during `didResolveOperation`,
+ *     which — like validation — runs strictly before execution, so
+ *     resolvers are never invoked for a rejected query.
+ *
+ * Both rejection paths throw a `GraphQLError` (never a bare `Error`), so
+ * Apollo returns a well-formed GraphQL error response (HTTP 200 with an
+ * `errors` array carrying a machine-readable `extensions.code`) instead of
+ * an HTTP 500.
+ */
 @Plugin()
 export class ComplexityPlugin implements ApolloServerPlugin {
-  constructor(private readonly gqlSchemaHost: GraphQLSchemaHost) {}
+  private readonly logger = new Logger(ComplexityPlugin.name);
+
+  constructor(
+    private readonly gqlSchemaHost: GraphQLSchemaHost,
+    private readonly configService: ConfigService,
+    private readonly tenantConfigService: TenantConfigService,
+    private readonly auditLogService: AuditLogService,
+  ) {}
 
   async requestDidStart(): Promise<GraphQLRequestListener<any>> {
     const { schema } = this.gqlSchemaHost;
+    const plugin = this;
 
     return {
-      async didResolveOperation({ request, document }) {
+      async didResolveOperation(requestContext: GraphQLRequestContext<any>) {
+        const { request, document, contextValue } = requestContext as unknown as {
+          request: GraphQLRequestContext<any>['request'];
+          document: DocumentNode;
+          contextValue: any;
+        };
+
+        if (!document) {
+          return;
+        }
+
+        const client = plugin.extractClientInfo(contextValue);
+        const { complexityThreshold, maxDepth } = await plugin.resolveLimits(client.tenantId);
+
+        // 1. Depth check (per-tenant aware; the environment-wide ceiling is
+        // already enforced separately via the depthLimit() validation rule).
+        const depth = calculateQueryDepth(document, request.operationName);
+        if (depth > maxDepth) {
+          await plugin.rejectQuery({
+            reason: 'QUERY_DEPTH_EXCEEDED',
+            message:
+              `Query depth ${depth} exceeds maximum allowed depth of ${maxDepth}. ` +
+              `Reduce nested selection depth or split the query into multiple operations.`,
+            extensions: {
+              code: 'GRAPHQL_QUERY_DEPTH_EXCEEDED',
+              depth,
+              maxDepth,
+            },
+            client,
+            operationName: request.operationName,
+          });
+        }
+
+        // 2. Per-field complexity check.
         const complexity = getComplexity({
           schema,
           operationName: request.operationName,
           query: document,
           variables: request.variables,
           estimators: [
+            // Honors per-field `complexity` set via GraphQL field extensions.
             fieldExtensionsEstimator(),
+            // Falls back to a flat cost of 1 per requested field.
             simpleEstimator({ defaultComplexity: 1 }),
           ],
         });
 
-        if (complexity > COMPLEXITY_THRESHOLD) {
-          throw new GraphQLError(
-            `Query complexity ${complexity} exceeds maximum allowed complexity of ${COMPLEXITY_THRESHOLD}. ` +
-              `Consider using filters or reducing nested pagination depth.`,
-            { extensions: { code: 'QUERY_COMPLEXITY_EXCEEDED', complexity, threshold: COMPLEXITY_THRESHOLD } },
-          );
+        if (complexity > complexityThreshold) {
+          await plugin.rejectQuery({
+            reason: 'QUERY_COMPLEXITY_EXCEEDED',
+            message:
+              `Query complexity ${complexity} exceeds maximum allowed complexity of ${complexityThreshold}. ` +
+              `Consider using filters, pagination, or reducing nested selections.`,
+            extensions: {
+              code: 'GRAPHQL_QUERY_COMPLEXITY_EXCEEDED',
+              complexity,
+              threshold: complexityThreshold,
+            },
+            client,
+            operationName: request.operationName,
+          });
         }
       },
     };
+  }
+
+  /**
+   * Resolves the effective complexity/depth limits for a request. Tenant
+   * overrides (looked up via TenantConfigService, which already implements
+   * the tenant -> global-default -> env-var fallback chain used across the
+   * codebase) may only tighten the environment-wide ceiling, never exceed
+   * it — this keeps a compromised/misconfigured tenant from disabling the
+   * DoS protection.
+   */
+  private async resolveLimits(
+    tenantId: string,
+  ): Promise<{ complexityThreshold: number; maxDepth: number }> {
+    const envComplexity = this.readEnvNumber(
+      'GRAPHQL_QUERY_COMPLEXITY_THRESHOLD',
+      DEFAULT_COMPLEXITY_THRESHOLD,
+    );
+    const envMaxDepth = this.readEnvNumber('GRAPHQL_MAX_QUERY_DEPTH', DEFAULT_MAX_QUERY_DEPTH);
+
+    let complexityThreshold = envComplexity;
+    let maxDepth = envMaxDepth;
+
+    if (tenantId && tenantId !== 'global') {
+      try {
+        const [tenantComplexity, tenantDepth] = await Promise.all([
+          this.tenantConfigService.get<number>(tenantId, TENANT_CONFIG_KEY_MAX_COMPLEXITY),
+          this.tenantConfigService.get<number>(tenantId, TENANT_CONFIG_KEY_MAX_DEPTH),
+        ]);
+
+        if (this.isPositiveNumber(tenantComplexity)) {
+          complexityThreshold = Math.min(tenantComplexity, envComplexity);
+        }
+        if (this.isPositiveNumber(tenantDepth)) {
+          maxDepth = Math.min(tenantDepth, envMaxDepth);
+        }
+      } catch (error) {
+        // Never let a tenant-config/Redis/DB blip turn into a broken
+        // request — fall back to the environment-wide defaults and log.
+        this.logger.warn(
+          `Failed to resolve tenant GraphQL limits for tenant=${tenantId}; ` +
+            `falling back to environment defaults. ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+        );
+      }
+    }
+
+    return { complexityThreshold, maxDepth };
+  }
+
+  private isPositiveNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0;
+  }
+
+  private readEnvNumber(key: string, fallback: number): number {
+    const raw = this.configService.get<string>(key) ?? process.env[key];
+    const parsed = Number(raw);
+    return raw !== undefined && !Number.isNaN(parsed) ? parsed : fallback;
+  }
+
+  /** Extracts the requesting client's identity for logging/audit purposes. */
+  private extractClientInfo(contextValue: any): RequestingClient {
+    const req = contextValue?.req ?? {};
+    const user = req.user ?? {};
+    const headers = req.headers ?? {};
+
+    const tenantId = user.tenantId ?? user.organizationId ?? headers['x-tenant-id'] ?? 'global';
+    const userId = user.userId ?? user.id ?? 'anonymous';
+    const forwardedFor: string | undefined = headers['x-forwarded-for'];
+    const clientIp =
+      (forwardedFor ? forwardedFor.split(',')[0].trim() : undefined) ??
+      req.ip ??
+      req.socket?.remoteAddress ??
+      'unknown';
+
+    return { userId: String(userId), tenantId: String(tenantId), clientIp: String(clientIp) };
+  }
+
+  /**
+   * Logs and audits a rejected query, then throws a GraphQLError carrying
+   * a machine-readable `extensions.code`. Because this runs from within
+   * `didResolveOperation` — a pre-execution lifecycle hook — the thrown
+   * error short-circuits the request before any resolver is invoked, and
+   * Apollo surfaces it as a normal GraphQL error response rather than an
+   * HTTP 500.
+   */
+  private async rejectQuery(params: {
+    reason: string;
+    message: string;
+    extensions: Record<string, any>;
+    client: RequestingClient;
+    operationName?: string | null;
+  }): Promise<never> {
+    const { reason, message, extensions, client, operationName } = params;
+    const operation = operationName ?? 'anonymous';
+
+    this.logger.warn(
+      `GraphQL query rejected [${reason}] tenant=${client.tenantId} user=${client.userId} ` +
+        `operation=${operation} ip=${client.clientIp} :: ${message}`,
+    );
+
+    try {
+      await this.auditLogService.log({
+        entityType: 'GraphQLQuery',
+        entityId: operation,
+        action: 'QUERY_REJECTED',
+        userId: client.userId,
+        changes: { reason, ...extensions },
+        metadata: {
+          tenantId: client.tenantId,
+          clientIp: client.clientIp,
+          operationName: operation,
+        },
+      } as any);
+    } catch (auditError) {
+      // Audit-log failures must never mask the rejection or crash the request.
+      this.logger.error(
+        `Failed to record audit log entry for rejected GraphQL query: ${
+          auditError instanceof Error ? auditError.message : String(auditError)
+        }`,
+      );
+    }
+
+    throw new GraphQLError(message, { extensions });
   }
 }


### PR DESCRIPTION
## Summary

- Consolidated GraphQL DoS protection into a single, canonical `ComplexityPlugin` (`src/graphql/plugins/complexity.plugin.ts`). Previously there were **two** overlapping, differently-configured complexity checks: a hard-coded `COMPLEXITY_THRESHOLD = 50` in `complexity.plugin.ts` (auto-wired via NestJS's `@Plugin()` provider discovery) and a second, inline duplicate in `graphql.module.ts` with a different threshold (150, read from `GRAPHQL_QUERY_COMPLEXITY_THRESHOLD`). Both ran on every request; neither was configurable per tenant.
- `ComplexityPlugin` now enforces **both** per-field query complexity and query depth in Apollo's `didResolveOperation` hook, which fires after parsing/validation but strictly **before** execution — so a rejected query never reaches a resolver.
- Thresholds are resolved as: **tenant override → environment variable → built-in default**, using `TenantConfigService` (same tenant → global → env fallback chain used elsewhere in the codebase, e.g. `CustomThrottlerGuard`). Tenant overrides can only **tighten** the limit — never exceed the environment-wide ceiling — so a misconfigured/compromised tenant can't disable the protection.
- The static `depthLimit()` validation rule in `graphql.module.ts` remains in place as the environment-wide depth ceiling, enforced at the true GraphQL *validation* phase (before the operation is even resolved). `ComplexityPlugin` adds per-tenant depth tightening on top of it, via its own AST depth walker (`calculateQueryDepth`), plus the complexity budget itself.
- Every rejected query now produces a `Logger.warn` entry and an `AuditLogService.log(...)` audit trail (`entityType: 'GraphQLQuery'`, `action: 'QUERY_REJECTED'`) capturing the requesting tenant, user, client IP, operation name, and rejection reason/code. Audit-log failures are caught and logged, never allowed to mask the rejection or crash the request.
- Fixed `src/graphql-queries/graphql.module.ts` (an unused/unwired duplicate GraphQL module kept for reference): it imported `ComplexityPlugin` from a non-existent local `./plugins/complexity.plugin` path and had no depth-limit validation rule at all. It now imports the canonical plugin from `../graphql/plugins/complexity.plugin` and wires up the same `depthLimit()` validation rule.

## Context: before/after error behavior for rejected queries

**Before:** two independent complexity checks with different thresholds (50 vs 150) ran redundantly; neither was tenant-aware; rejection reasons/audit trail were inconsistent between the two.

**After:** a single check runs once per request. On rejection (depth or complexity), the response is a normal GraphQL error — HTTP 200 with a populated `errors` array — never an HTTP 500:

```json
{
  "errors": [
    {
      "message": "Query depth 8 exceeds maximum allowed depth of 7. Reduce nested selection depth or split the query into multiple operations.",
      "extensions": {
        "code": "GRAPHQL_QUERY_DEPTH_EXCEEDED",
        "depth": 8,
        "maxDepth": 7
      }
    }
  ]
}
```

```json
{
  "errors": [
    {
      "message": "Query complexity 212 exceeds maximum allowed complexity of 150. Consider using filters, pagination, or reducing nested selections.",
      "extensions": {
        "code": "GRAPHQL_QUERY_COMPLEXITY_EXCEEDED",
        "complexity": 212,
        "threshold": 150
      }
    }
  ]
}
```

The rejection happens in `didResolveOperation` (post-validation, pre-execution) and always throws a `GraphQLError` — never a bare `Error` — so it can't be mistaken for, or degrade into, an unhandled-exception 500. Resolvers for the requested fields are never invoked.

## Testing notes

- Added `src/graphql/__tests__/complexity.plugin.spec.ts`: unit-tests `ComplexityPlugin` directly (constructed with mocked `ConfigService` / `TenantConfigService` / `AuditLogService`, matching the existing pattern in `apq.plugin.spec.ts`). Covers: `calculateQueryDepth` (nesting, introspection-field exclusion, fragment-spread resolution, missing-operation handling), default-limit enforcement, env-configured thresholds, per-tenant tightening of both complexity and depth, the "tenant can never loosen past the env ceiling" guarantee, graceful fallback when the tenant-config lookup fails, and that an audit-log write failure never suppresses the rejection.
- Extended `src/graphql/__tests__/query-depth-complexity.integration.spec.ts`: resolvers are now `jest.fn()` spies; new assertions confirm no resolver in the chain is ever invoked for an over-depth or over-complexity query, plus a control-case test that a small valid query does invoke resolvers normally. Also corrected the Apollo Server v5 `executeOperation()` result-shape access (`result.body.singleResult.errors`, not `result.errors`) used to read back the error extensions.
- **Could not execute the test suite in this environment** — this worktree has no `node_modules` (per task instructions, no install was run) and no cached `jest` toolchain is reachable via `npx` here either. Please run `npm install` and `npx jest src/graphql --selectProjects unit` in CI/locally to confirm.
- No new dependencies were introduced — `graphql-depth-limit`, `graphql-query-complexity`, and `ioredis` (used transitively via `TenantConfigService`) are already present in `package.json`.

Closes #861